### PR TITLE
organization.yml supports local

### DIFF
--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -136,3 +136,7 @@ az acr login --name rhawesprimedevregistry
 docker build --tag rhawesprimedevregistry.azurecr.io/prime-data-hub . 
 docker push rhawesprimedevregistry.azurecr.io/prime-data-hub 
 ```
+
+## Using local configuration for organizations.yml
+
+By default, the functions will pull their configuration for organizations from the `organizations.yml` file.  You can override this locally or in test by declaring an environment variable `PRIME_ENVIRONMENT`.  If you declare something like, `export PRIME_ENVIRONMENT=mylocal` then the system will look for a configuration file `organizations-mylocal.yml` and will use that, even if the `organizations.yml` file exists.  In this way, you can set up local SFTP routing, etc. without impacting the production (`organizations.yml`) config.  Note that depending on the OS - case matters.

--- a/prime-router/src/main/kotlin/Metadata.kt
+++ b/prime-router/src/main/kotlin/Metadata.kt
@@ -19,7 +19,12 @@ object Metadata {
     private const val schemasSubdirectory = "schemas"
     private const val valuesetsSubdirectory = "valuesets"
     private const val tableSubdirectory = "tables"
-    private const val organizationsList = "organizations.yml"
+
+    private val PRIME_ENVIRONMENT = System.getenv("PRIME_ENVIRONMENT") ?: ""
+
+    private val ext = if (PRIME_ENVIRONMENT.isNotEmpty() ) "-" + PRIME_ENVIRONMENT else  PRIME_ENVIRONMENT;
+
+    private val organizationsList = "organizations${ext}.yml"
 
     private var schemas = mapOf<String, Schema>()
     private var mappers = listOf(


### PR DESCRIPTION
This PR allows for orginizations.yml files in the local environment

## Changes
- can create an environment variable PRIME_ENVIRONMENT and copy organizations to organizations-${PRIME_ENVIRONMENT}.yml to support local dev
- by default, if there isnt a PRIME_ENVIRONMENT variable organizations.yml will be used

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [X] Updated the docs?
- [ ] Added a test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

