### PR TITLE
ValueSets and other metadata improvements

### DIFF
--- a/prime-router/metadata/receivers.yml
+++ b/prime-router/metadata/receivers.yml
@@ -18,7 +18,7 @@ receivers:
     description: Florida PHD
     topic: sample
     schema: sample/phd2-sample
-    patterns: {observation: covid-19:.*, state: FL}
+    patterns: {observation: covid-19:pos, state: FL}
     transforms: {deidentify: false}
     address: http://localhost:1281/
     format: CSV

--- a/prime-router/metadata/receivers.yml
+++ b/prime-router/metadata/receivers.yml
@@ -18,7 +18,7 @@ receivers:
     description: Florida PHD
     topic: sample
     schema: sample/phd2-sample
-    patterns: {observation: covid-19:pos, state: FL}
+    patterns: {observation: covid-19:.*, state: FL}
     transforms: {deidentify: false}
     address: http://localhost:1281/
     format: CSV

--- a/prime-router/metadata/schemas/AZ/az-covid-19.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19.schema
@@ -105,13 +105,13 @@ elements:
   - name: standard.specimen_type_text
     csvField: Specimen_Type
 
-  - name: standard.specimen_source_site_description
+  - name: standard.specimen_source_site_text
     csvField: Specimen_Site
 
   - name: standard.test_performed_code
     csvField: Test_Code
 
-  - name: standard.test_performed_description
+  - name: standard.test_performed_text
     csvField: Test_Name
 
   - name: standard.test_result_text

--- a/prime-router/metadata/schemas/AZ/az-covid-19.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19.schema
@@ -4,122 +4,122 @@ description: AZ COVID-19 flat file
 topic: covid-19
 trackingElement: standard.Testing_lab_specimen_ID
 elements:
-  - name: standard.Sending_application
+  - name: standard.sending_application
     type: TEXT
     csvField: Sending_Application
 
-  - name: standard.Sending_application_id
+  - name: standard.sending_application_id
     type: HD
     csvField: Sending_Application_ID
 
-  - name: standard.Testing_lab_name
+  - name: standard.testing_lab_name
     csvField: Lab_Name
 
-  - name: standard.Testing_lab_ID
+  - name: standard.testing_lab_ID
     csvField: Lab_CLIA
 
-  - name: standard.Testing_lab_street
+  - name: standard.testing_lab_street
     csvField: Lab_Address
 
-  - name: standard.Testing_lab_city
+  - name: standard.testing_lab_city
     csvField: Lab_City
 
-  - name: standard.Testing_lab_state
+  - name: standard.testing_lab_state
     csvField: Lab_State
 
-  - name: standard.Testing_lab_zip_code
+  - name: standard.testing_lab_zip_code
     csvField: Lab_Zip
 
-  - name: standard.Testing_lab_phone_number
+  - name: standard.testing_lab_phone_number
     csvField: Lab_Phone
 
-  - name: standard.Patient_ID
+  - name: standard.patient_ID
     csvField: Patient_ID
 
-  - name: standard.Patient_first_name
+  - name: standard.patient_first_name
     csvField: Patient_First_Name
 
-  - name: standard.Patient_last_name
+  - name: standard.patient_last_name
     csvField: Patient_Last_Name
 
-  - name: standard.Patient_DOB
+  - name: standard.patient_DOB
     csvField: Patient_Date_of_Birth
 
-  - name: standard.Patient_gender
+  - name: standard.patient_gender
     csvField: Patient_Sex
 
-  - name: standard.Patient_race
+  - name: standard.patient_race
     csvField: Race
 
-  - name: standard.Patient_ethnicity
+  - name: standard.patient_ethnicity
     csvField: Ethnicity
 
-  - name: standard.Patient_street
+  - name: standard.patient_street
     csvField: Patient_Street_Address
 
-  - name: standard.Patient_city
+  - name: standard.patient_city
     csvField: Patient_City
 
-  - name: standard.Patient_state
+  - name: standard.patient_state
     csvField: Patient_State
 
-  - name: standard.Patient_zip_code
+  - name: standard.patient_zip_code
     csvField: Patient_Zip
 
-  - name: standard.Patient_county
+  - name: standard.patient_county
     csvField: Patient_County
 
-  - name: standard.Patient_phone_number
+  - name: standard.patient_phone_number
     csvField: Patient_Phone_Number
 
-  - name: standard.Ordering_facility_name
+  - name: standard.ordering_facility_name
     csvField: Ordering_Facility
 
-  - name: standard.Ordering_facility_street
+  - name: standard.ordering_facility_street
     csvField: Ordering_Facility_Address
 
-  - name: standard.Ordering_facility_city
+  - name: standard.ordering_facility_city
     csvField: Ordering_Facility_City
 
-  - name: standard.Ordering_facility_state
+  - name: standard.ordering_facility_state
     csvField: Ordering_Facility_State
 
-  - name: standard.Ordering_facility_zip_code
+  - name: standard.ordering_facility_zip_code
     csvField: Ordering_Facility_Zip
 
-  - name: standard.Ordering_provider_first_name
+  - name: standard.ordering_provider_first_name
     csvField: Provider_First_Name
 
-  - name: standard.Ordering_provider_last_name
+  - name: standard.ordering_provider_last_name
     csvField: Provider_Last_Name
 
-  - name: standard.Ordering_provider_phone_number
+  - name: standard.ordering_provider_phone_number
     csvField: Provider_Phone_Number
 
-  - name: standard.Testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_ID
     csvField: Specimen_ID
 
-  - name: standard.Specimen_collection_date_time
+  - name: standard.specimen_collection_date_time
     csvField: Collection_Date
 
-  - name: standard.Specimen_type_free_text
+  - name: standard.specimen_type_text
     csvField: Specimen_Type
 
-  - name: standard.Specimen_source_site_description
+  - name: standard.specimen_source_site_description
     csvField: Specimen_Site
 
-  - name: standard.Test_performed_code
+  - name: standard.test_performed_code
     csvField: Test_Code
 
-  - name: standard.Test_performed_description
+  - name: standard.test_performed_description
     csvField: Test_Name
 
-  - name: standard.Test_result_free_text
+  - name: standard.test_result_text
     csvField: Result
 
-  - name: standard.Test_result_date
+  - name: standard.test_result_date
     csvField: Result_Date
 
-  - name: standard.Comment
+  - name: standard.comment
     csvField: Notes
 

--- a/prime-router/metadata/schemas/AZ/az-covid-19.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19.schema
@@ -2,7 +2,7 @@
 name: az-covid-19
 description: AZ COVID-19 flat file
 topic: covid-19
-trackingElement: standard.Testing_lab_specimen_ID
+trackingElement: standard.testing_lab_specimen_id
 elements:
   - name: standard.sending_application
     type: TEXT
@@ -15,7 +15,7 @@ elements:
   - name: standard.testing_lab_name
     csvField: Lab_Name
 
-  - name: standard.testing_lab_ID
+  - name: standard.testing_lab_id
     csvField: Lab_CLIA
 
   - name: standard.testing_lab_street
@@ -33,7 +33,7 @@ elements:
   - name: standard.testing_lab_phone_number
     csvField: Lab_Phone
 
-  - name: standard.patient_ID
+  - name: standard.patient_id
     csvField: Patient_ID
 
   - name: standard.patient_first_name
@@ -42,7 +42,7 @@ elements:
   - name: standard.patient_last_name
     csvField: Patient_Last_Name
 
-  - name: standard.patient_DOB
+  - name: standard.patient_dob
     csvField: Patient_Date_of_Birth
 
   - name: standard.patient_gender
@@ -96,25 +96,25 @@ elements:
   - name: standard.ordering_provider_phone_number
     csvField: Provider_Phone_Number
 
-  - name: standard.testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_id
     csvField: Specimen_ID
 
   - name: standard.specimen_collection_date_time
     csvField: Collection_Date
 
-  - name: standard.specimen_type_text
+  - name: standard.specimen_type#text
     csvField: Specimen_Type
 
   - name: standard.specimen_source_site_text
     csvField: Specimen_Site
 
-  - name: standard.test_performed_code
+  - name: standard.test_performed
     csvField: Test_Code
 
-  - name: standard.test_performed_text
+  - name: standard.test_performed#text
     csvField: Test_Name
 
-  - name: standard.test_result_text
+  - name: standard.test_result#text
     csvField: Result
 
   - name: standard.test_result_date

--- a/prime-router/metadata/schemas/PA/pa-covid-19.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19.schema
@@ -49,7 +49,7 @@ elements:
   - name: standard.specimen_collection_date_time
     csvField: SpecimenCollectedDate
 
-  - name: standard.specimen_source_site_description
+  - name: standard.specimen_source_site_text
     csvField: SpecimenSource
 
   - name: standard.specimen_type_text

--- a/prime-router/metadata/schemas/PA/pa-covid-19.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19.schema
@@ -4,62 +4,62 @@ description: PA COVID-19 flat file
 topic: covid-19
 trackingElement: standard.Testing_lab_specimen_ID
 elements:
-  - name: standard.Patient_first_name
+  - name: standard.patient_first_name
     csvField: PatientFirstName
 
-  - name: standard.Patient_middle_initial
+  - name: standard.patient_middle_initial
     csvField: PatientMiddleInitial
 
-  - name: standard.Patient_last_name
+  - name: standard.patient_last_name
     csvField: PatientLastName
 
-  - name: standard.Patient_suffix
+  - name: standard.patient_suffix
     csvField: PatientSuffix
 
-  - name: standard.Patient_DOB
+  - name: standard.patient_DOB
     csvField: PatientDOB
 
-  - name: standard.Patient_street
+  - name: standard.patient_street
     csvField: PatientAddress1
 
-  - name: standard.Patient_city
+  - name: standard.patient_city
     csvField: PatientCity
 
-  - name: standard.Patient_state
+  - name: standard.patient_state
     csvField: PatientState
 
-  - name: standard.Patient_zip_code
+  - name: standard.patient_zip_code
     csvField: PatientZipCode
 
-  - name: standard.Patient_phone_number
+  - name: standard.patient_phone_number
     csvField: PatientPhoneNumber
 
-  - name: standard.Patient_gender
+  - name: standard.patient_gender
     csvField: PatientGender
 
-  - name: standard.Patient_race
+  - name: standard.patient_race
     csvField: PatientRace
 
-  - name: standard.Patient_ethnicity
+  - name: standard.patient_ethnicity
     csvField: PatientEthnicity
 
-  - name: standard.Testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_ID
     csvField: TestID
 
-  - name: standard.Specimen_collection_date_time
+  - name: standard.specimen_collection_date_time
     csvField: SpecimenCollectedDate
 
-  - name: standard.Specimen_source_site_description
+  - name: standard.specimen_source_site_description
     csvField: SpecimenSource
 
-  - name: standard.Specimen_type_free_text
+  - name: standard.specimen_type_text
     csvField: TestName
 
-  - name: standard.Test_result_free_text
+  - name: standard.test_result_text
     csvField: TestQualitativeResult
 
-  - name: standard.Comment
+  - name: standard.comment
     csvField: Notes
 
-  - name: standard.Ordering_facility_name
+  - name: standard.ordering_facility_name
     csvField: PerformingFacilityName

--- a/prime-router/metadata/schemas/PA/pa-covid-19.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19.schema
@@ -2,7 +2,7 @@
 name: pa-covid-19
 description: PA COVID-19 flat file
 topic: covid-19
-trackingElement: standard.Testing_lab_specimen_ID
+trackingElement: standard.testing_lab_specimen_id
 elements:
   - name: standard.patient_first_name
     csvField: PatientFirstName
@@ -16,7 +16,7 @@ elements:
   - name: standard.patient_suffix
     csvField: PatientSuffix
 
-  - name: standard.patient_DOB
+  - name: standard.patient_dob
     csvField: PatientDOB
 
   - name: standard.patient_street
@@ -43,19 +43,20 @@ elements:
   - name: standard.patient_ethnicity
     csvField: PatientEthnicity
 
-  - name: standard.testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_id
     csvField: TestID
 
   - name: standard.specimen_collection_date_time
     csvField: SpecimenCollectedDate
 
+  # TODO: Fix when specimen_source_site valueSet is defined
   - name: standard.specimen_source_site_text
     csvField: SpecimenSource
 
-  - name: standard.specimen_type_text
+  - name: standard.specimen_type#text
     csvField: TestName
 
-  - name: standard.test_result_text
+  - name: standard.test_result#text
     csvField: TestQualitativeResult
 
   - name: standard.comment

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -4,156 +4,156 @@ description: PRIME POC COVID-19 flat file
 topic: covid-19
 trackingElement: standard.Testing_lab_specimen_ID
 elements:
-  - name: standard.Patient_last_name
+  - name: standard.patient_last_name
     csvField: Patient_last_name
 
-  - name: standard.Patient_first_name
+  - name: standard.patient_first_name
     csvField: Patient_first_name
 
-  - name: standard.Patient_middle_name
+  - name: standard.patient_middle_name
     csvField: Patient_middle_name
 
-  - name: standard.Patient_suffix
+  - name: standard.patient_suffix
     csvField: Patient_suffix
 
-  - name: standard.Patient_race
+  - name: standard.patient_race
     csvField: Patient_race
 
-  - name: standard.Patient_DOB
+  - name: standard.patient_DOB
     csvField: Patient_DOB
 
-  - name: standard.Patient_gender
+  - name: standard.patient_gender
     csvField: Patient_gender
 
-  - name: standard.Patient_ethnicity
+  - name: standard.patient_ethnicity
     csvField: Patient_ethnicity
 
-  - name: standard.Patient_street
+  - name: standard.patient_street
     csvField: Patient_street
 
-  - name: standard.Patient_street2
+  - name: standard.patient_street2
     csvField: Patient_street2
 
-  - name: standard.Patient_city
+  - name: standard.patient_city
     csvField: Patient_city
 
-  - name: standard.Patient_county
+  - name: standard.patient_county
     csvField: Patient_county
 
-  - name: standard.Patient_state
+  - name: standard.patient_state
     csvField: Patient_state
 
-  - name: standard.Patient_zip_code
+  - name: standard.patient_zip_code
     csvField: Patient_zip_code
 
-  - name: standard.Patient_phone_number
+  - name: standard.patient_phone_number
     csvField: Patient_phone_number
 
-  - name: standard.Patient_Id
+  - name: standard.patient_Id
     csvField: Patient_ID
 
-  - name: standard.Employed_in_healthcare
+  - name: standard.employed_in_healthcare
     csvField: Employed_in_healthcare
 
-  - name: standard.Resident_congregate_setting
+  - name: standard.resident_congregate_setting
     csvField: Resident_congregate_setting
 
-  - name: standard.Testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_ID
     csvField: Testing_lab_specimen_ID
 
-  - name: standard.Test_result_coded
+  - name: standard.test_result_coded
     csvField: Test_result_coded
 
-  - name: standard.Specimen_collection_date_time
+  - name: standard.specimen_collection_date_time
     csvField: Specimen_collection_date_time
 
-  - name: standard.Ordering_provider_ID
+  - name: standard.ordering_provider_ID
     csvField: Ordering_provider_ID
 
-  - name: standard.First_test
+  - name: standard.first_test
     csvField: First_test
 
-  - name: standard.Symptomatic_for_disease
+  - name: standard.symptomatic_for_disease
     csvField: Symptomatic_for_disease
 
-  - name: standard.Testing_lab_name
+  - name: standard.testing_lab_name
     csvField: Testing_lab_name
 
-  - name: standard.Testing_lab_ID
+  - name: standard.testing_lab_ID
     csvField: Testing_lab_ID
 
-  - name: standard.Testing_lab_city
+  - name: standard.testing_lab_city
     csvField: Testing_lab_city
 
-  - name: standard.Testing_lab_state
+  - name: standard.testing_lab_state
     csvField: Testing_lab_state
 
-  - name: standard.Testing_lab_street
+  - name: standard.testing_lab_street
     csvField: Testing_lab_street
 
-  - name: standard.Testing_lab_street2
+  - name: standard.testing_lab_street2
     csvField: Testing_lab_street2
 
-  - name: standard.Testing_lab_zip_code
+  - name: standard.testing_lab_zip_code
     csvField: Testing_lab_zip_code
 
-  - name: standard.Testing_lab_phone_number
+  - name: standard.testing_lab_phone_number
     csvField: Testing_lab_zip_code
 
-  - name: standard.Ordering_facility_city
+  - name: standard.ordering_facility_city
     csvField: Ordering_facility_city
 
-  - name: standard.Ordering_facility_county
+  - name: standard.ordering_facility_county
     csvField: Odering_facility_county
 
-  - name: standard.Ordering_facility_name
+  - name: standard.ordering_facility_name
     csvField: Ordering_facility_name
 
-  - name: standard.Ordering_facility_phone_number
+  - name: standard.ordering_facility_phone_number
     csvField: Ordering_facility_phone_number
 
-  - name: standard.Ordering_facility_state
+  - name: standard.ordering_facility_state
     csvField: Ordering_facility_state
 
-  - name: standard.Ordering_facility_street
+  - name: standard.ordering_facility_street
     csvField: Ordering_facility_street
 
-  - name: standard.Ordering_facility_street_2
+  - name: standard.ordering_facility_street_2
     csvField: Ordering_facility_street_2
 
-  - name: standard.Ordering_facility_zip_code
+  - name: standard.ordering_facility_zip_code
     csvField: Ordering_facility_zip_code
 
-  - name: standard.Ordering_provider_last_name
+  - name: standard.ordering_provider_last_name
     csvField: Ordering_provider_last_name
 
-  - name: standard.Ordering_provider_first_name
+  - name: standard.ordering_provider_first_name
     csvField: Ordering_provider_first_name
 
-  - name: standard.Ordering_provider_street
+  - name: standard.ordering_provider_street
     csvField: Ordering_provider_street
 
-  - name: standard.Ordering_provider_zip_code
+  - name: standard.ordering_provider_zip_code
     csvField: Ordering_provider_zip_code
 
-  - name: standard.Ordering_provider_phone_number
+  - name: standard.ordering_provider_phone_number
     csvField: Ordering_provider_phone
 
-  - name: standard.Ordered_test_code
+  - name: standard.ordered_test_code
     csvField: Ordered_test_code
 
-  - name: standard.Specimen_source_site_code
+  - name: standard.specimen_source_site_code
     csvField: Specimen_source_site_code
 
-  - name: standard.Specimen_type_code
+  - name: standard.specimen_type_code
     csvField: Specimen_type_code
 
-  - name: standard.Equipment_instance_ID
+  - name: standard.equipment_instance_ID
     csvField: Instrument_ID
 
-  - name: standard.Test_result_date
+  - name: standard.test_result_date
     csvField: Test_date
 
-  - name: standard.Date_result_released
+  - name: standard.date_result_released
     csvField: Date_result_released
 

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -2,7 +2,7 @@
 name: pdi-covid-19
 description: PRIME POC COVID-19 flat file
 topic: covid-19
-trackingElement: standard.Testing_lab_specimen_ID
+trackingElement: standard.testing_lab_specimen_id
 elements:
   - name: standard.patient_last_name
     csvField: Patient_last_name
@@ -19,7 +19,7 @@ elements:
   - name: standard.patient_race
     csvField: Patient_race
 
-  - name: standard.patient_DOB
+  - name: standard.patient_dob
     csvField: Patient_DOB
 
   - name: standard.patient_gender
@@ -49,7 +49,7 @@ elements:
   - name: standard.patient_phone_number
     csvField: Patient_phone_number
 
-  - name: standard.patient_Id
+  - name: standard.patient_id
     csvField: Patient_ID
 
   - name: standard.employed_in_healthcare
@@ -58,16 +58,16 @@ elements:
   - name: standard.resident_congregate_setting
     csvField: Resident_congregate_setting
 
-  - name: standard.testing_lab_specimen_ID
+  - name: standard.testing_lab_specimen_id
     csvField: Testing_lab_specimen_ID
 
-  - name: standard.test_result_coded
+  - name: standard.test_result
     csvField: Test_result_coded
 
   - name: standard.specimen_collection_date_time
     csvField: Specimen_collection_date_time
 
-  - name: standard.ordering_provider_ID
+  - name: standard.ordering_provider_id
     csvField: Ordering_provider_ID
 
   - name: standard.first_test
