### PR TITLE
added sftp server to docker-compose

### DIFF
--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     entrypoint: [/prime-data-hub-router/start_func.sh]
     environment: 
       AzureWebJobsStorage: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;
-    depends_on: [azurite]   
+    depends_on: [azurite, sftp]   
     ports:
       - 7071:7071 # default function port
       - 5005:5005 # Java debug port
@@ -26,3 +26,12 @@ services:
     ports:  
       - 10000:10000 
       - 10001:10001
+
+  #local SFTP server as a receive point
+  sftp:
+    image: atmoz/sftp
+    volumes:
+        - ./target/sftp:/home/foo/upload
+    ports:
+        - "9022:22"
+    command: foo:pass:1001

--- a/prime-router/metadata/receivers.yml
+++ b/prime-router/metadata/receivers.yml
@@ -15,7 +15,7 @@ receivers:
     transport:
         type: SFTP
         host: localhost
-        port: 22
+        port: 9022
         
   # Florida PHD
   - name: phd2

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -30,9 +30,9 @@ class SftpTransport {
 
     private fun initSshClient(
         host: String = "localhost",
-        port: String = "22",
-        user: String = "tester",
-        password: String = "testing"
+        port: String = "9022",
+        user: String = "foo",
+        password: String = "pass"
     ) : Session {
         val jsch = JSch()
         val session = jsch.getSession(user, host, port.toInt() )


### PR DESCRIPTION
This PR adds an SFTP server to the docker-compose for use in local testing using docker

## Changes
- added SFTP server - listens on host port 9022 (internally port 22)
- for the account specified, sftp output will be written to ./target/sftp when delivered

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

