### PR TITLE
Normalize phone number and its formatting

### DIFF
--- a/prime-router/src/main/kotlin/Hl7Converter.kt
+++ b/prime-router/src/main/kotlin/Hl7Converter.kt
@@ -114,16 +114,17 @@ object Hl7Converter {
     }
 
     private fun setTelephoneComponent(terser: Terser, value: String, pathSpec: String, element: Element) {
-        val number = phoneNumberUtil.parse(value, "US")
-        val national = DecimalFormat("0000000000").format(number.nationalNumber)
-        val areaCode = national.substring(0, 3)
-        val local = national.toString().substring(3, 10)
+        val parts = value.split(Element.phoneDelimiter)
+        val areaCode = parts[0].substring(0, 3)
+        val local = parts[0].substring(3)
+        val country = parts[1]
+        val extension = parts[2]
 
         terser.set(buildComponent(pathSpec, 2), "PH")
-        if (number.hasCountryCode()) terser.set(buildComponent(pathSpec, 5), number.countryCode.toString())
+        terser.set(buildComponent(pathSpec, 5), country)
         terser.set(buildComponent(pathSpec, 6), areaCode)
         terser.set(buildComponent(pathSpec, 7), local)
-        if (number.hasExtension()) terser.set(buildComponent(pathSpec, 8), number.extension)
+        if (extension.isNotEmpty()) terser.set(buildComponent(pathSpec, 8), extension)
     }
 
     private fun setLiterals(terser: Terser) {

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -103,4 +103,38 @@ internal class ElementTests {
         assertEquals("199803300000", result2)
     }
 
+    @Test
+    fun `test toNormalized phone`() {
+        val one = Element("a",
+            type = Element.Type.TELEPHONE,
+            csvFields = Element.csvFields("phone"))
+        val result1 = one.toNormalized("5559938322")
+        assertEquals("5559938322:1:", result1)
+        val result2 = one.toNormalized("1(555)-968-5052")
+        assertEquals("5559685052:1:", result2)
+        val result3 = one.toNormalized("555-968-5052")
+        assertEquals("5559685052:1:", result3)
+        val result4 = one.toNormalized("+1(555)-968-5052")
+        assertEquals("5559685052:1:", result4)
+        val result5 = one.toNormalized("968-5052")
+        assertEquals("0009685052:1:", result5)
+        val result6 = one.toNormalized("+1(555)-968-5052 x5555")
+        assertEquals("5559685052:1:5555", result6)
+        // MX phone number
+        val result7 = one.toNormalized("+52-65-8888-8888")
+        assertEquals("6588888888:52:", result7)
+    }
+
+    @Test
+    fun `test toFormatted phone`() {
+        val one = Element("a",
+            type = Element.Type.TELEPHONE,
+            csvFields = Element.csvFields("phone"))
+        val result1 = one.toFormatted("5559938322:1:")
+        assertEquals("5559938322", result1)
+        val result2 = one.toFormatted("5559938322:1:", Element.CsvField("test", "\$country-\$area-\$exchange-\$subscriber"))
+        assertEquals("1-555-993-8322", result2)
+        val result3 = one.toFormatted("5559938322:1:", Element.CsvField("test", "(\$area)\$exchange-\$subscriber"))
+        assertEquals("(555)993-8322", result3)
+    }
 }


### PR DESCRIPTION
This PR does adds formatting flexibility for phone numbers. The default remains 10 digits, but there is much greater flexibility for input and output. This change was requested by the AZ PHD

## Changes
- Used the Google phone number utility to parse phone numbers
- Support for $country, $area, $exchange, and $subscriber parts of the phone number
- Support for International numbers
- Changed the default which is used by AZ to be a plain 10 digits

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