@@ -79,7 +79,7 @@ elements:
   - name: standard.testing_lab_name
     csvField: Testing_lab_name
 
-  - name: standard.testing_lab_ID
+  - name: standard.testing_lab_id
     csvField: Testing_lab_ID
 
   - name: standard.testing_lab_city
@@ -142,13 +142,14 @@ elements:
   - name: standard.ordered_test_code
     csvField: Ordered_test_code
 
+  # TODO: change when specimen_source_site has a valueSet
   - name: standard.specimen_source_site_code
     csvField: Specimen_source_site_code
 
-  - name: standard.specimen_type_code
+  - name: standard.specimen_type
     csvField: Specimen_type_code
 
-  - name: standard.equipment_instance_ID
+  - name: standard.equipment_instance_id
     csvField: Instrument_ID
 
   - name: standard.test_result_date

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -37,21 +37,15 @@ elements:
     hl7Field: REPEAT_OBX_MAP_MULTIPLE
 
   - name: employed_in_healthcare
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: Employed_in_healthcare
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
   - name: employed_in_high_risk_setting
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: Employed_in_high_risk_setting
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
@@ -81,11 +75,8 @@ elements:
     hl7Field: MSH-7
 
   - name: first_test
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: First_test
     hhsGuidanceField: First Test
     hl7Field: REPEAT_OBX_MAP
@@ -97,21 +88,15 @@ elements:
     hl7Field: IGNORE
 
   - name: hospitalized
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: Hospitalized
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: iCU
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+  - name: icu
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: ICU
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
@@ -135,7 +120,7 @@ elements:
     hl7Field: OBR-26
 
   - name: order_result_status
-    type: CODED_SNOMED
+    type: CODED
     natFlatFileField: Order_result_status
     hhsGuidanceField:
     hl7Field: OBR-25
@@ -149,7 +134,7 @@ elements:
   - name: ordered_test_code
     type: TEXT
     natFlatFileField: Ordered_test_code
-    hhsGuidanceField: 'Test ordered '
+    hhsGuidanceField: Test ordered
     hl7Field: OBR-4.1
 
   - name: ordered_test_code_system
@@ -280,9 +265,7 @@ elements:
 
   - name: patient_age_units
     type: CODED
-    valueSet:
-      - months
-      - years
+    valueSet: patient_age_units
     natFlatFileField: Patient_age_units
     hhsGuidanceField:
     hl7Field: OBX-6
@@ -319,11 +302,7 @@ elements:
 
   - name: patient_ethnicity
     type: CODED
-    valueSet:
-      - Hispanic or Latino # 2135-2
-      - Non Hispanic or Latino # 2186-5
-      - Unknown # UNK
-      - Asked, but unknown # ASKU
+    valueSet: omb_ethnicity
     natFlatFileField: Patient_ethnicity
     hhsGuidanceField: Patient ethnicity
     hl7Field: PID-22.2
@@ -331,17 +310,12 @@ elements:
   - name: patient_first_name
     type: PERSON_NAME
     natFlatFileField: Patient_first_name
-    hhsGuidanceField: 'Patient name '
+    hhsGuidanceField: Patient name
     hl7Field: PID-5.2
 
   - name: patient_gender
     type: CODED
-    valueSet:
-      - Male
-      - Female
-      - Other
-      - Ambiguous
-      - Unknown
+    valueSet: patient_gender
     natFlatFileField: Patient_gender
     hhsGuidanceField: Patient sex
     hl7Field: PID-8
@@ -420,16 +394,9 @@ elements:
 
   - name: patient_race
     type: CODED
-    valueSet:
-      - American Indian or Alaska Native #1002-5
-      - Asian #2028-9
-      - Black or African American #2054-5
-      - Native Hawaiian or Other Pacific Islander #2076-8
-      - White #2106-3
-      - Unknown #UNK
-      - Asked, but unknown #ASKU
+    valueSet: omb_race
     natFlatFileField: Patient_race
-    hhsGuidanceField: 'Patient race '
+    hhsGuidanceField: Patient race
     hl7Field: PID-10
 
   - name: patient_residency_type
@@ -463,13 +430,15 @@ elements:
     hl7Field: PID-5.4
 
   - name: patient_tribal_citizenship_coded
-    type: CODED_HL7
+    type: CODED
+    valueSet: tribal_citizenship
     natFlatFileField:
     hhsGuidanceField:
     hl7Field: PID-39
 
   - name: patient_tribal_citizenship_text
     type: TEXT
+    valueSet: tribal_citizenship
     natFlatFileField:
     hhsGuidanceField:
     hl7Field: PID-39
@@ -481,23 +450,15 @@ elements:
     hl7Field: PID-11.5
 
   - name: pregnant_code
-    type: CODED_SNOMED
-    valueSet:
-      - 77386006 # Pregnant
-      - 60001007 # Not Pregnant
-      - 261665006 # Unknown
-      - 276727009 # Null
+    type: CODED
+    valueSet: pregnant_aoe
     natFlatFileField: Pregnant
     hhsGuidanceField: Pregnant
     hl7Field: OBX-5
 
-  - name: pregnant
-    type: CODED
-    valueSet:
-      - Pregnant
-      - Not Pregnant
-      - Unknown
-      - Null
+  - name: pregnant_text
+    type: TEXT
+    valueSet: pregnant_aoe
     natFlatFileField: Pregnant
     hhsGuidanceField: Pregnant
     hl7Field: OBX-5
@@ -565,77 +526,34 @@ elements:
     hl7Field: SPM-18
 
   - name: specimen_role
-    type: CODED_HL7
-    valueSet:
-      - B # Blind sample
-      - E # Electronic QC
-      - F # Filer
-      - G # Group
-      - L # Pool
-      - O # Operator proficiency
-      - P # Patient
-      - Q # Control specimen
-      - R # Replicate
-      - V # Verifying collaborator
+    type: CODED
+    valueSet: covid-19/specimen_role
     natFlatFileField: Role
     hhsGuidanceField:
     hl7Field: SPM-11
 
   - name: specimen_source_site_code
-    type: CODED_SNOMED
+    type: TEXT
     natFlatFileField: Specimen_source_site_code
     hhsGuidanceField: Specimen source
     hl7Field: SPM-8.1
 
-  - name: specimen_source_site_code_sys
-    type: CODED
-    valueSet: [SCT,L]
-    natFlatFileField: Specimen_source_site_code_sys
-    hhsGuidanceField:
-    hl7Field: SPM-8.3
-
-  - name: specimen_source_site_description
+  - name: specimen_source_site_text
     type: TEXT
     natFlatFileField: Specimen_source_site_descrip
     hhsGuidanceField:
     hl7Field: SPM-8.2
 
   - name: specimen_type_code
-    type: CODED_SNOMED
-    valueSet:
-      - 258500001 # Nasopharyngeal swab
-      - 871810001 # Mid-turbinate nasal swab
-      - 697989009 # Anterior nares swab
-      - 258411007 # Nasopharyngeal aspirate
-      - 429931000124105 # Nasal aspirate
-      - 258529004 # Throat swab
-      - 119334006 # Sputum specimen
-      - 119342007 # Saliva specimen
-      - 258607008 # Bronchoalveolar lavage fluid sample
-      - 119364003 # Serum specimen
-      - 119361006 # Plasma specimen
-      - 440500007 # Dried blood spot specimen
-      - 258580003 # Whole blood sample
-      - 122555007 # Venous blood specimen
+    type: CODED
+    valueSet: covid-19/specimen_type
     natFlatFileField: Specimen_type_code
     hhsGuidanceField: Specimen source
     hl7Field: SPM-4.1
 
-  - name: specimen_type_code_system
-    type: CODED
-    valueSet: [SCT]
-    natFlatFileField: Specimen_type_code_system
-    hhsGuidanceField:
-    hl7Field: SPM-4.3
-
-  - name: specimen_type_description
-    type: TEXT
-    natFlatFileField: Specimen_type_description
-    hhsGuidanceField:
-    hl7Field: SPM-4.2
-
   - name: specimen_type_text
     type: TEXT
+    valueSet: covid-19/specimen_type
     natFlatFileField: Specimen_type_text
     hhsGuidanceField:
     hl7Field: SPM-4.9
@@ -653,11 +571,8 @@ elements:
     hl7Field: SPM-2.1.1
 
   - name: symptomatic_for_disease
-    type: CODED_HL7
-    valueSet:
-      - YES
-      - NO
-      - UNK # Unknown
+    type: CODED
+    valueSet: hl7_0136
     natFlatFileField: Symptomatic_for_disease
     hhsGuidanceField: Symptomatic per CDC
     hl7Field: OBX-5
@@ -694,18 +609,14 @@ elements:
 
   - name: test_performed_code
     type: CODED
+    valueSet: covid-19/order
     natFlatFileField: Test_performed_code
     hhsGuidanceField:
     hl7Field: OBX-3.1
 
-  - name: test_performed_code_system
+  - name: test_performed_text
     type: TEXT
-    natFlatFileField: Test_performed_code_system
-    hhsGuidanceField:
-    hl7Field: OBX-3.3
-
-  - name: test_performed_description
-    type: TEXT
+    valueSet: covid-19/order
     natFlatFileField: Test_performed_description
     hhsGuidanceField:
     hl7Field: OBX-3.2
@@ -716,21 +627,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-1
 
-  - name: test_result_code_system
-    type: CODED_HL7
-    valueSet: ["L", "SCT"]
-    natFlatFileField: Test_result_code_system
-    hhsGuidanceField:
-    hl7Field: OBX-5.3
-
   - name: test_result_coded
-    type: CODED_SNOMED
-    valueSet:
-      - 260373001 #Detected
-      - 260415000 #Not detected
-      - 895231008 #Not detected in pooled specimen
-      - 462371000124108 #Detected in pooled specimen
-      - 419984006 #Inconclusive
+    type: CODED
+    valueSet: covid-19/test_result
     natFlatFileField: Test_result_coded
     hhsGuidanceField: Test result
     hl7Field: OBX-5.1
@@ -761,6 +660,7 @@ elements:
 
   - name: test_result_text
     type: TEXT
+    valueSet: covid-19/test_result
     natFlatFileField: Test_Result_text
     hhsGuidanceField:
     hl7Field: OBX-5.1

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -13,7 +13,8 @@ topic: covid-19
 description: collection of standard elements, not an actual schema
 elements:
   - name: abnormal_flag
-    type: CODED
+    type: CODE
+    valueSet: hl7_0136
     natFlatFileField: Abnormal_flag
     hhsGuidanceField:
     hl7Field: OBX-8
@@ -31,34 +32,34 @@ elements:
     hl7Field: OBR-22
 
   - name: disease_symptoms
-    type: CODED
+    type: TEXT
     natFlatFileField: Disease_symptoms
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_MULTIPLE
 
   - name: employed_in_healthcare
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: Employed_in_healthcare
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
   - name: employed_in_high_risk_setting
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: Employed_in_high_risk_setting
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: equipment_instance_ID
+  - name: equipment_instance_id
     type: ID
-    natFlatFileField: Instrument_instance_ID
+    natFlatFileField: Instrument_instance_id
     hhsGuidanceField:
     hl7Field: OBX-18
 
-  - name: equipment_model_ID
+  - name: equipment_model_id
     type: TEXT
-    natFlatFileField: Instrument_model_ID
+    natFlatFileField: Instrument_model_id
     hhsGuidanceField:
     hl7Field: OBX-17
 
@@ -75,7 +76,7 @@ elements:
     hl7Field: MSH-7
 
   - name: first_test
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: First_test
     hhsGuidanceField: First Test
@@ -88,14 +89,14 @@ elements:
     hl7Field: IGNORE
 
   - name: hospitalized
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: Hospitalized
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
   - name: icu
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: ICU
     hhsGuidanceField:
@@ -119,8 +120,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBR-26
 
+  # TODO: valueSet?
   - name: order_result_status
-    type: CODED
+    type: TEXT
     natFlatFileField: Order_result_status
     hhsGuidanceField:
     hl7Field: OBR-25
@@ -215,9 +217,9 @@ elements:
     hhsGuidanceField:
     hl7Field: ORC-12.3/OBR-16.3
 
-  - name: ordering_provider_ID
+  - name: ordering_provider_id
     type: ID
-    natFlatFileField: Ordering_provider_ID
+    natFlatFileField: Ordering_provider_id
     hhsGuidanceField: Ordering provider name; NPI
     hl7Field: ORC-12.1/OBR-16.1
 
@@ -264,7 +266,7 @@ elements:
     hl7Field: REPEAT_OBX_NM
 
   - name: patient_age_units
-    type: CODED
+    type: CODE
     valueSet: patient_age_units
     natFlatFileField: Patient_age_units
     hhsGuidanceField:
@@ -289,19 +291,20 @@ elements:
     hl7Field: PID-29
 
   - name: patient_died
-    type: CODED
+    type: CODE
+    valueSet: hl7_0136
     natFlatFileField: Patient_died
     hhsGuidanceField:
     hl7Field: PID-30
 
-  - name: patient_DOB
+  - name: patient_dob
     type: DATE
     natFlatFileField: Patient_DOB
     hhsGuidanceField: Patient date of birth
     hl7Field: PID-7
 
   - name: patient_ethnicity
-    type: CODED
+    type: CODE
     valueSet: omb_ethnicity
     natFlatFileField: Patient_ethnicity
     hhsGuidanceField: Patient ethnicity
@@ -314,45 +317,45 @@ elements:
     hl7Field: PID-5.2
 
   - name: patient_gender
-    type: CODED
+    type: CODE
     valueSet: patient_gender
     natFlatFileField: Patient_gender
     hhsGuidanceField: Patient sex
     hl7Field: PID-8
 
-  - name: patient_ID
+  - name: patient_id
     type: ID
-    natFlatFileField: Patient_ID
+    natFlatFileField: Patient_id
     hhsGuidanceField:
     hl7Field: PID-3.1-1
 
-  - name: patient_ID_2
+  - name: patient_id_2
     type: ID
-    natFlatFileField: Patient_ID_2
+    natFlatFileField: Patient_id_2
     hhsGuidanceField:
     hl7Field: PID-3.1-2
 
-  - name: patient_ID_2_assigner
+  - name: patient_id_2_assigner
     type: TEXT
-    natFlatFileField: Patient_ID_2_assigner
+    natFlatFileField: Patient_id_2_assigner
     hhsGuidanceField:
     hl7Field: PID-3.4.1-2
 
-  - name: patient_ID_2_type
+  - name: patient_id_2_type
     type: TEXT
-    natFlatFileField: Patient_ID_2_type
+    natFlatFileField: Patient_id_2_type
     hhsGuidanceField:
     hl7Field: PID-3.5-2
 
-  - name: patient_ID_assigner
+  - name: patient_id_assigner
     type: TEXT
-    natFlatFileField: Patient_ID_assigner
+    natFlatFileField: Patient_id_assigner
     hhsGuidanceField:
     hl7Field: PID-3.4.1-1
 
-  - name: patient_ID_type
-    type: CODED
-    natFlatFileField: Patient_ID_type
+  - name: patient_id_type
+    type: TEXT
+    natFlatFileField: Patient_id_type
     hhsGuidanceField:
     hl7Field: PID-3.5-1
 
@@ -363,7 +366,7 @@ elements:
     hl7Field: PID-5.1
 
   - name: patient_location
-    type: CODED
+    type: TEXT
     natFlatFileField: Patient_location
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_OTHER
@@ -380,8 +383,9 @@ elements:
     hhsGuidanceField: Patient name
     hl7Field: PID-5.3
 
+  # TODO: Need valueSet
   - name: patient_occupation
-    type: CODED
+    type: TEXT
     natFlatFileField: Patient_occupation
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_OTHER
@@ -393,14 +397,14 @@ elements:
     hl7Field: PID-13
 
   - name: patient_race
-    type: CODED
+    type: CODE
     valueSet: omb_race
     natFlatFileField: Patient_race
     hhsGuidanceField: Patient race
     hl7Field: PID-10
 
   - name: patient_residency_type
-    type: CODED
+    type: CODE
     natFlatFileField: Patient_residency_type
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
@@ -429,15 +433,8 @@ elements:
     hhsGuidanceField:
     hl7Field: PID-5.4
 
-  - name: patient_tribal_citizenship_coded
-    type: CODED
-    valueSet: tribal_citizenship
-    natFlatFileField:
-    hhsGuidanceField:
-    hl7Field: PID-39
-
-  - name: patient_tribal_citizenship_text
-    type: TEXT
+  - name: patient_tribal_citizenship
+    type: CODE
     valueSet: tribal_citizenship
     natFlatFileField:
     hhsGuidanceField:
@@ -449,23 +446,16 @@ elements:
     hhsGuidanceField: Patient residence zip code
     hl7Field: PID-11.5
 
-  - name: pregnant_code
-    type: CODED
+  - name: pregnant
+    type: CODE
     valueSet: pregnant_aoe
     natFlatFileField: Pregnant
     hhsGuidanceField: Pregnant
     hl7Field: OBX-5
 
-  - name: pregnant_text
-    type: TEXT
-    valueSet: pregnant_aoe
-    natFlatFileField: Pregnant
-    hhsGuidanceField: Pregnant
-    hl7Field: OBX-5
-
-  - name: public_health_case_ID
+  - name: public_health_case_id
     type: ID
-    natFlatFileField: Public_health_case_ID
+    natFlatFileField: Public_health_case_id
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_ST
 
@@ -475,9 +465,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-7
 
-  - name: reporting_facility_ID
+  - name: reporting_facility_id
     type: ID
-    natFlatFileField: Reporting_facility_ID
+    natFlatFileField: Reporting_facility_id
     hhsGuidanceField:
     hl7Field: MSH-4.2
 
@@ -526,72 +516,67 @@ elements:
     hl7Field: SPM-18
 
   - name: specimen_role
-    type: CODED
+    type: CODE
     valueSet: covid-19/specimen_role
     natFlatFileField: Role
     hhsGuidanceField:
     hl7Field: SPM-11
 
+  # TODO: ValueSet
   - name: specimen_source_site_code
     type: TEXT
     natFlatFileField: Specimen_source_site_code
     hhsGuidanceField: Specimen source
     hl7Field: SPM-8.1
 
+  # TODO: ValueSet
   - name: specimen_source_site_text
     type: TEXT
     natFlatFileField: Specimen_source_site_descrip
     hhsGuidanceField:
     hl7Field: SPM-8.2
 
-  - name: specimen_type_code
-    type: CODED
+  - name: specimen_type
+    type: CODE
     valueSet: covid-19/specimen_type
     natFlatFileField: Specimen_type_code
     hhsGuidanceField: Specimen source
     hl7Field: SPM-4.1
 
-  - name: specimen_type_text
+  - name: submitter_sample_id_assigner
     type: TEXT
-    valueSet: covid-19/specimen_type
-    natFlatFileField: Specimen_type_text
-    hhsGuidanceField:
-    hl7Field: SPM-4.9
-
-  - name: submitter_sample_ID_assigner
-    type: TEXT
-    natFlatFileField: Submitter_sample_ID_assigner
+    natFlatFileField: Submitter_sample_id_assigner
     hhsGuidanceField:
     hl7Field: SPM-2.1.2
 
-  - name: submitter_unique_sample_ID
+  - name: submitter_unique_sample_id
     type: ID
-    natFlatFileField: Submitter_unique_sample_ID
+    natFlatFileField: Submitter_unique_sample_id
     hhsGuidanceField:
     hl7Field: SPM-2.1.1
 
   - name: symptomatic_for_disease
-    type: CODED
+    type: CODE
     valueSet: hl7_0136
     natFlatFileField: Symptomatic_for_disease
     hhsGuidanceField: Symptomatic per CDC
     hl7Field: OBX-5
 
-  - name: test_kit_EUA_ID
+  - name: test_kit_eua_id
     type: ID
-    natFlatFileField: Test_kit_EUA_ID
+    natFlatFileField: Test_kit_EUA_id
     hhsGuidanceField:
     hl7Field: OBX-17.1
 
-  - name: test_kit_instance_ID
+  - name: test_kit_instance_id
     type: ID
-    natFlatFileField: Test_kit_instance_ID
+    natFlatFileField: Test_kit_instance_id
     hhsGuidanceField:
     hl7Field: OBX-18
 
