### PR TITLE
zipcode

### DIFF
--- a/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
@@ -103,6 +103,7 @@ elements:
   - name: standard.patient_zip_code
     csvFields:
     - name: Patient_Zip
+      format: $zip # Only a 5 digit zipcode
 
   - name: standard.patient_county
     csvFields:

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -169,6 +169,11 @@ data class Element(
                     .replace(exchangeToken, parts[0].substring(3, 6))
                     .replace(subscriberToken, parts[0].substring(6))
                     .replace(extensionToken, parts[2])
+            Type.POSTAL_CODE -> {
+                when (field?.format) {
+                    zipPlus4Token -> normalizedValue
+                    else -> normalizedValue.substring(0, 5)
+                }
             }
             else -> normalizedValue
         }
@@ -235,6 +240,10 @@ data class Element(
                     error("Invalid phone number '$formattedValue' for '$name'")
                 val nationalNumber = DecimalFormat("0000000000").format(number.nationalNumber)
                 "${nationalNumber}$phoneDelimiter${number.countryCode}$phoneDelimiter${number.extension}"
+            Type.POSTAL_CODE -> {
+                if (!Regex("^\\d{5}(-\\d{4})?\$").matches(formattedValue))
+                    error("Input Error: invalid postal code '$formattedValue'")
+                formattedValue
             }
             else -> formattedValue
         }
@@ -269,6 +278,9 @@ data class Element(
         const val defaultPhoneFormat = "\$area\$exchange\$subscriber"
         const val phoneDelimiter = ":"
         val phoneNumberUtil: PhoneNumberUtil = PhoneNumberUtil.getInstance()
+        const val zipToken = "\$zip"
+        const val zipPlus4Token = "\$zipPlus4"
+        const val zipDefaultFormat = zipToken
 
         fun csvFields(name: String, format: String? = null): List<CsvField> {
             return listOf(CsvField(name, format))

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -114,10 +114,13 @@ internal class ElementTests {
         val result2 = one.toNormalized("99999-9999")
         assertEquals("99999-9999", result2)
         // format should not affect normalization
-        val result4 = one.toNormalized("99999-9999", Element.CsvField("zip", "\$zip"))
-        assertEquals("99999-9999", result4)
+        val result4 = one.toNormalized("999999999", Element.CsvField("zip", "\$zipFive"))
+        assertEquals("999999999", result4)
+        val result5 = one.toNormalized("KY1-6666") // Cayman zipcode
+        assertEquals("KY1-6666", result5)
+        val result6 = one.toNormalized("KX33-77777") // Letters and numbers, but a made up zipcode
         assertFails {
-            val result5 = one.toNormalized("999999")
+            one.toNormalized("%%%%XXXX") // Unreasonable
         }
     }
 
@@ -150,20 +153,36 @@ internal class ElementTests {
             csvFields = Element.csvFields("phone"))
         val result1 = one.toFormatted("5559938322:1:")
         assertEquals("5559938322", result1)
-        val result2 = one.toFormatted("5559938322:1:", Element.CsvField("test", "\$country-\$area-\$exchange-\$subscriber"))
+        val result2 = one.toFormatted("5559938322:1:",
+            Element.CsvField("test", "\$country-\$area-\$exchange-\$subscriber"))
         assertEquals("1-555-993-8322", result2)
-        val result3 = one.toFormatted("5559938322:1:", Element.CsvField("test", "(\$area)\$exchange-\$subscriber"))
+        val result3 = one.toFormatted("5559938322:1:",
+            Element.CsvField("test", "(\$area)\$exchange-\$subscriber"))
         assertEquals("(555)993-8322", result3)
+    }
 
+    @Test
     fun `test toFormatted zip`() {
         val one = Element("a",
             type = Element.Type.POSTAL_CODE,
             csvFields = Element.csvFields("zip"))
         val result1 = one.toFormatted("99999")
         assertEquals("99999", result1)
-        val result2 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zipPlus4"))
+        val result1a = one.toFormatted("99999-9999")
+        assertEquals("99999-9999", result1a)
+        val result2 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zipFivePlusFour"))
         assertEquals("99999-9999", result2)
-        val result3 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zip"))
+        val result3 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zipFive"))
         assertEquals("99999", result3)
+        val result4 = one.toFormatted("999999999", Element.CsvField("zip", "\$zipFive"))
+        assertEquals("99999", result4)
+        val result5 = one.toFormatted("999999999", Element.CsvField("zip", "\$zipFivePlusFour"))
+        assertEquals("99999-9999", result5)
+        val result6 = one.toFormatted("99999", Element.CsvField("zip", "\$zipFivePlusFour"))
+        assertEquals("99999", result6)
+        val result7 = one.toFormatted("KY1-5555", Element.CsvField("zip", "\$zipFivePlusFour"))
+        assertEquals("KY1-5555", result7)
+        val result8 = one.toFormatted("XZ5555", Element.CsvField("zip", "\$zipFivePlusFour"))
+        assertEquals("XZ5555", result8)
     }
 }

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -3,6 +3,7 @@ package gov.cdc.prime.router
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertNotNull
 
 internal class ElementTests {
@@ -102,6 +103,23 @@ internal class ElementTests {
         val result2 = one.toFormatted("199803300000")
         assertEquals("199803300000", result2)
     }
+    
+    @Test
+    fun `test toNormalized zip`() {
+        val one = Element("a",
+            type = Element.Type.POSTAL_CODE,
+            csvFields = Element.csvFields("zip"))
+        val result1 = one.toNormalized("99999")
+        assertEquals("99999", result1)
+        val result2 = one.toNormalized("99999-9999")
+        assertEquals("99999-9999", result2)
+        // format should not affect normalization
+        val result4 = one.toNormalized("99999-9999", Element.CsvField("zip", "\$zip"))
+        assertEquals("99999-9999", result4)
+        assertFails {
+            val result5 = one.toNormalized("999999")
+        }
+    }
 
     @Test
     fun `test toNormalized phone`() {
@@ -136,5 +154,16 @@ internal class ElementTests {
         assertEquals("1-555-993-8322", result2)
         val result3 = one.toFormatted("5559938322:1:", Element.CsvField("test", "(\$area)\$exchange-\$subscriber"))
         assertEquals("(555)993-8322", result3)
+
+    fun `test toFormatted zip`() {
+        val one = Element("a",
+            type = Element.Type.POSTAL_CODE,
+            csvFields = Element.csvFields("zip"))
+        val result1 = one.toFormatted("99999")
+        assertEquals("99999", result1)
+        val result2 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zipPlus4"))
+        assertEquals("99999-9999", result2)
+        val result3 = one.toFormatted("99999-9999", Element.CsvField("zip", "\$zip"))
+        assertEquals("99999", result3)
     }
 }


### PR DESCRIPTION
This PR does adds formatting options for POSTAL_CODE types. 

## Changes
- 5 and 9 digit zipcode support
- Validation of zipcode on entry

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