-  - name: test_kit_model_ID
+  - name: test_kit_model_id
     type: ID
-    natFlatFileField: Test_kit_model_ID
+    natFlatFileField: Test_kit_model_id
     hhsGuidanceField:
     hl7Field: OBX-17.1
 
@@ -607,19 +592,12 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-17.9
 
-  - name: test_performed_code
-    type: CODED
+  - name: test_performed
+    type: CODE
     valueSet: covid-19/order
     natFlatFileField: Test_performed_code
     hhsGuidanceField:
     hl7Field: OBX-3.1
-
-  - name: test_performed_text
-    type: TEXT
-    valueSet: covid-19/order
-    natFlatFileField: Test_performed_description
-    hhsGuidanceField:
-    hl7Field: OBX-3.2
 
   - name: test_performed_number
     type: NUMBER
@@ -627,13 +605,14 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-1
 
-  - name: test_result_coded
-    type: CODED
+  - name: test_result
+    type: CODE
     valueSet: covid-19/test_result
     natFlatFileField: Test_result_coded
     hhsGuidanceField: Test result
     hl7Field: OBX-5.1
 
+  # TODO: What is this
   - name: test_result_comparator
     type: TEXT
     natFlatFileField: Test_result_comparator
@@ -657,13 +636,6 @@ elements:
     natFlatFileField: Test_result_description
     hhsGuidanceField:
     hl7Field: OBX-5.2
-
-  - name: test_result_text
-    type: TEXT
-    valueSet: covid-19/test_result
-    natFlatFileField: Test_Result_text
-    hhsGuidanceField:
-    hl7Field: OBX-5.1
 
   - name: test_result_number
     type: TEXT
@@ -689,9 +661,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-11
 
-  - name: test_result_sub_ID
+  - name: test_result_sub_id
     type: ID
-    natFlatFileField: Test_result_sub_ID
+    natFlatFileField: Test_result_sub_id
     hhsGuidanceField:
     hl7Field: OBX-4
 
@@ -719,9 +691,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-24.9
 
-  - name: testing_lab_ID
+  - name: testing_lab_id
     type: ID
-    natFlatFileField: Testing_lab_ID
+    natFlatFileField: Testing_lab_id
     hhsGuidanceField:
     hl7Field: OBX-23.10/OBX-15.1
 
@@ -731,9 +703,9 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-23.1/OBX-15.2
 
-  - name: testing_lab_specimen_ID
+  - name: testing_lab_specimen_id
     type: ID
-    natFlatFileField: Testing_lab_specimen_ID
+    natFlatFileField: Testing_lab_specimen_id
     hhsGuidanceField:
     hl7Field: SPM-2.2.1
 

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -4,7 +4,7 @@
 # Conventions:
 # - Sort by element name
 # - Use the HL7 message name with _ instead of space and lower cased
-# - Extended with _text or _coded or _system for the various parts of the HL7 field
+# - Extended with #text or #system for the various parts of the HL7 field
 # - Use ID instead of Identifier
 # - Avoid abbreviations. Use street1, phone_number, zip_code, ...
 #

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -1,35 +1,42 @@
 ---
 # This is set of standard data elements for covid-19 topic
 #
+# Conventions:
+# - Sort by element name
+# - Use the HL7 message name with _ instead of space and lower cased
+# - Extended with _text or _coded or _system for the various parts of the HL7 field
+# - Use ID instead of Identifier
+# - Avoid abbreviations. Use street1, phone_number, zip_code, ...
+#
 name: standard
 topic: covid-19
 description: collection of standard elements, not an actual schema
 elements:
-  - name: Abnormal_flag
+  - name: abnormal_flag
     type: CODED
     natFlatFileField: Abnormal_flag
     hhsGuidanceField:
     hl7Field: OBX-8
 
-  - name: Comment
+  - name: comment
     type: TEXT
     natFlatFileField: Comments
     hhsGuidanceField:
     hl7Field: NTE-3
 
-  - name: Date_result_released
+  - name: date_result_released
     type: DATE
     natFlatFileField: Date_result_released
     hhsGuidanceField: Test report date
     hl7Field: OBR-22
 
-  - name: Disease_symptoms
+  - name: disease_symptoms
     type: CODED
     natFlatFileField: Disease_symptoms
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_MULTIPLE
 
-  - name: Employed_in_healthcare
+  - name: employed_in_healthcare
     type: CODED_HL7
     valueSet:
       - YES
@@ -39,7 +46,7 @@ elements:
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: Employed_in_high_risk_setting
+  - name: employed_in_high_risk_setting
     type: CODED_HL7
     valueSet:
       - YES
@@ -49,31 +56,31 @@ elements:
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: Equipment_instance_ID
+  - name: equipment_instance_ID
     type: ID
     natFlatFileField: Instrument_instance_ID
     hhsGuidanceField:
     hl7Field: OBX-18
 
-  - name: Equipment_model_ID
+  - name: equipment_model_ID
     type: TEXT
     natFlatFileField: Instrument_model_ID
     hhsGuidanceField:
     hl7Field: OBX-17
 
-  - name: Equipment_model_name
+  - name: equipment_model_name
     type: TEXT
     natFlatFileField: Instrument_model_name
     hhsGuidanceField:
     hl7Field: OBX-17
 
-  - name: File_created_date
+  - name: file_created_date
     type: DATE
     natFlatFileField: File_created_date
     hhsGuidanceField:
     hl7Field: MSH-7
 
-  - name: First_test
+  - name: first_test
     type: CODED_HL7
     valueSet:
       - YES
@@ -89,7 +96,7 @@ elements:
     hhsGuidanceField:
     hl7Field: IGNORE
 
-  - name: Hospitalized
+  - name: hospitalized
     type: CODED_HL7
     valueSet:
       - YES
@@ -99,7 +106,7 @@ elements:
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: ICU
+  - name: iCU
     type: CODED_HL7
     valueSet:
       - YES
@@ -109,169 +116,169 @@ elements:
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: Illness_onset_date
+  - name: illness_onset_date
     type: DATE
     natFlatFileField: Illness_onset_date
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_DT
 
-  - name: Link_test_to_parent_accession
+  - name: link_test_to_parent_accession
     type: TEXT
     natFlatFileField: Link_test_to_parent_accession
     hhsGuidanceField:
     hl7Field: OBR-29
 
-  - name: Link_test_to_parent_result
+  - name: link_test_to_parent_result
     type: TEXT
     natFlatFileField: Link_test_to_parent_result
     hhsGuidanceField:
     hl7Field: OBR-26
 
-  - name: Order_result_status
+  - name: order_result_status
     type: CODED_SNOMED
     natFlatFileField: Order_result_status
     hhsGuidanceField:
     hl7Field: OBR-25
 
-  - name: Order_test_date
+  - name: order_test_date
     type: DATE
     natFlatFileField: Order_test_date
     hhsGuidanceField:
     hl7Field: ORC-15
 
-  - name: Ordered_test_code
+  - name: ordered_test_code
     type: TEXT
     natFlatFileField: Ordered_test_code
     hhsGuidanceField: 'Test ordered '
     hl7Field: OBR-4.1
 
-  - name: Ordered_test_code_system
+  - name: ordered_test_code_system
     type: TEXT
     natFlatFileField: Ordered_test_code_system
     hhsGuidanceField:
     hl7Field: OBR-4.3
 
-  - name: Ordered_test_description
+  - name: ordered_test_description
     type: TEXT
     natFlatFileField: Ordered_test_description
     hhsGuidanceField:
     hl7Field: OBR-4.2
 
-  - name: Ordering_facility_city
+  - name: ordering_facility_city
     type: CITY
     natFlatFileField: Ordering_facility_city
     hhsGuidanceField:
     hl7Field: ORC-22.3
 
-  - name: Ordering_facility_county
+  - name: ordering_facility_county
     type: COUNTY
     natFlatFileField: Ordering_facility_county
     hhsGuidanceField:
     hl7Field: ORC-22.9
 
-  - name: Ordering_facility_name
+  - name: ordering_facility_name
     type: TEXT
     natFlatFileField: Ordering_facility_name
     hhsGuidanceField:
     hl7Field: ORC-21.1
 
-  - name: Ordering_facility_phone_number
+  - name: ordering_facility_phone_number
     type: TELEPHONE
     natFlatFileField: Ordering_facility_phone_number
     hhsGuidanceField:
     hl7Field: ORC-23
 
-  - name: Ordering_facility_state
+  - name: ordering_facility_state
     type: STATE
     natFlatFileField: Ordering_facility_state
     hhsGuidanceField:
     hl7Field: ORC-22.4
 
-  - name: Ordering_facility_street
+  - name: ordering_facility_street
     type: STREET
     natFlatFileField: Ordering_facility_street
     hhsGuidanceField:
     hl7Field: ORC-22.1
 
-  - name: Ordering_facility_street_2
+  - name: ordering_facility_street_2
     type: STREET
     natFlatFileField: Ordering_facility_street_2
     hhsGuidanceField:
     hl7Field: ORC-22.2
 
-  - name: Ordering_facility_zip_code
+  - name: ordering_facility_zip_code
     type: POSTAL_CODE
     natFlatFileField: Ordering_facility_zip_code
     hhsGuidanceField:
     hl7Field: ORC-22.5
 
-  - name: Ordering_provider_city
+  - name: ordering_provider_city
     type: CITY
     natFlatFileField: Ordering_provider_city
     hhsGuidanceField:
     hl7Field: ORC-24.3
 
-  - name: Ordering_provider_county
+  - name: ordering_provider_county
     type: COUNTY
     natFlatFileField: Ordering_provider_county
     hhsGuidanceField:
     hl7Field: ORC-24.9
 
-  - name: Ordering_provider_first_name
+  - name: ordering_provider_first_name
     type: PERSON_NAME
     natFlatFileField: Ordering_provider_first_name
     hhsGuidanceField:
     hl7Field: ORC-12.3/OBR-16.3
 
-  - name: Ordering_provider_ID
+  - name: ordering_provider_ID
     type: ID
     natFlatFileField: Ordering_provider_ID
     hhsGuidanceField: Ordering provider name; NPI
     hl7Field: ORC-12.1/OBR-16.1
 
-  - name: Ordering_provider_last_name
+  - name: ordering_provider_last_name
     type: PERSON_NAME
     natFlatFileField: Ordering_provider_last_name
     hhsGuidanceField:
     hl7Field: ORC-12.2/OBR-16.2
 
-  - name: Ordering_provider_phone_number
+  - name: ordering_provider_phone_number
     type: TELEPHONE
     natFlatFileField: Ordering_provider_phone
     hhsGuidanceField: Ordering provider phone number
     hl7Field: ORC-14/OBR-17
 
-  - name: Ordering_provider_state
+  - name: ordering_provider_state
     type: STATE
     natFlatFileField: Ordering_provider_state
     hhsGuidanceField:
     hl7Field: ORC-24.4
 
-  - name: Ordering_provider_street
+  - name: ordering_provider_street
     type: STREET
     natFlatFileField: Ordering_provider_street
     hhsGuidanceField: Ordering provider address
     hl7Field: ORC-24.1
 
-  - name: Ordering_provider_street2
+  - name: ordering_provider_street2
     type: STREET
     natFlatFileField: Ordering_provider_street2
     hhsGuidanceField:
     hl7Field: ORC-24.2
 
-  - name: Ordering_provider_zip_code
+  - name: ordering_provider_zip_code
     type: POSTAL_CODE
     natFlatFileField: Ordering_provider_zip_code
     hhsGuidanceField: Ordering provider zip code
     hl7Field: ORC-24.5
 
-  - name: Patient_age
+  - name: patient_age
     type: NUMBER
     natFlatFileField: Patient_age
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_NM
 
-  - name: Patient_age_units
+  - name: patient_age_units
     type: CODED
     valueSet:
       - months
@@ -280,37 +287,37 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-6
 
-  - name: Patient_city
+  - name: patient_city
     type: CITY
     natFlatFileField: Patient_city
     hhsGuidanceField:
     hl7Field: PID-11.3
 
-  - name: Patient_county
+  - name: patient_county
     type: COUNTY
     natFlatFileField: Patient_county
     hhsGuidanceField: Patient residence county
     hl7Field: PID-11.9
 
-  - name: Patient_death_date
+  - name: patient_death_date
     type: DATE
     natFlatFileField: Patient_death_date
     hhsGuidanceField:
     hl7Field: PID-29
 
-  - name: Patient_died
+  - name: patient_died
     type: CODED
     natFlatFileField: Patient_died
     hhsGuidanceField:
     hl7Field: PID-30
 
-  - name: Patient_DOB
+  - name: patient_DOB
     type: DATE
     natFlatFileField: Patient_DOB
     hhsGuidanceField: Patient date of birth
     hl7Field: PID-7
 
-  - name: Patient_ethnicity
+  - name: patient_ethnicity
     type: CODED
     valueSet:
       - Hispanic or Latino # 2135-2
@@ -321,13 +328,13 @@ elements:
     hhsGuidanceField: Patient ethnicity
     hl7Field: PID-22.2
 
-  - name: Patient_first_name
+  - name: patient_first_name
     type: PERSON_NAME
     natFlatFileField: Patient_first_name
     hhsGuidanceField: 'Patient name '
     hl7Field: PID-5.2
 
-  - name: Patient_gender
+  - name: patient_gender
     type: CODED
     valueSet:
       - Male
@@ -339,79 +346,79 @@ elements:
     hhsGuidanceField: Patient sex
     hl7Field: PID-8
 
-  - name: Patient_ID
+  - name: patient_ID
     type: ID
     natFlatFileField: Patient_ID
     hhsGuidanceField:
     hl7Field: PID-3.1-1
 
-  - name: Patient_ID_2
+  - name: patient_ID_2
     type: ID
     natFlatFileField: Patient_ID_2
     hhsGuidanceField:
     hl7Field: PID-3.1-2
 
-  - name: Patient_ID_2_assigner
+  - name: patient_ID_2_assigner
     type: TEXT
     natFlatFileField: Patient_ID_2_assigner
     hhsGuidanceField:
     hl7Field: PID-3.4.1-2
 
-  - name: Patient_ID_2_type
+  - name: patient_ID_2_type
     type: TEXT
     natFlatFileField: Patient_ID_2_type
     hhsGuidanceField:
     hl7Field: PID-3.5-2
 
-  - name: Patient_ID_assigner
+  - name: patient_ID_assigner
     type: TEXT
     natFlatFileField: Patient_ID_assigner
     hhsGuidanceField:
     hl7Field: PID-3.4.1-1
 
-  - name: Patient_ID_type
+  - name: patient_ID_type
     type: CODED
     natFlatFileField: Patient_ID_type
     hhsGuidanceField:
     hl7Field: PID-3.5-1
 
-  - name: Patient_last_name
+  - name: patient_last_name
     type: PERSON_NAME
     natFlatFileField: Patient_last_name
     hhsGuidanceField: 'Patient name '
     hl7Field: PID-5.1
 
-  - name: Patient_location
+  - name: patient_location
     type: CODED
     natFlatFileField: Patient_location
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_OTHER
 
-  - name: Patient_middle_initial
+  - name: patient_middle_initial
     type: PERSON_NAME
     natFlatFileField: Patient_middle_name
-    hhsGuidanceField: 'Patient name '
+    hhsGuidanceField: Patient name
     hl7Field: PID-5.3
 
-  - name: Patient_middle_name
+  - name: patient_middle_name
     type: PERSON_NAME
     natFlatFileField: Patient_middle_name
-    hhsGuidanceField: 'Patient name '
+    hhsGuidanceField: Patient name
     hl7Field: PID-5.3
 
-  - name: Patient_occupation
+  - name: patient_occupation
     type: CODED
     natFlatFileField: Patient_occupation
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP_OTHER
 
-  - name: Patient_phone_number
+  - name: patient_phone_number
     type: TELEPHONE
     natFlatFileField: Patient_phone_number
     hhsGuidanceField: Patient phone number
     hl7Field: PID-13
 
-  - name: Patient_race
+  - name: patient_race
     type: CODED
     valueSet:
       - American Indian or Alaska Native #1002-5
@@ -425,43 +432,55 @@ elements:
     hhsGuidanceField: 'Patient race '
     hl7Field: PID-10
 
-  - name: Patient_residency_type
+  - name: patient_residency_type
     type: CODED
     natFlatFileField: Patient_residency_type
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_MAP
 
-  - name: Patient_state
+  - name: patient_state
     type: STATE
     natFlatFileField: Patient_state
     hhsGuidanceField:
     hl7Field: PID-11.4
 
-  - name: Patient_street
+  - name: patient_street
     type: STREET
     natFlatFileField: Patient_street
     hhsGuidanceField: Patient street address
     hl7Field: PID-11.1
 
-  - name: Patient_street2
+  - name: patient_street2
     type: STREET
     natFlatFileField: Patient_street2
     hhsGuidanceField:
     hl7Field: PID-11.2
 
-  - name: Patient_suffix
+  - name: patient_suffix
     type: PERSON_NAME
     natFlatFileField: Patient_suffix
     hhsGuidanceField:
     hl7Field: PID-5.4
 
-  - name: Patient_zip_code
+  - name: patient_tribal_citizenship_coded
+    type: CODED_HL7
+    natFlatFileField:
+    hhsGuidanceField:
+    hl7Field: PID-39
+
+  - name: patient_tribal_citizenship_text
+    type: TEXT
+    natFlatFileField:
+    hhsGuidanceField:
+    hl7Field: PID-39
+
+  - name: patient_zip_code
     type: POSTAL_CODE
     natFlatFileField: Patient_zip_code
     hhsGuidanceField: Patient residence zip code
     hl7Field: PID-11.5
 
-  - name: Pregnant_code
+  - name: pregnant_code
     type: CODED_SNOMED
     valueSet:
       - 77386006 # Pregnant
@@ -472,7 +491,7 @@ elements:
     hhsGuidanceField: Pregnant
     hl7Field: OBX-5
 
-  - name: Pregnant
+  - name: pregnant
     type: CODED
     valueSet:
       - Pregnant
@@ -483,69 +502,69 @@ elements:
     hhsGuidanceField: Pregnant
     hl7Field: OBX-5
 
-  - name: Public_health_case_ID
+  - name: public_health_case_ID
     type: ID
     natFlatFileField: Public_health_case_ID
     hhsGuidanceField:
     hl7Field: REPEAT_OBX_ST
 
-  - name: Reference_range
+  - name: reference_range
     type: TEXT
     natFlatFileField: Reference_range
     hhsGuidanceField:
     hl7Field: OBX-7
 
-  - name: Reporting_facility_ID
+  - name: reporting_facility_ID
     type: ID
     natFlatFileField: Reporting_facility_ID
     hhsGuidanceField:
     hl7Field: MSH-4.2
 
-  - name: Reporting_facility_name
+  - name: reporting_facility_name
     type: TEXT
     natFlatFileField: Reporting_facility_name
     hhsGuidanceField:
     hl7Field: MSH-4.1
 
-  - name: Resident_congregate_setting
+  - name: resident_congregate_setting
     type: TEXT
     natFlatFileField: Resident_congregate_setting
     hhsGuidanceField: Resident in congregate care/living setting
     hl7Field: REPEAT_OBX_MAP
 
-  - name: Result_format
+  - name: result_format
     type: TEXT
     natFlatFileField: Result_format
     hhsGuidanceField:
     hl7Field: OBX-2
 
-  - name: Sending_application
+  - name: sending_application
     type: TEXT
     natFlatFileField:
     hl7Field: MSH-3
 
-  - name: Sending_application_id
+  - name: sending_application_id
     type: HD
     natFlatFileField:
     hl7Field: MSH-3.1
 
-  - name: Specimen_collection_site # collection location
+  - name: specimen_collection_site # collection location
     type: TEXT # CWE without a defined table
     hl7Field: SPM-10
 
-  - name: Specimen_collection_date_time
+  - name: specimen_collection_date_time
     type: DATETIME
     natFlatFileField: Specimen_collection_date_time
     hhsGuidanceField: Test result date
     hl7Field: OBR-7/SPM-17.1
 
-  - name: Specimen_received_date_time
+  - name: specimen_received_date_time
     type: DATETIME
     natFlatFileField: Specimen_received_date_time
     hhsGuidanceField:
     hl7Field: SPM-18
 
-  - name: Specimen_role
+  - name: specimen_role
     type: CODED_HL7
     valueSet:
       - B # Blind sample
@@ -562,26 +581,26 @@ elements:
     hhsGuidanceField:
     hl7Field: SPM-11
 
-  - name: Specimen_source_site_code
+  - name: specimen_source_site_code
     type: CODED_SNOMED
     natFlatFileField: Specimen_source_site_code
     hhsGuidanceField: Specimen source
     hl7Field: SPM-8.1
 
-  - name: Specimen_source_site_code_sys
+  - name: specimen_source_site_code_sys
     type: CODED
     valueSet: [SCT,L]
     natFlatFileField: Specimen_source_site_code_sys
     hhsGuidanceField:
     hl7Field: SPM-8.3
 
-  - name: Specimen_source_site_description
+  - name: specimen_source_site_description
     type: TEXT
     natFlatFileField: Specimen_source_site_descrip
     hhsGuidanceField:
     hl7Field: SPM-8.2
 
-  - name: Specimen_type_code
+  - name: specimen_type_code
     type: CODED_SNOMED
     valueSet:
       - 258500001 # Nasopharyngeal swab
@@ -602,38 +621,38 @@ elements:
     hhsGuidanceField: Specimen source
     hl7Field: SPM-4.1
 
-  - name: Specimen_type_code_system
+  - name: specimen_type_code_system
     type: CODED
     valueSet: [SCT]
     natFlatFileField: Specimen_type_code_system
     hhsGuidanceField:
     hl7Field: SPM-4.3
 
-  - name: Specimen_type_description
+  - name: specimen_type_description
     type: TEXT
     natFlatFileField: Specimen_type_description
     hhsGuidanceField:
     hl7Field: SPM-4.2
 
-  - name: Specimen_type_free_text
+  - name: specimen_type_text
     type: TEXT
-    natFlatFileField: Specimen_type_free_text
+    natFlatFileField: Specimen_type_text
     hhsGuidanceField:
     hl7Field: SPM-4.9
 
-  - name: Submitter_sample_ID_assigner
+  - name: submitter_sample_ID_assigner
     type: TEXT
     natFlatFileField: Submitter_sample_ID_assigner
     hhsGuidanceField:
     hl7Field: SPM-2.1.2
 
-  - name: Submitter_unique_sample_ID
+  - name: submitter_unique_sample_ID
     type: ID
     natFlatFileField: Submitter_unique_sample_ID
     hhsGuidanceField:
     hl7Field: SPM-2.1.1
 
-  - name: Symptomatic_for_disease
+  - name: symptomatic_for_disease
     type: CODED_HL7
     valueSet:
       - YES
@@ -643,68 +662,68 @@ elements:
     hhsGuidanceField: Symptomatic per CDC
     hl7Field: OBX-5
 
-  - name: Test_kit_EUA_ID
+  - name: test_kit_EUA_ID
     type: ID
     natFlatFileField: Test_kit_EUA_ID
     hhsGuidanceField:
     hl7Field: OBX-17.1
 
-  - name: Test_kit_instance_ID
+  - name: test_kit_instance_ID
     type: ID
     natFlatFileField: Test_kit_instance_ID
     hhsGuidanceField:
     hl7Field: OBX-18
 
-  - name: Test_kit_model_ID
+  - name: test_kit_model_ID
     type: ID
     natFlatFileField: Test_kit_model_ID
     hhsGuidanceField:
     hl7Field: OBX-17.1
 
-  - name: Test_kit_model_name
+  - name: test_kit_model_name
     type: TEXT
     natFlatFileField: Test_kit_model_name
     hhsGuidanceField:
     hl7Field: OBX-17.1
 
-  - name: Test_method_description
+  - name: test_method_description
     type: TEXT
     natFlatFileField: Test_method_description
     hhsGuidanceField:
     hl7Field: OBX-17.9
 
-  - name: Test_performed_code
+  - name: test_performed_code
     type: CODED
     natFlatFileField: Test_performed_code
     hhsGuidanceField:
     hl7Field: OBX-3.1
 
-  - name: Test_performed_code_system
+  - name: test_performed_code_system
     type: TEXT
     natFlatFileField: Test_performed_code_system
     hhsGuidanceField:
     hl7Field: OBX-3.3
 
-  - name: Test_performed_description
+  - name: test_performed_description
     type: TEXT
     natFlatFileField: Test_performed_description
     hhsGuidanceField:
     hl7Field: OBX-3.2
 
-  - name: Test_performed_number
+  - name: test_performed_number
     type: NUMBER
     natFlatFileField: Test_performed_number
     hhsGuidanceField:
     hl7Field: OBX-1
 
-  - name: Test_result_code_system
+  - name: test_result_code_system
     type: CODED_HL7
     valueSet: ["L", "SCT"]
     natFlatFileField: Test_result_code_system
     hhsGuidanceField:
     hl7Field: OBX-5.3
 
-  - name: Test_result_coded
+  - name: test_result_coded
     type: CODED_SNOMED
     valueSet:
       - 260373001 #Detected
@@ -713,142 +732,142 @@ elements:
       - 462371000124108 #Detected in pooled specimen
       - 419984006 #Inconclusive
     natFlatFileField: Test_result_coded
-    hhsGuidanceField: 'Test result '
+    hhsGuidanceField: Test result
     hl7Field: OBX-5.1
 
-  - name: Test_result_comparator
+  - name: test_result_comparator
     type: TEXT
     natFlatFileField: Test_result_comparator
     hhsGuidanceField:
     hl7Field: OBX-5.1
 
-  - name: Test_result_date
+  - name: test_result_date
     type: DATETIME
     natFlatFileField: Test_date
     hhsGuidanceField: Test result date
     hl7Field: OBX-19
 
-  - name: Test_result_report_date
+  - name: test_result_report_date
     type: DATETIME
     natFlatFileField:
     hhsGuidanceField: Test report date
     hl7Field: OBX-22
 
-  - name: Test_result_description
+  - name: test_result_description
     type: TEXT
     natFlatFileField: Test_result_description
     hhsGuidanceField:
     hl7Field: OBX-5.2
 
-  - name: Test_result_free_text
+  - name: test_result_text
     type: TEXT
-    natFlatFileField: Test_Result_free_text
+    natFlatFileField: Test_Result_text
     hhsGuidanceField:
     hl7Field: OBX-5.1
 
-  - name: Test_result_number
+  - name: test_result_number
     type: TEXT
     natFlatFileField: Test_result_number
     hhsGuidanceField:
     hl7Field: OBX-5.1
 
-  - name: Test_result_number_separator
+  - name: test_result_number_separator
     type: TEXT
     natFlatFileField: Test_result_number_separator
     hhsGuidanceField:
     hl7Field: OBX-5.3
 
-  - name: Test_result_number2
+  - name: test_result_number2
     type: TEXT
     natFlatFileField: Test_result_number2
     hhsGuidanceField:
     hl7Field: OBX-5.4
 
-  - name: Test_result_status
+  - name: test_result_status
     type: TEXT
     natFlatFileField: Test_result_status
     hhsGuidanceField:
     hl7Field: OBX-11
 
-  - name: Test_result_sub_ID
+  - name: test_result_sub_ID
     type: ID
     natFlatFileField: Test_result_sub_ID
     hhsGuidanceField:
     hl7Field: OBX-4
 
-  - name: Test_result_units
+  - name: test_result_units
     type: TEXT
     natFlatFileField: Test_result_units
     hhsGuidanceField:
     hl7Field: OBX-6
 
-  - name: Testing_lab_accession_number
+  - name: testing_lab_accession_number
     type: ID
     natFlatFileField: Testing_lab_accession_number
     hhsGuidanceField:
     hl7Field: ORC-3.1/OBR-3.1
 
-  - name: Testing_lab_city
+  - name: testing_lab_city
     type: CITY
     natFlatFileField: Testing_lab_city
     hhsGuidanceField:
     hl7Field: OBX-24.3
 
-  - name: Testing_lab_county
+  - name: testing_lab_county
     type: COUNTY
     natFlatFileField: Testing_lab_county
     hhsGuidanceField:
     hl7Field: OBX-24.9
 
-  - name: Testing_lab_ID
+  - name: testing_lab_ID
     type: ID
     natFlatFileField: Testing_lab_ID
     hhsGuidanceField:
     hl7Field: OBX-23.10/OBX-15.1
 
-  - name: Testing_lab_name
+  - name: testing_lab_name
     type: TEXT
     natFlatFileField: Testing_lab_name
     hhsGuidanceField:
     hl7Field: OBX-23.1/OBX-15.2
 
-  - name: Testing_lab_specimen_ID
+  - name: testing_lab_specimen_ID
     type: ID
     natFlatFileField: Testing_lab_specimen_ID
     hhsGuidanceField:
     hl7Field: SPM-2.2.1
 
-  - name: Testing_lab_state
+  - name: testing_lab_state
     type: STATE
     natFlatFileField: Testing_lab_state
     hhsGuidanceField:
     hl7Field: OBX-24.4
 
-  - name: Testing_lab_street
+  - name: testing_lab_street
     type: STREET
     natFlatFileField: Testing_lab_street
     hhsGuidanceField:
     hl7Field: OBX-24.1
 
-  - name: Testing_lab_street2
+  - name: testing_lab_street2
     type: STREET
     natFlatFileField: Testing_lab_street2
     hhsGuidanceField:
     hl7Field: OBX-24.2
 
-  - name: Testing_lab_zip_code
+  - name: testing_lab_zip_code
     type: POSTAL_CODE
     natFlatFileField: Testing_lab_zip_code
     hhsGuidanceField:
     hl7Field: OBX-24.5
 
-  - name: Testing_lab_phone_number
+  - name: testing_lab_phone_number
     type: TELEPHONE
     natFlatFileField:
     hhsGuidanceField:
     hl7Field:
 
-  - name: Travel_history
+  - name: travel_history
     type: TEXT
     natFlatFileField: Travel_history
     hhsGuidanceField:

--- a/prime-router/metadata/valuesets/common.valuesets
+++ b/prime-router/metadata/valuesets/common.valuesets
@@ -1,0 +1,113 @@
+# These ValueSets are not associated with specific topic.
+# ValueSets are used with CODED data elements and their display TEXT equivalents
+#
+# Name conventions
+#
+#  for SNOMED-CT use the standard element name
+#  for hl7 value sets use the HL7 name
+#  for LOINC value sets use TBD
+#  for LOCAL match the standard element
+#
+# sort alphabetically
+#
+---
+- name: hl7_0136
+  system: HL7
+  values:
+    - code: YES
+      alt_codes: [true]
+      display: Yes
+    - code: NO
+      alt_codes: [false]
+      display: No
+    - code: UNK
+      alt_codes: [Unknown]
+      display: Unknown
+
+- name: patient_age_units
+  reference: Per the HHS guidance
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  system: LOCAL
+  values:
+    - display: months
+      alt_codes: [mo]
+    - display: years
+      alt_codes: [yr, yrs]
+
+- name: patient_gender
+  system: LOCAL
+  reference: HHS guidance for sex at birth
+  referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Tables/0001
+  values:
+    - display: Male
+      alt_codes: [M]
+    - display: Female
+      alt_codes: [F]
+    - display: Other
+      alt_codes: [O]
+    - display: Ambiguous
+      alt_codes: [A]
+    - display: Unknown
+      alt_codes: [U, UNK]
+    - display: Not applicable
+      alt_codes: [N]
+
+- name: omb_ethnicity
+  system: FHIR
+  reference: OMB 2020 Census values per the HHS guidance
+  referenceUrl: https://hl7.org/fhir/us/core/2017Jan/ValueSet-omb-ethnicity.html
+  values:
+    - code: Hispanic or Latino
+      display: 2135-2
+    - code: Non Hispanic or Latino
+      display: 2186-5
+    - code: Unknown
+      display: UNK
+    - code: Asked, but unknown
+      display: ASKU
+
+- name: omb_race
+  system: FHIR
+  reference: OMB 2020 Census specified by the HHS guidance
+  referenceUrl: http://hl7.org/fhir/us/core/2017Jan/ValueSet-omb-race.html
+  values:
+    - display: American Indian or Alaska Native
+      code: 1002-5
+    - display: Asian
+      code: 2028-9
+    - display: Black or African American
+      code: 2054-5
+    - display: Native Hawaiian or Other Pacific Islander
+      code: 2076-8
+    - display: White
+      code: 2106-3
+    - display: Unknown
+      code: UNK
+    - display: Asked, but unknown
+      code: ASKU
+
+- name: specimen_role
+  system: FHIR
+  referenceUrl: https://terminology.hl7.org/ValueSet-v3-SpecimenRoleType.html
+  values:
+    - code: B
+      display: Blind sample
+    - code: E
+      display: Electronic QC
+    - code: F
+      display: Filer
+    - code: G
+      display: Group
+    - code: L
+      display: Pool
+    - code: O
+      display: Operator proficiency
+    - code: P
+      display: Patient
+    - code: Q
+      display: Control specimen
+    - code: R
+      display: Replicate
+    - code: V
+      display: Verifying collaborator
+

--- a/prime-router/metadata/valuesets/common.valuesets
+++ b/prime-router/metadata/valuesets/common.valuesets
@@ -1,5 +1,5 @@
 # These ValueSets are not associated with specific topic.
-# ValueSets are used with CODED data elements and their display TEXT equivalents
+# ValueSets are used with CODE data elements and their display equivalents
 #
 # Name conventions
 #

--- a/prime-router/metadata/valuesets/covid-19.valuesets
+++ b/prime-router/metadata/valuesets/covid-19.valuesets
@@ -1,0 +1,84 @@
+# These ValueSets are associated with covid-19 topic
+# ValueSets are used with CODED data elements and their display TEXT equivalents
+#
+# Name conventions
+#
+#  for SNOMED-CT use the standard element name
+#  for hl7 value sets use the HL7 name
+#  for LOINC value sets use TBD
+#  for LOCAL match the standard element
+#
+# sort alphabetically
+#
+---
+- name: covid-19/specimen_type
+  system: SNOMED_CT
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  values:
+    - code: 258500001
+      display: Nasopharyngeal swab
+    - code: 871810001
+      display: Mid-turbinate nasal swab 
+    - code: 697989009
+      display: Anterior nares swab 
+    - code: 258411007
+      display: Nasopharyngeal aspirate 
+    - code: 429931000124105
+      display: Nasal aspirate 
+    - code: 258529004
+      display: Throat swab 
+    - code: 119334006
+      display: Sputum specimen 
+    - code: 119342007
+      display: Saliva specimen 
+    - code: 258607008
+      display: Bronchoalveolar lavage fluid sample 
+    - code: 119364003
+      display: Serum specimen 
+    - code: 119361006
+      display: Plasma specimen 
+    - code: 440500007
+      display: Dried blood spot specimen 
+    - code: 258580003
+      display: Whole blood sample 
+    - code: 122555007
+      display: Venous blood specimen
+
+- name: covid-19/test_result
+  system: SNOMED_CT
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  values:
+    - code: 260373001
+      display: Detected
+    - code: 260415000
+      display: Not detected
+    - code: 895231008
+      display: Not detected in pooled specimen
+    - code: 462371000124108
+      display: Detected in pooled specimen
+    - code: 419984006
+      display: Inconclusive
+
+- name: covid-19/order
+  system: LOINC
+  reference: Incomplete - Supports BD Veritor, Quidell Sofia, and Abbott ID Now
+  referenceUrl: https://www.cdc.gov/csels/dls/documents/livd_test_code_mapping/LIVD-SARS-CoV-2-2020-10-21.xlsx
+  values:
+    - code: 94563-4
+      display: SARS coronavirus 2 IgG Ab [Presence] in Serum or Plasma by Immunoassay
+    - code: 94500-6
+      display: SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection
+    - code: 94558-4
+      display: SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay
+    - code: 94534-5
+      display: SARS coronavirus 2 RdRp gene [Presence] in Respiratory specimen by NAA with probe detection
+    - code: 94564-2
+      display: SARS-CoV-2 (COVID-19) IgM Ab [Presence] in Serum or Plasma by Immunoassay
+    - code: 94531-1
+      display: SARS coronavirus 2 RNA panel - Respiratory specimen by NAA with probe detection
+    - code: 94559-2
+      display: SARS coronavirus 2 ORF1ab region [Presence] in Respiratory specimen by NAA with probe detection
+    - code: 95209-3
+      display: SARS coronavirus+SARS coronavirus 2 Ag [Presence] in Respiratory specimen by Rapid immunoassay
+
+

--- a/prime-router/metadata/valuesets/covid-19.valuesets
+++ b/prime-router/metadata/valuesets/covid-19.valuesets
@@ -1,5 +1,5 @@
 # These ValueSets are associated with covid-19 topic
-# ValueSets are used with CODED data elements and their display TEXT equivalents
+# ValueSets are used with CODE data elements and their display equivalents
 #
 # Name conventions
 #

--- a/prime-router/metadata/valuesets/tribal.valuesets
+++ b/prime-router/metadata/valuesets/tribal.valuesets
@@ -1,0 +1,1139 @@
+#
+# Many display lines are truncated as they are in the source material
+---
+- name: tribal_citizenship
+  system: FHIR
+  referenceUrl: https://terminology.hl7.org/1.0.0/CodeSystem-v3-TribalEntityUS.html
+  values:
+    - code: 338
+      display: Village of Afognak
+    - code: 339
+      display: Agdaagux Tribe of King Cove
+    - code: 340
+      display: Native Village of Akhiok
+    - code: 341
+      display: Akiachak Native Community
+    - code: 342
+      display: Akiak Native Community
+    - code: 343
+      display: Native Village of Akutan
+    - code: 344
+      display: Village of Alakanuk
+    - code: 345
+      display: Alatna Village
+    - code: 346
+      display: Native Village of Aleknagik
+    - code: 347
+      display: Algaaciq Native Village (St. Mary's)
+    - code: 348
+      display: Allakaket Village
+    - code: 349
+      display: Native Village of Ambler
+    - code: 350
+      display: Village of Anaktuvuk Pass
+    - code: 351
+      display: Yupiit of Andreafski
+    - code: 352
+      display: Angoon Community Association
+    - code: 353
+      display: Village of Aniak
+    - code: 354
+      display: Anvik Village
+    - code: 355
+      display: Arctic Village (See Native Village of Venetie Trib
+    - code: 356
+      display: Asa carsarmiut Tribe (formerly Native Village of M
+    - code: 357
+      display: Native Village of Atka
+    - code: 358
+      display: Village of Atmautluak
+    - code: 359
+      display: Atqasuk Village (Atkasook)
+    - code: 360
+      display: Native Village of Barrow Inupiat Traditional Gover
+    - code: 361
+      display: Beaver Village
+    - code: 362
+      display: Native Village of Belkofski
+    - code: 363
+      display: Village of Bill Moore's Slough
+    - code: 364
+      display: Birch Creek Tribe
+    - code: 365
+      display: Native Village of Brevig Mission
+    - code: 366
+      display: Native Village of Buckland
+    - code: 367
+      display: Native Village of Cantwell
+    - code: 368
+      display: Native Village of Chanega (aka Chenega)
+    - code: 369
+      display: Chalkyitsik Village
+    - code: 370
+      display: Village of Chefornak
+    - code: 371
+      display: Chevak Native Village
+    - code: 372
+      display: Chickaloon Native Village
+    - code: 373
+      display: Native Village of Chignik
+    - code: 374
+      display: Native Village of Chignik Lagoon
+    - code: 375
+      display: Chignik Lake Village
+    - code: 376
+      display: Chilkat Indian Village (Klukwan)
+    - code: 377
+      display: Chilkoot Indian Association (Haines)
+    - code: 378
+      display: Chinik Eskimo Community (Golovin)
+    - code: 379
+      display: Native Village of Chistochina
+    - code: 380
+      display: Native Village of Chitina
+    - code: 381
+      display: Native Village of Chuathbaluk (Russian Mission, Ku
+    - code: 382
+      display: Chuloonawick Native Village
+    - code: 383
+      display: Circle Native Community
+    - code: 384
+      display: Village of Clark's Point
+    - code: 385
+      display: Native Village of Council
+    - code: 386
+      display: Craig Community Association
+    - code: 387
+      display: Village of Crooked Creek
+    - code: 388
+      display: Curyung Tribal Council (formerly Native Village of
+    - code: 389
+      display: Native Village of Deering
+    - code: 390
+      display: Native Village of Diomede (aka Inalik)
+    - code: 391
+      display: Village of Dot Lake
+    - code: 392
+      display: Douglas Indian Association
+    - code: 393
+      display: Native Village of Eagle
+    - code: 394
+      display: Native Village of Eek
+    - code: 395
+      display: Egegik Village
+    - code: 396
+      display: Eklutna Native Village
+    - code: 397
+      display: Native Village of Ekuk
+    - code: 398
+      display: Ekwok Village
+    - code: 399
+      display: Native Village of Elim
+    - code: 400
+      display: Emmonak Village
+    - code: 401
+      display: Evansville Village (aka Bettles Field)
+    - code: 402
+      display: Native Village of Eyak (Cordova)
+    - code: 403
+      display: Native Village of False Pass
+    - code: 404
+      display: Native Village of Fort Yukon
+    - code: 405
+      display: Native Village of Gakona
+    - code: 406
+      display: Galena Village (aka Louden Village)
+    - code: 407
+      display: Native Village of Gambell
+    - code: 408
+      display: Native Village of Georgetown
+    - code: 409
+      display: Native Village of Goodnews Bay
+    - code: 410
+      display: Organized Village of Grayling (aka Holikachuk)
+    - code: 411
+      display: Gulkana Village
+    - code: 412
+      display: Native Village of Hamilton
+    - code: 413
+      display: Healy Lake Village
+    - code: 414
+      display: Holy Cross Village
+    - code: 415
+      display: Hoonah Indian Association
+    - code: 416
+      display: Native Village of Hooper Bay
+    - code: 417
+      display: Hughes Village
+    - code: 418
+      display: Huslia Village
+    - code: 419
+      display: Hydaburg Cooperative Association
+    - code: 420
+      display: Igiugig Village
+    - code: 421
+      display: Village of Iliamna
+    - code: 422
+      display: Inupiat Community of the Arctic Slope
+    - code: 423
+      display: Iqurmuit Traditional Council (formerly Native Vill
+    - code: 424
+      display: Ivanoff Bay Village
+    - code: 425
+      display: Kaguyak Village
+    - code: 426
+      display: Organized Village of Kake
+    - code: 427
+      display: Kaktovik Village (aka Barter Island)
+    - code: 428
+      display: Village of Kalskag
+    - code: 429
+      display: Village of Kaltag
+    - code: 430
+      display: Native Village of Kanatak
+    - code: 431
+      display: Native Village of Karluk
+    - code: 432
+      display: Organized Village of Kasaan
+    - code: 433
+      display: Native Village of Kasigluk
+    - code: 434
+      display: Kenaitze Indian Tribe
+    - code: 435
+      display: Ketchikan Indian Corporation
+    - code: 436
+      display: Native Village of Kiana
+    - code: 437
+      display: King Island Native Community
+    - code: 438
+      display: King Salmon Tribe
+    - code: 439
+      display: Native Village of Kipnuk
+    - code: 440
+      display: Native Village of Kivalina
+    - code: 441
+      display: Klawock Cooperative Association
+    - code: 442
+      display: Native Village of Kluti Kaah (aka Copper Center)
+    - code: 443
+      display: Knik Tribe
+    - code: 444
+      display: Native Village of Kobuk
+    - code: 445
+      display: Kokhanok Village
+    - code: 446
+      display: Native Village of Kongiganak
+    - code: 447
+      display: Village of Kotlik
+    - code: 448
+      display: Native Village of Kotzebue
+    - code: 449
+      display: Native Village of Koyuk
+    - code: 450
+      display: Koyukuk Native Village
+    - code: 451
+      display: Organized Village of Kwethluk
+    - code: 452
+      display: Native Village of Kwigillingok
+    - code: 453
+      display: Native Village of Kwinhagak (aka Quinhagak)
+    - code: 454
+      display: Native Village of Larsen Bay
+    - code: 455
+      display: Levelock Village
+    - code: 456
+      display: Lesnoi Village (aka Woody Island)
+    - code: 457
+      display: Lime Village
+    - code: 458
+      display: Village of Lower Kalskag
+    - code: 459
+      display: Manley Hot Springs Village
+    - code: 460
+      display: Manokotak Village
+    - code: 461
+      display: Native Village of Marshall (aka Fortuna Ledge)
+    - code: 462
+      display: Native Village of Mary's Igloo
+    - code: 463
+      display: McGrath Native Village
+    - code: 464
+      display: Native Village of Mekoryuk
+    - code: 465
+      display: Mentasta Traditional Council
+    - code: 466
+      display: Metlakatla Indian Community, Annette Island Reserv
+    - code: 467
+      display: Native Village of Minto
+    - code: 468
+      display: Naknek Native Village
+    - code: 469
+      display: Native Village of Nanwalek (aka English Bay)
+    - code: 470
+      display: Native Village of Napaimute
+    - code: 471
+      display: Native Village of Napakiak
+    - code: 472
+      display: Native Village of Napaskiak
+    - code: 473
+      display: Native Village of Nelson Lagoon
+    - code: 474
+      display: Nenana Native Association
+    - code: 475
+      display: New Koliganek Village Council (formerly Koliganek
+    - code: 476
+      display: New Stuyahok Village
+    - code: 477
+      display: Newhalen Village
+    - code: 478
+      display: Newtok Village
+    - code: 479
+      display: Native Village of Nightmute
+    - code: 480
+      display: Nikolai Village
+    - code: 481
+      display: Native Village of Nikolski
+    - code: 482
+      display: Ninilchik Village
+    - code: 483
+      display: Native Village of Noatak
+    - code: 484
+      display: Nome Eskimo Community
+    - code: 485
+      display: Nondalton Village
+    - code: 486
+      display: Noorvik Native Community
+    - code: 487
+      display: Northway Village
+    - code: 488
+      display: Native Village of Nuiqsut (aka Nooiksut)
+    - code: 489
+      display: Nulato Village
+    - code: 490
+      display: Nunakauyarmiut Tribe (formerly Native Village of T
+    - code: 491
+      display: Native Village of Nunapitchuk
+    - code: 492
+      display: Village of Ohogamiut
+    - code: 493
+      display: Village of Old Harbor
+    - code: 494
+      display: Orutsararmuit Native Village (aka Bethel)
+    - code: 495
+      display: Oscarville Traditional Village
+    - code: 496
+      display: Native Village of Ouzinkie
+    - code: 497
+      display: Native Village of Paimiut
+    - code: 498
+      display: Pauloff Harbor Village
+    - code: 499
+      display: Pedro Bay Village
+    - code: 500
+      display: Native Village of Perryville
+    - code: 501
+      display: Petersburg Indian Association
+    - code: 502
+      display: Native Village of Pilot Point
+    - code: 503
+      display: Pilot Station Traditional Village
+    - code: 504
+      display: Native Village of Pitka's Point
+    - code: 505
+      display: Platinum Traditional Village
+    - code: 506
+      display: Native Village of Point Hope
+    - code: 507
+      display: Native Village of Point Lay
+    - code: 508
+      display: Native Village of Port Graham
+    - code: 509
+      display: Native Village of Port Heiden
+    - code: 510
+      display: Native Village of Port Lions
+    - code: 511
+      display: Portage Creek Village (aka Ohgsenakale)
+    - code: 512
+      display: Pribilof Islands Aleut Communities of St. Paul & S
+    - code: 513
+      display: Qagan Tayagungin Tribe of Sand Point Village
+    - code: 514
+      display: Qawalangin Tribe of Unalaska
+    - code: 515
+      display: Rampart Village
+    - code: 516
+      display: Village of Red Devil
+    - code: 517
+      display: Native Village of Ruby
+    - code: 518
+      display: Saint George Island(See Pribilof Islands Aleut Com
+    - code: 519
+      display: Native Village of Saint Michael
+    - code: 520
+      display: Saint Paul Island (See Pribilof Islands Aleut Comm
+    - code: 521
+      display: Village of Salamatoff
+    - code: 522
+      display: Native Village of Savoonga
+    - code: 523
+      display: Organized Village of Saxman
+    - code: 524
+      display: Native Village of Scammon Bay
+    - code: 525
+      display: Native Village of Selawik
+    - code: 526
+      display: Seldovia Village Tribe
+    - code: 527
+      display: Shageluk Native Village
+    - code: 528
+      display: Native Village of Shaktoolik
+    - code: 529
+      display: Native Village of Sheldon's Point
+    - code: 530
+      display: Native Village of Shishmaref
+    - code: 531
+      display: Shoonaq Tribe of Kodiak
+    - code: 532
+      display: Native Village of Shungnak
+    - code: 533
+      display: Sitka Tribe of Alaska
+    - code: 534
+      display: Skagway Village
+    - code: 535
+      display: Village of Sleetmute
+    - code: 536
+      display: Village of Solomon
+    - code: 537
+      display: South Naknek Village
+    - code: 538
+      display: Stebbins Community Association
+    - code: 539
+      display: Native Village of Stevens
+    - code: 540
+      display: Village of Stony River
+    - code: 541
+      display: Takotna Village
+    - code: 542
+      display: Native Village of Tanacross
+    - code: 543
+      display: Native Village of Tanana
+    - code: 544
+      display: Native Village of Tatitlek
+    - code: 545
+      display: Native Village of Tazlina
+    - code: 546
+      display: Telida Village
+    - code: 547
+      display: Native Village of Teller
+    - code: 548
+      display: Native Village of Tetlin
+    - code: 549
+      display: Central Council of the Tlingit and Haida Indian Tb
+    - code: 550
+      display: Traditional Village of Togiak
+    - code: 551
+      display: Tuluksak Native Community
+    - code: 552
+      display: Native Village of Tuntutuliak
+    - code: 553
+      display: Native Village of Tununak
+    - code: 554
+      display: Twin Hills Village
+    - code: 555
+      display: Native Village of Tyonek
+    - code: 556
+      display: Ugashik Village
+    - code: 557
+      display: Umkumiute Native Village
+    - code: 558
+      display: Native Village of Unalakleet
+    - code: 559
+      display: Native Village of Unga
+    - code: 560
+      display: Village of Venetie (See Native Village of Venetie
+    - code: 561
+      display: Native Village of Venetie Tribal Government (Arcti
+    - code: 562
+      display: Village of Wainwright
+    - code: 563
+      display: Native Village of Wales
+    - code: 564
+      display: Native Village of White Mountain
+    - code: 565
+      display: Wrangell Cooperative Association
+    - code: 566
+      display: Yakutat Tlingit Tribe
+    - code: 1
+      display: Absentee-Shawnee Tribe of Indians of Oklahoma
+    - code: 10
+      display: Assiniboine and Sioux Tribes of the Fort Peck Indi
+    - code: 100
+      display: Havasupai Tribe of the Havasupai Reservation, Ariz
+    - code: 101
+      display: Ho-Chunk Nation of Wisconsin (formerly known as th
+    - code: 102
+      display: Hoh Indian Tribe of the Hoh Indian Reservation, Wa
+    - code: 103
+      display: Hoopa Valley Tribe, California
+    - code: 104
+      display: Hopi Tribe of Arizona
+    - code: 105
+      display: Hopland Band of Pomo Indians of the Hopland Ranche
+    - code: 106
+      display: Houlton Band of Maliseet Indians of Maine
+    - code: 107
+      display: Hualapai Indian Tribe of the Hualapai Indian Reser
+    - code: 108
+      display: Huron Potawatomi, Inc., Michigan
+    - code: 109
+      display: Inaja Band of Diegueno Mission Indians of the Inaj
+    - code: 11
+      display: Augustine Band of Cahuilla Mission Indians of the
+    - code: 110
+      display: Ione Band of Miwok Indians of California
+    - code: 111
+      display: Iowa Tribe of Kansas and Nebraska
+    - code: 112
+      display: Iowa Tribe of Oklahoma
+    - code: 113
+      display: Jackson Rancheria of Me-Wuk Indians of California
+    - code: 114
+      display: Jamestown S'Klallam Tribe of Washington
+    - code: 115
+      display: Jamul Indian Village of California
+    - code: 116
+      display: Jena Band of Choctaw Indians, Louisiana
+    - code: 117
+      display: Jicarilla Apache Tribe of the Jicarilla Apache Ind
+    - code: 118
+      display: Kaibab Band of Paiute Indians of the Kaibab Indian
+    - code: 119
+      display: Kalispel Indian Community of the Kalispel Reservat
+    - code: 12
+      display: Bad River Band of the Lake Superior Tribe of Chipp
+    - code: 120
+      display: Karuk Tribe of California
+    - code: 121
+      display: Kashia Band of Pomo Indians of the Stewarts Point
+    - code: 122
+      display: Kaw Nation, Oklahoma
+    - code: 123
+      display: Keweenaw Bay Indian Community of L'Anse and Ontona
+    - code: 124
+      display: Kialegee Tribal Town, Oklahoma
+    - code: 125
+      display: Kickapoo Tribe of Indians of the Kickapoo Reservat
+    - code: 126
+      display: Kickapoo Tribe of Oklahoma
+    - code: 127
+      display: Kickapoo Traditional Tribe of Texas
+    - code: 128
+      display: Kiowa Indian Tribe of Oklahoma
+    - code: 129
+      display: Klamath Indian Tribe of Oregon
+    - code: 13
+      display: Bay Mills Indian Community of the Sault Ste. Marie
+    - code: 130
+      display: Kootenai Tribe of Idaho
+    - code: 131
+      display: La Jolla Band of Luiseno Mission Indians of the La
+    - code: 132
+      display: La Posta Band of Diegueno Mission Indians of the L
+    - code: 133
+      display: Lac Courte Oreilles Band of Lake Superior Chippewa
+    - code: 134
+      display: Lac du Flambeau Band of Lake Superior Chippewa Ind
+    - code: 135
+      display: Lac Vieux Desert Band of Lake Superior Chippewa In
+    - code: 136
+      display: Las Vegas Tribe of Paiute Indians of the Las Vegas
+    - code: 137
+      display: Little River Band of Ottawa Indians of Michigan
+    - code: 138
+      display: Little Traverse Bay Bands of Odawa Indians of Mich
+    - code: 139
+      display: Lower Lake Rancheria, California
+    - code: 14
+      display: Bear River Band of the Rohnerville Rancheria, Cali
+    - code: 140
+      display: Los Coyotes Band of Cahuilla Mission Indians of th
+    - code: 141
+      display: Lovelock Paiute Tribe of the Lovelock Indian Colon
+    - code: 142
+      display: Lower Brule Sioux Tribe of the Lower Brule Reserva
+    - code: 143
+      display: Lower Elwha Tribal Community of the Lower Elwha Re
+    - code: 144
+      display: Lower Sioux Indian Community of Minnesota Mdewakan
+    - code: 145
+      display: Lummi Tribe of the Lummi Reservation, Washington
+    - code: 146
+      display: Lytton Rancheria of California
+    - code: 147
+      display: Makah Indian Tribe of the Makah Indian Reservation
+    - code: 148
+      display: Manchester Band of Pomo Indians of the Manchester-
+    - code: 149
+      display: Manzanita Band of Diegueno Mission Indians of the
+    - code: 15
+      display: Berry Creek Rancheria of Maidu Indians of Californ
+    - code: 150
+      display: Mashantucket Pequot Tribe of Connecticut
+    - code: 151
+      display: Match-e-be-nash-she-wish Band of Pottawatomi India
+    - code: 152
+      display: Mechoopda Indian Tribe of Chico Rancheria, Califor
+    - code: 153
+      display: Menominee Indian Tribe of Wisconsin
+    - code: 154
+      display: Mesa Grande Band of Diegueno Mission Indians of th
+    - code: 155
+      display: Mescalero Apache Tribe of the Mescalero Reservatio
+    - code: 156
+      display: Miami Tribe of Oklahoma
+    - code: 157
+      display: Miccosukee Tribe of Indians of Florida
+    - code: 158
+      display: Middletown Rancheria of Pomo Indians of California
+    - code: 159
+      display: Minnesota Chippewa Tribe, Minnesota (Six component
+    - code: 16
+      display: Big Lagoon Rancheria, California
+    - code: 160
+      display: Bois Forte Band (Nett Lake); Fond du Lac Band; Gra
+    - code: 161
+      display: Mississippi Band of Choctaw Indians, Mississippi
+    - code: 162
+      display: Moapa Band of Paiute Indians of the Moapa River In
+    - code: 163
+      display: Modoc Tribe of Oklahoma
+    - code: 164
+      display: Mohegan Indian Tribe of Connecticut
+    - code: 165
+      display: Mooretown Rancheria of Maidu Indians of California
+    - code: 166
+      display: Morongo Band of Cahuilla Mission Indians of the Mo
+    - code: 167
+      display: Muckleshoot Indian Tribe of the Muckleshoot Reserv
+    - code: 168
+      display: Muscogee (Creek) Nation, Oklahoma
+    - code: 169
+      display: Narragansett Indian Tribe of Rhode Island
+    - code: 17
+      display: Big Pine Band of Owens Valley Paiute Shoshone Indi
+    - code: 170
+      display: Navajo Nation, Arizona, New Mexico & Utah
+    - code: 171
+      display: Nez Perce Tribe of Idaho
+    - code: 172
+      display: Nisqually Indian Tribe of the Nisqually Reservatio
+    - code: 173
+      display: Nooksack Indian Tribe of Washington
+    - code: 174
+      display: Northern Cheyenne Tribe of the Northern Cheyenne I
+    - code: 175
+      display: Northfork Rancheria of Mono Indians of California
+    - code: 176
+      display: Northwestern Band of Shoshoni Nation of Utah (Wash
+    - code: 177
+      display: Oglala Sioux Tribe of the Pine Ridge Reservation,
+    - code: 178
+      display: Omaha Tribe of Nebraska
+    - code: 179
+      display: Oneida Nation of New York
+    - code: 18
+      display: Big Sandy Rancheria of Mono Indians of California
+    - code: 180
+      display: Oneida Tribe of Wisconsin
+    - code: 181
+      display: Onondaga Nation of New York
+    - code: 182
+      display: Osage Tribe, Oklahoma
+    - code: 183
+      display: Ottawa Tribe of Oklahoma
+    - code: 184
+      display: Otoe-Missouria Tribe of Indians, Oklahoma
+    - code: 185
+      display: Paiute Indian Tribe of Utah
+    - code: 186
+      display: Paiute-Shoshone Indians of the Bishop Community of
+    - code: 187
+      display: Paiute-Shoshone Tribe of the Fallon Reservation an
+    - code: 188
+      display: Paiute-Shoshone Indians of the Lone Pine Community
+    - code: 189
+      display: Pala Band of Luiseno Mission Indians of the Pala R
+    - code: 19
+      display: Big Valley Band of Pomo Indians of the Big Valley
+    - code: 190
+      display: Pascua Yaqui Tribe of Arizona
+    - code: 191
+      display: Paskenta Band of Nomlaki Indians of California
+    - code: 192
+      display: Passamaquoddy Tribe of Maine
+    - code: 193
+      display: Pauma Band of Luiseno Mission Indians of the Pauma
+    - code: 194
+      display: Pawnee Nation of Oklahoma
+    - code: 195
+      display: Pechanga Band of Luiseno Mission Indians of the Pe
+    - code: 196
+      display: Penobscot Tribe of Maine
+    - code: 197
+      display: Peoria Tribe of Indians of Oklahoma
+    - code: 198
+      display: Picayune Rancheria of Chukchansi Indians of Califo
+    - code: 199
+      display: Pinoleville Rancheria of Pomo Indians of Californi
+    - code: 2
+      display: Agua Caliente Band of Cahuilla Indians of the Agua
+    - code: 20
+      display: Blackfeet Tribe of the Blackfeet Indian Reservatio
+    - code: 200
+      display: Pit River Tribe, California (includes Big Bend, Lo
+    - code: 201
+      display: Poarch Band of Creek Indians of Alabama
+    - code: 202
+      display: Pokagon Band of Potawatomi Indians of Michigan
+    - code: 203
+      display: Ponca Tribe of Indians of Oklahoma
+    - code: 204
+      display: Ponca Tribe of Nebraska
+    - code: 205
+      display: Port Gamble Indian Community of the Port Gamble Re
+    - code: 206
+      display: Potter Valley Rancheria of Pomo Indians of Califor
+    - code: 207
+      display: Prairie Band of Potawatomi Indians, Kansas
+    - code: 208
+      display: Prairie Island Indian Community of Minnesota Mdewa
+    - code: 209
+      display: Pueblo of Acoma, New Mexico
+    - code: 21
+      display: Blue Lake Rancheria, California
+    - code: 210
+      display: Pueblo of Cochiti, New Mexico
+    - code: 211
+      display: Pueblo of Jemez, New Mexico
+    - code: 212
+      display: Pueblo of Isleta, New Mexico
+    - code: 213
+      display: Pueblo of Laguna, New Mexico
+    - code: 214
+      display: Pueblo of Nambe, New Mexico
+    - code: 215
+      display: Pueblo of Picuris, New Mexico
+    - code: 216
+      display: Pueblo of Pojoaque, New Mexico
+    - code: 217
+      display: Pueblo of San Felipe, New Mexico
+    - code: 218
+      display: Pueblo of San Juan, New Mexico
+    - code: 219
+      display: Pueblo of San Ildefonso, New Mexico
+    - code: 22
+      display: Bridgeport Paiute Indian Colony of California
+    - code: 220
+      display: Pueblo of Sandia, New Mexico
+    - code: 221
+      display: Pueblo of Santa Ana, New Mexico
+    - code: 222
+      display: Pueblo of Santa Clara, New Mexico
+    - code: 223
+      display: Pueblo of Santo Domingo, New Mexico
+    - code: 224
+      display: Pueblo of Taos, New Mexico
+    - code: 225
+      display: Pueblo of Tesuque, New Mexico
+    - code: 226
+      display: Pueblo of Zia, New Mexico
+    - code: 227
+      display: Puyallup Tribe of the Puyallup Reservation, Washin
+    - code: 228
+      display: Pyramid Lake Paiute Tribe of the Pyramid Lake Rese
+    - code: 229
+      display: Quapaw Tribe of Indians, Oklahoma
+    - code: 23
+      display: Buena Vista Rancheria of Me-Wuk Indians of Califor
+    - code: 230
+      display: Quartz Valley Indian Community of the Quartz Valle
+    - code: 231
+      display: Quechan Tribe of the Fort Yuma Indian Reservation,
+    - code: 232
+      display: Quileute Tribe of the Quileute Reservation, Washin
+    - code: 233
+      display: Quinault Tribe of the Quinault Reservation, Washin
+    - code: 234
+      display: Ramona Band or Village of Cahuilla Mission Indians
+    - code: 235
+      display: Red Cliff Band of Lake Superior Chippewa Indians o
+    - code: 236
+      display: Red Lake Band of Chippewa Indians of the Red Lake
+    - code: 237
+      display: Redding Rancheria, California
+    - code: 238
+      display: Redwood Valley Rancheria of Pomo Indians of Califo
+    - code: 239
+      display: Reno-Sparks Indian Colony, Nevada
+    - code: 24
+      display: Burns Paiute Tribe of the Burns Paiute Indian Colo
+    - code: 240
+      display: Resighini Rancheria, California (formerly known as
+    - code: 241
+      display: Rincon Band of Luiseno Mission Indians of the Rinc
+    - code: 242
+      display: Robinson Rancheria of Pomo Indians of California
+    - code: 243
+      display: Rosebud Sioux Tribe of the Rosebud Indian Reservat
+    - code: 244
+      display: Round Valley Indian Tribes of the Round Valley Res
+    - code: 245
+      display: Rumsey Indian Rancheria of Wintun Indians of Calif
+    - code: 246
+      display: Sac and Fox Tribe of the Mississippi in Iowa
+    - code: 247
+      display: Sac and Fox Nation of Missouri in Kansas and Nebra
+    - code: 248
+      display: Sac and Fox Nation, Oklahoma
+    - code: 249
+      display: Saginaw Chippewa Indian Tribe of Michigan, Isabell
+    - code: 25
+      display: Cabazon Band of Cahuilla Mission Indians of the Ca
+    - code: 250
+      display: Salt River Pima-Maricopa Indian Community of the S
+    - code: 251
+      display: Samish Indian Tribe, Washington
+    - code: 252
+      display: San Carlos Apache Tribe of the San Carlos Reservat
+    - code: 253
+      display: San Juan Southern Paiute Tribe of Arizona
+    - code: 254
+      display: San Manual Band of Serrano Mission Indians of the
+    - code: 255
+      display: San Pasqual Band of Diegueno Mission Indians of Ca
+    - code: 256
+      display: Santa Rosa Indian Community of the Santa Rosa Ranc
+    - code: 257
+      display: Santa Rosa Band of Cahuilla Mission Indians of the
+    - code: 258
+      display: Santa Ynez Band of Chumash Mission Indians of the
+    - code: 259
+      display: Santa Ysabel Band of Diegueno Mission Indians of t
+    - code: 26
+      display: Cachil DeHe Band of Wintun Indians of the Colusa I
+    - code: 260
+      display: Santee Sioux Tribe of the Santee Reservation of Ne
+    - code: 261
+      display: Sauk-Suiattle Indian Tribe of Washington
+    - code: 262
+      display: Sault Ste. Marie Tribe of Chippewa Indians of Mich
+    - code: 263
+      display: Scotts Valley Band of Pomo Indians of California
+    - code: 264
+      display: Seminole Nation of Oklahoma
+    - code: 265
+      display: Seminole Tribe of Florida, Dania, Big Cypress, Bri
+    - code: 266
+      display: Seneca Nation of New York
+    - code: 267
+      display: Seneca-Cayuga Tribe of Oklahoma
+    - code: 268
+      display: Shakopee Mdewakanton Sioux Community of Minnesota
+    - code: 269
+      display: Shawnee Tribe, Oklahoma
+    - code: 27
+      display: Caddo Indian Tribe of Oklahoma
+    - code: 270
+      display: Sherwood Valley Rancheria of Pomo Indians of Calif
+    - code: 271
+      display: Shingle Springs Band of Miwok Indians, Shingle Spr
+    - code: 272
+      display: Shoalwater Bay Tribe of the Shoalwater Bay Indian
+    - code: 273
+      display: Shoshone Tribe of the Wind River Reservation, Wyom
+    - code: 274
+      display: Shoshone-Bannock Tribes of the Fort Hall Reservati
+    - code: 275
+      display: Shoshone-Paiute Tribes of the Duck Valley Reservat
+    - code: 276
+      display: Sisseton-Wahpeton Sioux Tribe of the Lake Traverse
+    - code: 277
+      display: Skokomish Indian Tribe of the Skokomish Reservatio
+    - code: 278
+      display: Skull Valley Band of Goshute Indians of Utah
+    - code: 279
+      display: Smith River Rancheria, California
+    - code: 28
+      display: Cahuilla Band of Mission Indians of the Cahuilla R
+    - code: 280
+      display: Snoqualmie Tribe, Washington
+    - code: 281
+      display: Soboba Band of Luiseno Indians, California (former
+    - code: 282
+      display: Sokaogon Chippewa Community of the Mole Lake Band
+    - code: 283
+      display: Southern Ute Indian Tribe of the Southern Ute Rese
+    - code: 284
+      display: Spirit Lake Tribe, North Dakota (formerly known as
+    - code: 285
+      display: Spokane Tribe of the Spokane Reservation, Washingt
+    - code: 286
+      display: Squaxin Island Tribe of the Squaxin Island Reserva
+    - code: 287
+      display: St. Croix Chippewa Indians of Wisconsin, St. Croix
+    - code: 288
+      display: St. Regis Band of Mohawk Indians of New York
+    - code: 289
+      display: Standing Rock Sioux Tribe of North & South Dakota
+    - code: 29
+      display: Cahto Indian Tribe of the Laytonville Rancheria, C
+    - code: 290
+      display: Stockbridge-Munsee Community of Mohican Indians of
+    - code: 291
+      display: Stillaguamish Tribe of Washington
+    - code: 292
+      display: Summit Lake Paiute Tribe of Nevada
+    - code: 293
+      display: Suquamish Indian Tribe of the Port Madison Reserva
+    - code: 294
+      display: Susanville Indian Rancheria, California
+    - code: 295
+      display: Swinomish Indians of the Swinomish Reservation, Wa
+    - code: 296
+      display: Sycuan Band of Diegueno Mission Indians of Califor
+    - code: 297
+      display: Table Bluff Reservation - Wiyot Tribe, California
+    - code: 298
+      display: Table Mountain Rancheria of California
+    - code: 299
+      display: Te-Moak Tribe of Western Shoshone Indians of Nevad
+    - code: 3
+      display: Ak Chin Indian Community of the Maricopa (Ak Chin)
+    - code: 30
+      display: California Valley Miwok Tribe, California (formerl
+    - code: 300
+      display: Thlopthlocco Tribal Town, Oklahoma
+    - code: 301
+      display: Three Affiliated Tribes of the Fort Berthold Reser
+    - code: 302
+      display: Tohono O'odham Nation of Arizona
+    - code: 303
+      display: Tonawanda Band of Seneca Indians of New York
+    - code: 304
+      display: Tonkawa Tribe of Indians of Oklahoma
+    - code: 305
+      display: Tonto Apache Tribe of Arizona
+    - code: 306
+      display: Torres-Martinez Band of Cahuilla Mission Indians o
+    - code: 307
+      display: Tule River Indian Tribe of the Tule River Reservat
+    - code: 308
+      display: Tulalip Tribes of the Tulalip Reservation, Washing
+    - code: 309
+      display: Tunica-Biloxi Indian Tribe of Louisiana
+    - code: 31
+      display: Campo Band of Diegueno Mission Indians of the Camp
+    - code: 310
+      display: Tuolumne Band of Me-Wuk Indians of the Tuolumne Ra
+    - code: 311
+      display: Turtle Mountain Band of Chippewa Indians of North
+    - code: 312
+      display: Tuscarora Nation of New York
+    - code: 313
+      display: Twenty-Nine Palms Band of Mission Indians of Calif
+    - code: 314
+      display: United Auburn Indian Community of the Auburn Ranch
+    - code: 315
+      display: United Keetoowah Band of Cherokee Indians of Oklah
+    - code: 316
+      display: Upper Lake Band of Pomo Indians of Upper Lake Ranc
+    - code: 317
+      display: Upper Sioux Indian Community of the Upper Sioux Re
+    - code: 318
+      display: Upper Skagit Indian Tribe of Washington
+    - code: 319
+      display: Ute Indian Tribe of the Uintah & Ouray Reservation
+    - code: 32
+      display: Capitan Grande Band of Diegueno Mission Indians of
+    - code: 320
+      display: Ute Mountain Tribe of the Ute Mountain Reservation
+    - code: 321
+      display: Utu Utu Gwaitu Paiute Tribe of the Benton Paiute R
+    - code: 322
+      display: Walker River Paiute Tribe of the Walker River Rese
+    - code: 323
+      display: Wampanoag Tribe of Gay Head (Aquinnah) of Massachu
+    - code: 324
+      display: Washoe Tribe of Nevada & California (Carson Colony
+    - code: 325
+      display: White Mountain Apache Tribe of the Fort Apache Res
+    - code: 326
+      display: Wichita and Affiliated Tribes (Wichita, Keechi, Wa
+    - code: 327
+      display: Winnebago Tribe of Nebraska
+    - code: 328
+      display: Winnemucca Indian Colony of Nevada
+    - code: 329
+      display: Wyandotte Tribe of Oklahoma
+    - code: 33
+      display: Barona Group of Capitan Grande Band of Mission Ind
+    - code: 330
+      display: Yankton Sioux Tribe of South Dakota
+    - code: 331
+      display: Yavapai-Apache Nation of the Camp Verde Indian Res
+    - code: 332
+      display: Yavapai-Prescott Tribe of the Yavapai Reservation,
+    - code: 333
+      display: Yerington Paiute Tribe of the Yerington Colony & C
+    - code: 334
+      display: Yomba Shoshone Tribe of the Yomba Reservation, Nev
+    - code: 335
+      display: Ysleta Del Sur Pueblo of Texas
+    - code: 336
+      display: Yurok Tribe of the Yurok Reservation, California
+    - code: 337
+      display: Zuni Tribe of the Zuni Reservation, New Mexico
+    - code: 34
+      display: Viejas (Baron Long) Group of Capitan Grande Band o
+    - code: 35
+      display: Catawba Indian Nation (aka Catawba Tribe of South
+    - code: 36
+      display: Cayuga Nation of New York
+    - code: 37
+      display: Cedarville Rancheria, California
+    - code: 38
+      display: Chemehuevi Indian Tribe of the Chemehuevi Reservat
+    - code: 39
+      display: Cher-Ae Heights Indian Community of the Trinidad R
+    - code: 4
+      display: Alabama-Coushatta Tribes of Texas
+    - code: 40
+      display: Cherokee Nation, Oklahoma
+    - code: 41
+      display: Cheyenne-Arapaho Tribes of Oklahoma
+    - code: 42
+      display: Cheyenne River Sioux Tribe of the Cheyenne River
+    - code: 43
+      display: Chickasaw Nation, Oklahoma
+    - code: 44
+      display: Chicken Ranch Rancheria of Me-Wuk Indians of Calif
+    - code: 45
+      display: Chippewa-Cree Indians of the Rocky Boy's Reservati
+    - code: 46
+      display: Chitimacha Tribe of Louisiana
+    - code: 47
+      display: Choctaw Nation of Oklahoma
+    - code: 48
+      display: Citizen Potawatomi Nation, Oklahoma
+    - code: 49
+      display: Cloverdale Rancheria of Pomo Indians of California
+    - code: 5
+      display: Alabama-Quassarte Tribal Town, Oklahoma
+    - code: 50
+      display: Cocopah Tribe of Arizona
+    - code: 51
+      display: Coeur D'Alene Tribe of the Coeur D'Alene Reservati
+    - code: 52
+      display: Cold Springs Rancheria of Mono Indians of Californ
+    - code: 53
+      display: Colorado River Indian Tribes of the Colorado River
+    - code: 54
+      display: Comanche Indian Tribe, Oklahoma
+    - code: 55
+      display: Confederated Salish & Kootenai Tribes of the Flath
+    - code: 56
+      display: Confederated Tribes of the Chehalis Reservation, W
+    - code: 57
+      display: Confederated Tribes of the Colville Reservation, W
+    - code: 58
+      display: Confederated Tribes of the Coos, Lower Umpqua and
+    - code: 59
+      display: Confederated Tribes of the Goshute Reservation, Ne
+    - code: 6
+      display: Alturas Indian Rancheria, California
+    - code: 60
+      display: Confederated Tribes of the Grand Ronde Community o
+    - code: 61
+      display: Confederated Tribes of the Siletz Reservation, Ore
+    - code: 62
+      display: Confederated Tribes of the Umatilla Reservation, O
+    - code: 63
+      display: Confederated Tribes of the Warm Springs Reservatio
+    - code: 64
+      display: Confederated Tribes and Bands of the Yakama Indian
+    - code: 65
+      display: Coquille Tribe of Oregon
+    - code: 66
+      display: Cortina Indian Rancheria of Wintun Indians of Cali
+    - code: 67
+      display: Coushatta Tribe of Louisiana
+    - code: 68
+      display: Cow Creek Band of Umpqua Indians of Oregon
+    - code: 69
+      display: Coyote Valley Band of Pomo Indians of California
+    - code: 7
+      display: Apache Tribe of Oklahoma
+    - code: 70
+      display: Crow Tribe of Montana
+    - code: 71
+      display: Crow Creek Sioux Tribe of the Crow Creek Reservati
+    - code: 72
+      display: Cuyapaipe Community of Diegueno Mission Indians of
+    - code: 73
+      display: Death Valley Timbi-Sha Shoshone Band of California
+    - code: 74
+      display: Delaware Nation, Oklahoma (formerly Delaware Tribe
+    - code: 75
+      display: Delaware Tribe of Indians, Oklahoma
+    - code: 76
+      display: Dry Creek Rancheria of Pomo Indians of California
+    - code: 77
+      display: Duckwater Shoshone Tribe of the Duckwater Reservat
+    - code: 78
+      display: Eastern Band of Cherokee Indians of North Carolina
+    - code: 79
+      display: Eastern Shawnee Tribe of Oklahoma
+    - code: 8
+      display: Arapahoe Tribe of the Wind River Reservation, Wyom
+    - code: 80
+      display: Elem Indian Colony of Pomo Indians of the Sulphur
+    - code: 81
+      display: Elk Valley Rancheria, California
+    - code: 82
+      display: Ely Shoshone Tribe of Nevada
+    - code: 83
+      display: Enterprise Rancheria of Maidu Indians of Californi
+    - code: 84
+      display: Flandreau Santee Sioux Tribe of South Dakota
+    - code: 85
+      display: Forest County Potawatomi Community of Wisconsin Po
+    - code: 86
+      display: Fort Belknap Indian Community of the Fort Belknap
+    - code: 87
+      display: Fort Bidwell Indian Community of the Fort Bidwell
+    - code: 88
+      display: Fort Independence Indian Community of Paiute India
+    - code: 89
+      display: Fort McDermitt Paiute and Shoshone Tribes of the F
+    - code: 9
+      display: Aroostook Band of Micmac Indians of Maine
+    - code: 90
+      display: Fort McDowell Yavapai Nation, Arizona (formerly th
+    - code: 91
+      display: Fort Mojave Indian Tribe of Arizona, California
+    - code: 92
+      display: Fort Sill Apache Tribe of Oklahoma
+    - code: 93
+      display: Gila River Indian Community of the Gila River Indi
+    - code: 94
+      display: Grand Traverse Band of Ottawa & Chippewa Indians o
+    - code: 95
+      display: Graton Rancheria, California
+    - code: 96
+      display: Greenville Rancheria of Maidu Indians of Californi
+    - code: 97
+      display: Grindstone Indian Rancheria of Wintun-Wailaki Indi
+    - code: 98
+      display: Guidiville Rancheria of California
+    - code: 99
+      display: Hannahville Indian Community of Wisconsin Potawato

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -14,7 +14,6 @@ data class Element(
     val type: Type? = null,
     val format: String? = null,
     val valueSet: String? = null,
-    val pair: String? = null,
     val required: Boolean? = null,
     val pii: Boolean? = null,
     val phi: Boolean? = null,

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -13,8 +13,7 @@ data class Element(
     // General information
     val type: Type? = null,
     val format: String? = null,
-    val valueSetId: String? = null,
-    val valueSet: List<String>? = null, // If unspecified, any value is valid
+    val valueSet: String? = null, // If unspecified, any value is valid
     val required: Boolean? = null,
     val pii: Boolean? = null,
     val phi: Boolean? = null,
@@ -43,9 +42,6 @@ data class Element(
         DATETIME,
         DURATION,
         CODED,
-        CODED_LONIC,
-        CODED_SNOMED,
-        CODED_HL7,
         HD,
         ID,
         ID_DLN,
@@ -69,7 +65,6 @@ data class Element(
             name = this.name,
             type = this.type ?: baseElement.type,
             format = this.format ?: baseElement.format,
-            valueSetId = this.valueSetId ?: baseElement.valueSetId,
             valueSet = this.valueSet ?: baseElement.valueSet,
             required = this.required ?: baseElement.required,
             pii = this.pii ?: baseElement.pii,

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -60,8 +60,10 @@ data class Element(
     val isCodeType get() = this.type == Type.CODE
     val isCode get() = this.isCodeType && !name.contains('#')
     val isCodeText get() = this.isCodeType && name.endsWith("#text")
+    val isCodeSystem get() = this.isCodeType && name.endsWith("#system")
     val nameAsCode get() = if (name.contains('#')) name.split('#')[0] else name
     val nameAsCodeText get() = if (isCodeType) "$nameAsCode#text" else name
+    val nameAsCodeSystem get() = if (isCodeType) "$nameAsCode#system" else name
 
     fun nameContains(substring: String): Boolean {
         return name.contains(substring, ignoreCase = true)

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -13,7 +13,8 @@ data class Element(
     // General information
     val type: Type? = null,
     val format: String? = null,
-    val valueSet: String? = null, // If unspecified, any value is valid
+    val valueSet: String? = null,
+    val pair: String? = null,
     val required: Boolean? = null,
     val pii: Boolean? = null,
     val phi: Boolean? = null,
@@ -41,7 +42,7 @@ data class Element(
         DATE,
         DATETIME,
         DURATION,
-        CODED,
+        CODE,
         HD,
         ID,
         ID_DLN,
@@ -55,6 +56,12 @@ data class Element(
         TELEPHONE,
         EMAIL,
     }
+
+    val isCodeType get() = this.type == Type.CODE
+    val isCode get() = this.isCodeType && !name.contains('#')
+    val isCodeText get() = this.isCodeType && name.endsWith("#text")
+    val nameAsCode get() = if (name.contains('#')) name.split('#')[0] else name
+    val nameAsCodeText get() = if (isCodeType) "$nameAsCode#text" else name
 
     fun nameContains(substring: String): Boolean {
         return name.contains(substring, ignoreCase = true)

--- a/prime-router/src/main/kotlin/FakeTable.kt
+++ b/prime-router/src/main/kotlin/FakeTable.kt
@@ -46,6 +46,7 @@ class FakeTable {
                         when {
                             element.isCodeText -> it.display ?: "fake display"
                             element.isCode -> it.code ?: "fake code"
+                            element.isCodeSystem -> valueSet.systemCode
                             else -> error("element ${element.name} has is not a CODE type")
                         }
                     }.toTypedArray()
@@ -67,7 +68,7 @@ class FakeTable {
                     when {
                         element.nameContains("first") -> patientName.firstName()
                         element.nameContains("last") -> patientName.lastName()
-                        element.nameContains("middle") -> patientName.firstName()
+                        element.nameContains("middle") -> patientName.firstName() // no middle name in faker
                         element.nameContains("suffix") -> randomChoice(patientName.suffix(), "")
                         else -> TODO()
                     }

--- a/prime-router/src/main/kotlin/FakeTable.kt
+++ b/prime-router/src/main/kotlin/FakeTable.kt
@@ -47,7 +47,7 @@ class FakeTable {
                     formatter.format(faker.date().past(10, TimeUnit.DAYS))
                 }
                 Element.Type.DURATION -> TODO()
-                Element.Type.CODED -> {
+                Element.Type.CODE -> {
                     val valueSet =
                         valueSets[element.valueSet] ?: error("ValueSet ${element.valueSet} is not available}")
                     val possibleValues = valueSet.values.map {

--- a/prime-router/src/main/kotlin/MappableTable.kt
+++ b/prime-router/src/main/kotlin/MappableTable.kt
@@ -117,12 +117,13 @@ class MappableTable {
     }
 
     fun routeByReceiver(receivers: List<Receiver>): List<MappableTable> {
-        val onTopicReceivers = receivers.filter { it.topic == schema.topic }
-        return onTopicReceivers.map { receiver: Receiver ->
+        return receivers.filter {
+            it.topic == schema.topic
+        }.map { receiver: Receiver ->
             val outputName = "${receiver.name}-${name}"
             val input: MappableTable = if (receiver.schema != schema.name) {
                 val toSchema =
-                    Schema.schemas[receiver.schema] ?: error("${receiver.schema} schema is missing from catalog")
+                    Metadata.findSchema(receiver.schema) ?: error("${receiver.schema} schema is missing from catalog")
                 val mapping = schema.buildMapping(toSchema)
                 this.applyMapping(outputName, mapping)
             } else {
@@ -165,7 +166,7 @@ class MappableTable {
             }
             in mapping.useValueSet -> {
                 val valueSetName = mapping.useValueSet.getValue(toElement.name)
-                val valueSet = Schema.valueSets[valueSetName] ?: error("$valueSetName is not found")
+                val valueSet = Metadata.findValueSet(valueSetName) ?: error("$valueSetName is not found")
                 createValueSetTranslatedColumn(toElement, valueSet)
             }
             in mapping.useTranslator -> {

--- a/prime-router/src/main/kotlin/MappableTable.kt
+++ b/prime-router/src/main/kotlin/MappableTable.kt
@@ -202,6 +202,9 @@ class MappableTable {
                     valueSet.toDisplay(fromCode) ?: toElement.default ?: ""
                 }
             }
+            toElement.isCodeSystem -> {
+                Array(table.rowCount()) { valueSet.systemCode }
+            }
             toElement.isCode -> {
                 Array(table.rowCount()) { row ->
                     val fromDisplay = table.getString(row, toElement.nameAsCodeText)

--- a/prime-router/src/main/kotlin/Metadata.kt
+++ b/prime-router/src/main/kotlin/Metadata.kt
@@ -1,0 +1,170 @@
+package gov.cdc.prime.router
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.io.File
+import java.io.FilenameFilter
+import java.io.InputStream
+
+// The metadata object is a singleton representing all metadata loaded for MappableTables
+//
+object Metadata {
+    private const val defaultSchemaCatalog = "./metadata/schemas"
+    private const val schemaExtension = ".schema"
+    private const val defaultValueSetCatalog = "./metadata/valuesets"
+    private const val valueSetExtension = ".valuesets"
+    private const val defaultReceivers = "metadata/receivers.yml"
+
+    private var schemas = mapOf<String, Schema>()
+    private var translators = listOf(
+        MITranslator(),
+        SendingAppTranslator(),
+        SendingAppIdTranslator(),
+    )
+    private var valueSets = mapOf<String, ValueSet>()
+    private var receiversStore: List<Receiver> = ArrayList()
+    private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule())
+
+    fun loadAll() {
+        loadSchemaCatalog()
+        loadValueSetCatalog()
+        loadReceiversList()
+    }
+
+    /*
+     * Schema
+     */
+
+    // Load the schema catalog either from the default location or from the passed location
+    fun loadSchemaCatalog(catalog: String? = null) {
+        val catalogDir = File(catalog ?: defaultSchemaCatalog)
+        if (!catalogDir.isDirectory) error("Expected ${catalogDir.absolutePath} to be a directory")
+        loadSchemas(readAllSchemas(catalogDir, ""))
+    }
+
+    fun loadSchemas(schemas: List<Schema>) {
+        this.schemas = extendSchemas(schemas).map { normalizeSchemaName(it.name) to it }.toMap()
+    }
+
+    fun findSchema(name: String): Schema? {
+        return schemas[normalizeSchemaName(name)]
+    }
+
+    private fun readSchema(dirRelPath: String, file: File): Schema {
+        val fromSchemaFile = mapper.readValue<Schema>(file.inputStream())
+        val schemaName = normalizeSchemaName(
+            if (dirRelPath.isEmpty()) fromSchemaFile.name else dirRelPath + "/" + fromSchemaFile.name
+        )
+        return fromSchemaFile.copy(name = schemaName)
+    }
+
+    private fun readAllSchemas(catalogDir: File, dirRelPath: String): List<Schema> {
+        val outputSchemas = mutableListOf<Schema>()
+
+        // read the .schema files in the director
+        val schemaExtFilter = FilenameFilter { _: File, name: String -> name.endsWith(schemaExtension) }
+        val dir = File(catalogDir.absolutePath, dirRelPath)
+        val files = dir.listFiles(schemaExtFilter) ?: emptyArray()
+        outputSchemas.addAll(files.map { readSchema(dirRelPath, it) })
+
+        // read the schemas in the sub-directory
+        val subDirs = dir.listFiles { file -> file.isDirectory } ?: emptyArray()
+        subDirs.forEach {
+            val childPath = if (dirRelPath.isEmpty()) it.name else dirRelPath + "/" + it.name
+            outputSchemas.addAll(readAllSchemas(catalogDir, childPath))
+        }
+
+        return outputSchemas
+    }
+
+    private fun extendSchemas(schemas: List<Schema>): List<Schema> {
+        return schemas.map { schema ->
+            val expandedElements: List<Element> = schema.elements.map { element ->
+                if (element.name.contains('.')) {
+                    val splitName = element.name.split('.')
+                    if (splitName.size != 2) error("${element.name} is not a valid base name")
+                    val baseSchemaName = normalizeSchemaName(splitName[0])
+                    val basedElement = schemas.find { it.name == baseSchemaName }?.findElement(splitName[1])
+                        ?: error("${element.name} does not exists in $baseSchemaName")
+                    element.extendFrom(basedElement)
+                } else {
+                    element
+                }
+            }
+            schema.copy(elements = expandedElements)
+        }
+    }
+
+    private fun normalizeSchemaName(name: String): String {
+        return name.toLowerCase()
+    }
+
+    /*
+     * Translator
+     */
+
+    fun findTranslator(predicate: (t: Translator) -> Boolean): Translator? {
+        return translators.find(predicate)
+    }
+
+    /*
+     * ValueSet
+     */
+
+    fun loadValueSetCatalog(catalog: String? = null) {
+        val catalogDir = File(catalog ?: defaultValueSetCatalog)
+        if (!catalogDir.isDirectory) error("Expected ${catalogDir.absolutePath} to be a directory")
+        loadValueSets(readAllValueSets(catalogDir))
+    }
+
+    fun loadValueSets(sets: List<ValueSet>) {
+        this.valueSets = sets.map { normalizeValueSetName(it.name) to it }.toMap()
+    }
+
+    fun findValueSet(name: String): ValueSet? {
+        return valueSets[normalizeValueSetName(name)]
+    }
+
+    private fun readAllValueSets(catalogDir: File): List<ValueSet> {
+        // read the .valueset files in the director
+        val valueSetExtFilter = FilenameFilter { _, name -> name.endsWith(valueSetExtension) }
+        val files = File(catalogDir.absolutePath).listFiles(valueSetExtFilter) ?: emptyArray()
+        return files.flatMap { readValueSets(it) }
+    }
+
+    private fun readValueSets(file: File): List<ValueSet> {
+        return mapper.readValue(file.inputStream())
+    }
+
+    private fun normalizeValueSetName(name: String): String {
+        return name.toLowerCase()
+    }
+
+    /*
+     * Receiver
+     */
+
+    private data class ReceiversList(
+        val receivers: List<Receiver>
+    )
+
+    val receivers get() = receiversStore
+
+    fun loadReceiversList(receiversStream: InputStream? = null) {
+        val loadingStream = receiversStream ?: File(defaultReceivers).inputStream()
+        val receiversList = mapper.readValue<ReceiversList>(loadingStream)
+        loadReceivers(receiversList.receivers)
+    }
+
+    fun loadReceivers(receivers: List<Receiver>) {
+        receiversStore = receivers
+    }
+
+    fun findReceiver(name: String, topic: String): Receiver? {
+        return receiversStore.first {
+            it.name.equals(name, ignoreCase = true) && it.topic.equals(topic, ignoreCase = true)
+        }
+    }
+}

--- a/prime-router/src/main/kotlin/Receiver.kt
+++ b/prime-router/src/main/kotlin/Receiver.kt
@@ -1,12 +1,5 @@
 package gov.cdc.prime.router
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.readValue
-import java.io.File
-import java.io.InputStream
-
 data class Receiver(
     val name: String,
     val topic: String,
@@ -22,34 +15,5 @@ data class Receiver(
         CSV,
         //HL7,
         //FHIR
-    }
-
-    companion object {
-        private const val defaultReceivers = "metadata/receivers.yml"
-
-        val receivers: List<Receiver> get() = receiversStore
-        private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule())
-
-        data class ReceiversList(
-            val receivers: List<Receiver>
-        )
-
-        fun loadReceiversList(receiversStream: InputStream? = null) {
-            val loadingStream = receiversStream ?: File(defaultReceivers).inputStream()
-            val receiversList = mapper.readValue<ReceiversList>(loadingStream)
-            loadReceivers(receiversList.receivers)
-        }
-
-        fun loadReceivers(receivers: List<Receiver>) {
-            receiversStore = receivers
-        }
-
-        fun get(name: String, topic: String): Receiver? {
-            return receiversStore.first {
-                it.name.equals(name, ignoreCase = true) && it.topic.equals(topic, ignoreCase = true)
-            }
-        }
-
-        private var receiversStore: List<Receiver> = ArrayList()
     }
 }

--- a/prime-router/src/main/kotlin/Schema.kt
+++ b/prime-router/src/main/kotlin/Schema.kt
@@ -63,16 +63,11 @@ data class Schema(
     }
 
     private fun findMatchingElement(matchElement: Element): String? {
-        // TODO: Much more can be done here
-        val matchName = normalizeElementName(matchElement.name)
-        for ((name) in elements) {
-            if (matchName.equals(normalizeElementName(name), ignoreCase = true)) return name
-        }
-        return null
+        return findElement(matchElement.name)?.name
     }
 
     private fun findMatchingTranslator(matchElement: Element): Translator? {
-        return translators.find { translator ->
+        return Metadata.findTranslator { translator ->
             translator.topic.equals(topic, ignoreCase = true)
                     && translator.toElement.equals(matchElement.name, ignoreCase = true)
                     && translator.fromElements.find { findElement(it) == null } == null
@@ -85,107 +80,6 @@ data class Schema(
                 findElement(matchElement.name)?.valueSet
             }
             else -> null
-        }
-    }
-
-    companion object {
-        var schemas = mapOf<String, Schema>()
-        var translators = listOf(
-            MITranslator(),
-            SendingAppTranslator(),
-            SendingAppIdTranslator(),
-        )
-        var valueSets = mapOf<String, ValueSet>()
-
-        private const val defaultSchemaCatalog = "./metadata/schemas"
-        private const val schemaExtension = ".schema"
-        private const val defaultValueSetCatalog = "./metadata/valuesets"
-        private const val valueSetExtension = ".valuesets"
-        private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule())
-
-        // Load the schema catalog either from the default location or from the passed location
-        fun loadSchemaCatalog(catalog: String? = null) {
-            val catalogDir = File(catalog ?: defaultSchemaCatalog)
-            if (!catalogDir.isDirectory) error("Expected ${catalogDir.absolutePath} to be a directory")
-            loadSchemas(readAllSchemas(catalogDir, ""))
-        }
-
-        private fun readSchema(dirRelPath: String, file: File): Pair<String, Schema> {
-            val fromSchemaFile = mapper.readValue<Schema>(file.inputStream())
-            val schemaName = normalizeSchemaName(
-                if (dirRelPath.isEmpty()) fromSchemaFile.name else dirRelPath + "/" + fromSchemaFile.name
-            )
-            return Pair(schemaName, fromSchemaFile)
-        }
-
-        private fun readAllSchemas(catalogDir: File, dirRelPath: String): Map<String, Schema> {
-            val outputSchemas = mutableMapOf<String, Schema>()
-
-            // read the .schema files in the director
-            val schemaExtFilter = FilenameFilter { _: File, name: String -> name.endsWith(schemaExtension) }
-            val dir = File(catalogDir.absolutePath, dirRelPath)
-            val files = dir.listFiles(schemaExtFilter) ?: emptyArray()
-            outputSchemas.putAll(files.map { readSchema(dirRelPath, it) }.toMap())
-
-            // read the schemas in the sub-directory
-            val subDirs = dir.listFiles { file -> file.isDirectory } ?: emptyArray()
-            subDirs.forEach {
-                val childPath = if (dirRelPath.isEmpty()) it.name else dirRelPath + "/" + it.name
-                outputSchemas.putAll(readAllSchemas(catalogDir, childPath))
-            }
-
-            return outputSchemas
-        }
-
-        fun loadSchemas(schemas: Map<String, Schema>) {
-            this.schemas = extendSchemas(schemas)
-        }
-
-        private fun extendSchemas(schemas: Map<String, Schema>): Map<String, Schema> {
-            return schemas.mapValues { (name, schema) ->
-                val expandedElements: List<Element> = schema.elements.map { element ->
-                    if (element.name.contains('.')) {
-                        val splitName = element.name.split('.')
-                        if (splitName.size != 2) error("${element.name} is not a valid base name")
-                        val baseSchemaName = normalizeSchemaName(splitName[0])
-                        val basedElement = schemas[baseSchemaName]?.findElement(splitName[1])
-                            ?: error("${element.name} does not exists in $name")
-                        element.extendFrom(basedElement)
-                    } else {
-                        element
-                    }
-                }
-                schema.copy(elements = expandedElements)
-            }
-        }
-
-        fun loadValueSetCatalog(catalog: String? = null) {
-            val catalogDir = File(catalog ?: defaultValueSetCatalog)
-            if (!catalogDir.isDirectory) error("Expected ${catalogDir.absolutePath} to be a directory")
-            loadValueSets(readAllValueSets(catalogDir))
-        }
-
-        fun loadValueSets(sets: List<ValueSet>) {
-            this.valueSets = sets.map { it.name to it }.toMap()
-        }
-
-        private fun readAllValueSets(catalogDir: File): List<ValueSet> {
-            // read the .valueset files in the director
-            val valueSetExtFilter = FilenameFilter { _, name -> name.endsWith(valueSetExtension) }
-            val files = File(catalogDir.absolutePath).listFiles(valueSetExtFilter) ?: emptyArray()
-            return files.flatMap { readValueSets(it) }
-        }
-
-        private fun readValueSets(file: File): List<ValueSet> {
-            return mapper.readValue(file.inputStream())
-        }
-
-        private fun normalizeElementName(name: String): String {
-            return name.replace("_|\\s".toRegex(), "").toLowerCase()
-        }
-
-        private fun normalizeSchemaName(name: String): String {
-            return name.toLowerCase()
         }
     }
 }

--- a/prime-router/src/main/kotlin/Schema.kt
+++ b/prime-router/src/main/kotlin/Schema.kt
@@ -29,7 +29,11 @@ data class Schema(
     )
 
     fun findElement(name: String): Element? {
-        return elements.find { (it.name == name) || (it.isCode && (it.nameAsCode == name || it.nameAsCodeText == name)) }
+        return elements.find {
+            (it.name == name) ||
+                    // a CODE element can have 3 different names <name> or <name>#text or <name>#system depending
+                    (it.isCode && (it.nameAsCode == name || it.nameAsCodeText == name || it.nameAsCodeSystem == name))
+        }
     }
 
     fun buildMapping(toSchema: Schema): Mapping {

--- a/prime-router/src/main/kotlin/Translators.kt
+++ b/prime-router/src/main/kotlin/Translators.kt
@@ -37,47 +37,5 @@ class SendingAppIdTranslator : Translator {
     }
 }
 
-class SpecimenTypeFreeTranslator : Translator {
-    override val topic = "covid-19"
-    override val toElement = "standard.specimen_type_text"
-    override val fromElements = listOf("standard.Specimen_type_code")
-
-    override fun apply(values: List<String>): String? {
-        val codeToText = mapOf(
-            "258500001" to "Nasopharyngeal swab",
-            "871810001" to "Mid-turbinate nasal swab",
-            "697989009" to "Anterior nares swab",
-            "258411007" to "Nasopharyngeal aspirate",
-            "429931000124105" to "Nasal aspirate",
-            "258529004" to "Throat swab",
-            "119334006" to "Sputum specimen",
-            "119342007" to "Saliva specimen",
-            "258607008" to "Bronchoalveolar lavage fluid sample",
-            "119364003" to "Serum specimen",
-            "119361006" to "Plasma specimen",
-            "440500007" to "Dried blood spot specimen",
-            "258580003" to "Whole blood sample",
-            "122555007" to "Venous blood specimen",
-        )
-        return codeToText[values[0]]
-    }
-}
-
-class LabTestResultTranslator : Translator {
-    override val topic = "covid-19"
-    override val toElement = "standard.test_result_text"
-    override val fromElements = listOf("standard.Test_result_coded")
-
-    override fun apply(values: List<String>): String? {
-        val codeToText = mapOf(
-            "260373001" to "Detected",
-            "260415000" to "Not detected",
-            "895231008" to "Not detected in pooled specimen",
-            "462371000124108" to "Detected in pooled specimen",
-            "419984006" to "Inconclusive",
-        )
-        return codeToText[values[0]]
-    }
-}
 
 

--- a/prime-router/src/main/kotlin/Translators.kt
+++ b/prime-router/src/main/kotlin/Translators.kt
@@ -33,13 +33,13 @@ class SendingAppIdTranslator : Translator {
     override val fromElements = emptyList<String>()
 
     override fun apply(values: List<String>): String? {
-        return null
+        return "TODO PRIME OID"
     }
 }
 
 class SpecimenTypeFreeTranslator : Translator {
     override val topic = "covid-19"
-    override val toElement = "standard.Specimen_type_free_text"
+    override val toElement = "standard.specimen_type_text"
     override val fromElements = listOf("standard.Specimen_type_code")
 
     override fun apply(values: List<String>): String? {
@@ -65,7 +65,7 @@ class SpecimenTypeFreeTranslator : Translator {
 
 class LabTestResultTranslator : Translator {
     override val topic = "covid-19"
-    override val toElement = "standard.Test_result_free_text"
+    override val toElement = "standard.test_result_text"
     override val fromElements = listOf("standard.Test_result_coded")
 
     override fun apply(values: List<String>): String? {

--- a/prime-router/src/main/kotlin/ValueSet.kt
+++ b/prime-router/src/main/kotlin/ValueSet.kt
@@ -25,6 +25,15 @@ data class ValueSet(
         FHIR,
     }
 
+    val systemCode
+        get() = when (system) {
+            SetSystem.HL7 -> "HL7"
+            SetSystem.SNOMED_CT -> "SCT"
+            SetSystem.LOINC -> "L"
+            SetSystem.LOCAL -> "LOCAL"
+            SetSystem.FHIR -> "F"
+        }
+
     data class Value(
         val code: String? = null,
         val alt_codes: List<String> = emptyList(),

--- a/prime-router/src/main/kotlin/ValueSet.kt
+++ b/prime-router/src/main/kotlin/ValueSet.kt
@@ -30,4 +30,12 @@ data class ValueSet(
         val alt_codes: List<String> = emptyList(),
         val display: String? = null,
     )
+
+    fun toDisplay(code: String): String? {
+        return values.find { code.equals(it.code, ignoreCase = true) || it.alt_codes.contains(code) }?.display
+    }
+
+    fun toCode(display: String): String? {
+        return values.find { display.equals(it.display, ignoreCase = true) }?.code
+    }
 }

--- a/prime-router/src/main/kotlin/ValueSet.kt
+++ b/prime-router/src/main/kotlin/ValueSet.kt
@@ -1,0 +1,33 @@
+package gov.cdc.prime.router
+
+//  Example
+//
+//  - name: hl7_0136
+//  system: HL7
+//  reference: used where the HHS guidance specifies
+//  system_code: 0136
+//  values:
+//    - code: YES
+//      alt_codes: [true]
+//      display: Yes
+data class ValueSet(
+    val name: String,
+    val system: SetSystem,
+    val reference: String? = null,
+    val referenceUrl: String? = null,
+    val values: List<Value> = emptyList(),
+) {
+    enum class SetSystem {
+        HL7,
+        SNOMED_CT,
+        LOINC,
+        LOCAL,
+        FHIR,
+    }
+
+    data class Value(
+        val code: String? = null,
+        val alt_codes: List<String> = emptyList(),
+        val display: String? = null,
+    )
+}

--- a/prime-router/src/main/kotlin/main.kt
+++ b/prime-router/src/main/kotlin/main.kt
@@ -109,6 +109,7 @@ class RouterCli : CliktCommand(
         // Load the schema and receivers
         Schema.loadSchemaCatalog()
         Receiver.loadReceiversList()
+        Schema.loadValueSetCatalog()
         echo("Loaded schema and receivers")
 
         // Gather input source

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-class ElementTests {
+internal class ElementTests {
 
     @Test
     fun `create element`() {

--- a/prime-router/src/test/kotlin/FakeTableTest.kt
+++ b/prime-router/src/test/kotlin/FakeTableTest.kt
@@ -1,0 +1,17 @@
+package gov.cdc.prime.router
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class FakeTableTest {
+    @Test
+    fun `test a coded fake`() {
+        val state = Element("standard.patient_state", type = Element.Type.CODED, valueSet = "fake")
+        val valueSets = mapOf(
+            "fake" to
+                    ValueSet("fake", ValueSet.SetSystem.LOCAL, values = listOf(ValueSet.Value(code = "AZ")))
+        )
+        assertEquals("AZ", FakeTable.buildColumn(state, valueSets))
+    }
+
+}

--- a/prime-router/src/test/kotlin/FakeTableTest.kt
+++ b/prime-router/src/test/kotlin/FakeTableTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 internal class FakeTableTest {
     @Test
     fun `test a coded fake`() {
-        val state = Element("standard.patient_state", type = Element.Type.CODED, valueSet = "fake")
+        val state = Element("standard.patient_state", type = Element.Type.CODE, valueSet = "fake")
         val valueSets = mapOf(
             "fake" to
                     ValueSet("fake", ValueSet.SetSystem.LOCAL, values = listOf(ValueSet.Value(code = "AZ")))

--- a/prime-router/src/test/kotlin/FakeTableTest.kt
+++ b/prime-router/src/test/kotlin/FakeTableTest.kt
@@ -11,7 +11,6 @@ internal class FakeTableTest {
             "fake" to
                     ValueSet("fake", ValueSet.SetSystem.LOCAL, values = listOf(ValueSet.Value(code = "AZ")))
         )
-        assertEquals("AZ", FakeTable.buildColumn(state, valueSets))
+        assertEquals("AZ", FakeTable.buildColumn(state) { valueSets[it] })
     }
-
 }

--- a/prime-router/src/test/kotlin/MappableTableTests.kt
+++ b/prime-router/src/test/kotlin/MappableTableTests.kt
@@ -156,7 +156,7 @@ class MappableTableTests {
     @Test
     fun `test applyMapping`() {
         val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
-        val two = Schema(name = "two", topic = "test", elements = listOf(Element("B")))
+        val two = Schema(name = "two", topic = "test", elements = listOf(Element("b")))
 
         val oneTable =
             MappableTable(name = "one", schema = one, values = listOf(listOf("a1", "b1"), listOf("a2", "b2")))
@@ -176,7 +176,7 @@ class MappableTableTests {
             topic = "test",
             elements = listOf(Element("a", default = "~"), Element("b"))
         )
-        val two = Schema(name = "two", topic = "test", elements = listOf(Element("B")))
+        val two = Schema(name = "two", topic = "test", elements = listOf(Element("b")))
 
         val twoTable =
             MappableTable(name = "one", schema = two, values = listOf(listOf("b1"), listOf("b2")))

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -1,0 +1,48 @@
+package gov.cdc.prime.router
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MetadataTests {
+    @Test
+    fun `test loading schema catalog`() {
+        Metadata.loadSchemaCatalog("./src/test/unit_test_files")
+        assertNotNull(Metadata.findSchema("lab_test_results_schema"))
+        val elements = Metadata.findSchema("lab_test_results_schema")?.elements
+        assertEquals("lab", elements?.get(0)?.name)
+        assertEquals("extra", elements?.get(6)?.name)
+        assertEquals(Element.Type.POSTAL_CODE, elements?.get(8)?.type)
+    }
+
+    @Test
+    fun `test loading two schemas`() {
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
+        val two = Schema(name = "two", topic = "test", elements = listOf(Element("a"), Element("b")))
+        Metadata.loadSchemas(listOf(one, two))
+        assertNotNull(Metadata.findSchema("one"))
+    }
+
+    @Test
+    fun `load valueSets`() {
+        val one = ValueSet("one", ValueSet.SetSystem.HL7)
+        val two = ValueSet("two", ValueSet.SetSystem.LOCAL)
+        Metadata.loadValueSets(listOf(one, two))
+        assertNotNull(Metadata.findValueSet("one"))
+    }
+
+    @Test
+    fun `load value set directory`() {
+        Metadata.loadValueSetCatalog("./src/test/unit_test_files")
+        assertNotNull(Metadata.findValueSet("hl7_0136"))
+    }
+
+
+    @Test
+    fun `test find schemas`() {
+        val one = Schema(name = "One", topic = "test", elements = listOf(Element("a")))
+        val two = Schema(name = "Two", topic = "test", elements = listOf(Element("a"), Element("b")))
+        Metadata.loadSchemas(listOf(one, two))
+        assertNotNull(Metadata.findSchema("one"))
+    }
+}

--- a/prime-router/src/test/kotlin/ReceiverTests.kt
+++ b/prime-router/src/test/kotlin/ReceiverTests.kt
@@ -21,14 +21,13 @@ class ReceiverTests {
     @Test
     fun `test loading a receiver`() {
         val input = ByteArrayInputStream(receiversYaml.toByteArray())
-        Receiver.loadReceiversList(input)
-        assertEquals(1, Receiver.receivers.size)
-        assertEquals(2, Receiver.get("phd1", "covid-19")?.patterns?.size)
+        Metadata.loadReceiversList(input)
+        assertEquals(2, Metadata.findReceiver("phd1", "covid-19")?.patterns?.size)
     }
 
     @Test
     fun `test loading a single receiver`() {
-        Receiver.loadReceivers(listOf(Receiver("name", "topic", "schema")))
-        assertEquals(1, Receiver.receivers.size)
+        Metadata.loadReceivers(listOf(Receiver("name", "topic", "schema")))
+        assertNotNull(Metadata.findReceiver("name", "topic"))
     }
 }

--- a/prime-router/src/test/kotlin/SchemaTests.kt
+++ b/prime-router/src/test/kotlin/SchemaTests.kt
@@ -26,73 +26,37 @@ class SchemaTests {
     }
 
     @Test
-    fun `test loading schema catalog`() {
-        Schema.loadSchemaCatalog("./src/test/unit_test_files")
-        assertNotNull(Schema.schemas["lab_test_results_schema"])
-        assertEquals(9, Schema.schemas.getValue("lab_test_results_schema").elements.size)
-        assertEquals("lab", Schema.schemas.getValue("lab_test_results_schema").elements[0].name)
-        assertEquals("extra", Schema.schemas.getValue("lab_test_results_schema").elements[6].name)
-        assertEquals(Element.Type.POSTAL_CODE, Schema.schemas.getValue("lab_test_results_schema").elements[8].type)
-    }
-
-    @Test
-    fun `test loading two schemas`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
-        val two = Schema(name = "two", topic = "test", elements = listOf(Element("a"), Element("b")))
-        Schema.loadSchemas(mapOf("one" to one, "two" to two))
-        assertEquals(2, Schema.schemas.size)
-        assertNotNull(Schema.schemas["one"])
-    }
-
-    @Test
     fun `test buildMapping`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("A")))
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
         val two = Schema(name = "two", topic = "test", elements = listOf(Element("a"), Element("b")))
 
         val oneToTwo = one.buildMapping(two)
         assertEquals(one, oneToTwo.fromSchema)
         assertEquals(two, oneToTwo.toSchema)
         assertEquals(1, oneToTwo.useDirectly.size)
-        assertEquals("A", oneToTwo.useDirectly["a"])
+        assertEquals("a", oneToTwo.useDirectly["a"])
         assertEquals(true, oneToTwo.useDefault.contains("b"))
         assertEquals(0, oneToTwo.missing.size)
 
         val twoToOne = two.buildMapping(toSchema = one)
         assertEquals(1, twoToOne.useDirectly.size)
-        assertEquals("a", twoToOne.useDirectly["A"])
+        assertEquals("a", twoToOne.useDirectly["a"])
         assertEquals(0, twoToOne.useDefault.size)
         assertEquals(0, twoToOne.missing.size)
     }
 
     @Test
     fun `test buildMapping with missing`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("A")))
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
         val three = Schema(
             name = "three",
             topic = "test",
-            elements = listOf(Element("a_"), Element("c", required = true))
+            elements = listOf(Element("a"), Element("c", required = true))
         )
         val oneToThree = one.buildMapping(toSchema = three)
         assertEquals(1, oneToThree.useDirectly.size)
-        assertEquals("A", oneToThree.useDirectly["a_"])
+        assertEquals("a", oneToThree.useDirectly["a"])
         assertEquals(0, oneToThree.useDefault.size)
         assertEquals(1, oneToThree.missing.size)
     }
-
-    @Test
-    fun `load valueSets`() {
-        val one = ValueSet("one", ValueSet.SetSystem.HL7)
-        val two = ValueSet("two", ValueSet.SetSystem.LOCAL)
-        Schema.loadValueSets(listOf(one, two))
-        assertEquals(2, Schema.valueSets.size)
-        assertNotNull(Schema.valueSets["one"])
-    }
-
-    @Test
-    fun `load value set directory`() {
-        Schema.loadValueSetCatalog("./src/test/unit_test_files")
-        assertEquals(8, Schema.valueSets.size)
-        assertNotNull(Schema.valueSets["hl7_0136"])
-    }
-
 }

--- a/prime-router/src/test/kotlin/SchemaTests.kt
+++ b/prime-router/src/test/kotlin/SchemaTests.kt
@@ -78,4 +78,21 @@ class SchemaTests {
         assertEquals(0, oneToThree.useDefault.size)
         assertEquals(1, oneToThree.missing.size)
     }
+
+    @Test
+    fun `load valueSets`() {
+        val one = ValueSet("one", ValueSet.SetSystem.HL7)
+        val two = ValueSet("two", ValueSet.SetSystem.LOCAL)
+        Schema.loadValueSets(listOf(one, two))
+        assertEquals(2, Schema.valueSets.size)
+        assertNotNull(Schema.valueSets["one"])
+    }
+
+    @Test
+    fun `load value set directory`() {
+        Schema.loadValueSetCatalog("./src/test/unit_test_files")
+        assertEquals(8, Schema.valueSets.size)
+        assertNotNull(Schema.valueSets["hl7_0136"])
+    }
+
 }

--- a/prime-router/src/test/kotlin/TranslatorTests.kt
+++ b/prime-router/src/test/kotlin/TranslatorTests.kt
@@ -10,4 +10,8 @@ class TranslatorTests {
         assertEquals("R", MITranslator().apply(listOf("rick")))
     }
 
+    @Test
+    fun `test SendingAppTranslator`() {
+        assertEquals("PRIME", SendingAppTranslator().apply(listOf()))
+    }
 }

--- a/prime-router/src/test/unit_test_files/common.valuesets
+++ b/prime-router/src/test/unit_test_files/common.valuesets
@@ -1,0 +1,112 @@
+# These ValueSets are not associated with specific topic.
+# ValueSets are used with CODED data elements and their display TEXT equivalents
+#
+# Name conventions
+#
+#  for SNOMED-CT use the standard element name
+#  for hl7 value sets use the HL7 name
+#  for LOINC value sets use TBD
+#  for LOCAL match the standard element
+#
+# sort alphabetically
+#
+---
+- name: hl7_0136
+  system: HL7
+  values:
+    - code: YES
+      alt_codes: [true]
+      display: Yes
+    - code: NO
+      alt_codes: [false]
+      display: No
+    - code: UNK
+      alt_codes: [Unknown]
+      display: Unknown
+
+- name: patient_age_units
+  reference: Per the HHS guidance
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  system: LOCAL
+  values:
+    - display: months
+      alt_codes: [mo]
+    - display: years
+      alt_codes: [yr, yrs]
+
+- name: patient_gender
+  system: LOCAL
+  reference: HHS guidance for sex at birth
+  referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Tables/0001
+  values:
+    - display: Male
+      alt_codes: [M]
+    - display: Female
+      alt_codes: [F]
+    - display: Other
+      alt_codes: [O]
+    - display: Ambiguous
+      alt_codes: [A]
+    - display: Unknown
+      alt_codes: [U, UNK]
+    - display: Not applicable
+      alt_codes: [N]
+
+- name: omb_ethnicity
+  system: FHIR
+  reference: OMB 2020 Census values per the HHS guidance
+  referenceUrl: https://hl7.org/fhir/us/core/2017Jan/ValueSet-omb-ethnicity.html
+  values:
+    - code: Hispanic or Latino
+      display: 2135-2
+    - code: Non Hispanic or Latino
+      display: 2186-5
+    - code: Unknown
+      display: UNK
+    - code: Asked, but unknown
+      display: ASKU
+
+- name: omb_race
+  system: FHIR
+  reference: OMB 2020 Census specified by the HHS guidance
+  referenceUrl: http://hl7.org/fhir/us/core/2017Jan/ValueSet-omb-race.html
+  values:
+    - display: American Indian or Alaska Native
+      code: 1002-5
+    - display: Asian
+      code: 2028-9
+    - display: Black or African American
+      code: 2054-5
+    - display: Native Hawaiian or Other Pacific Islander
+      code: 2076-8
+    - display: White
+      code: 2106-3
+    - display: Unknown
+      code: UNK
+    - display: Asked, but unknown
+      code: ASKU
+
+- name: specimen_role
+  system: FHIR
+  referenceUrl: https://terminology.hl7.org/ValueSet-v3-SpecimenRoleType.html
+  values:
+    - code: B
+      display: Blind sample
+    - code: E
+      display: Electronic QC
+    - code: F
+      display: Filer
+    - code: G
+      display: Group
+    - code: L
+      display: Pool
+    - code: O
+      display: Operator proficiency
+    - code: P
+      display: Patient
+    - code: Q
+      display: Control specimen
+    - code: R
+      display: Replicate
+    - code: V
+      display: Verifying collaborator

--- a/prime-router/src/test/unit_test_files/common.valuesets
+++ b/prime-router/src/test/unit_test_files/common.valuesets
@@ -1,5 +1,5 @@
 # These ValueSets are not associated with specific topic.
-# ValueSets are used with CODED data elements and their display TEXT equivalents
+# ValueSets are used with CODE data elements and their display equivalents
 #
 # Name conventions
 #

--- a/prime-router/src/test/unit_test_files/covid-19.valuesets
+++ b/prime-router/src/test/unit_test_files/covid-19.valuesets
@@ -1,0 +1,61 @@
+# These ValueSets are associated with covid-19 topic
+# ValueSets are used with CODED data elements and their display TEXT equivalents
+#
+# Name conventions
+#
+#  for SNOMED-CT use the standard element name
+#  for hl7 value sets use the HL7 name
+#  for LOINC value sets use TBD
+#  for LOCAL match the standard element
+#
+# sort alphabetically
+#
+---
+- name: covid-19/specimen_type
+  system: SNOMED_CT
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  values:
+    - code: 258500001
+      display: Nasopharyngeal swab
+    - code: 871810001
+      display: Mid-turbinate nasal swab 
+    - code: 697989009
+      display: Anterior nares swab 
+    - code: 258411007
+      display: Nasopharyngeal aspirate 
+    - code: 429931000124105
+      display: Nasal aspirate 
+    - code: 258529004
+      display: Throat swab 
+    - code: 119334006
+      display: Sputum specimen 
+    - code: 119342007
+      display: Saliva specimen 
+    - code: 258607008
+      display: Bronchoalveolar lavage fluid sample 
+    - code: 119364003
+      display: Serum specimen 
+    - code: 119361006
+      display: Plasma specimen 
+    - code: 440500007
+      display: Dried blood spot specimen 
+    - code: 258580003
+      display: Whole blood sample 
+    - code: 122555007
+      display: Venous blood specimen
+
+- name: covid-19/test_result
+  system: SNOMED_CT
+  referenceUrl: https://www.hhs.gov/sites/default/files/hhs-guidance-implementation.pdf
+  values:
+    - code: 260373001
+      display: Detected
+    - code: 260415000
+      display: Not detected
+    - code: 895231008
+      display: Not detected in pooled specimen
+    - code: 462371000124108
+      display: Detected in pooled specimen
+    - code: 419984006
+      display: Inconclusive
+

--- a/prime-router/src/test/unit_test_files/covid-19.valuesets
+++ b/prime-router/src/test/unit_test_files/covid-19.valuesets
@@ -1,5 +1,5 @@
 # These ValueSets are associated with covid-19 topic
-# ValueSets are used with CODED data elements and their display TEXT equivalents
+# ValueSets are used with CODE data elements and their display equivalents
 #
 # Name conventions
 #


### PR DESCRIPTION
**Why**
This PR focuses on cleaning-up the metadata that is used by MappableTable. It is a precursor to writing HL7 messages. 

**Issues**
fixes #7 
fixes #20 

**Changes**
- A new file type called ValueSet to encode the mapping tables from LONIC, SNOMED, or HL7 that are specified by the HHS guidance. 
- Element types CODED, CODED_HL7, ... are now just CODE
- ValueSet is used by FakeTable and Mappings support using ValueSets
- The Schema companion object is now in its own Metadata object file
- The Metadata's interface doesn't leak implementation
- The naming of standard elements is now all lower-case to avoid input problems