### PR TITLE
Threema for Pima Schema

### DIFF
--- a/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
@@ -40,14 +40,20 @@ elements:
     csvFields: [{name: Device_ID}]
 
   # Add'l field per request from the County
+  # TODO Badness: As items are added in prime-data-input-client/backend/src/main/resources/application.yaml,
+  #  we need to add them here.
   - name: device_type
     type: CODE
     mapper: use(standard.equipment_model_id)
     altValues:
       - display: Antigen
+        code: "BD Veritor System for Rapid Detection of SARS-CoV-2*"
+      - display: Molecular
+        code: ID Now
+      - display: Antigen
         code: BinaxNOW COVID-19 Ag Card
       - display: Antigen
-        code: LumiraDx SARS-CoV-2 Ag Test*
+        code: "LumiraDx SARS-CoV-2 Ag Test*"
       - display: Antigen
         code: Sofia 2 SARS Antigen FIA
     csvFields:

--- a/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
@@ -64,8 +64,14 @@ elements:
   - name: standard.test_result
     csvFields: [{name: Test_result_code}]
 
+  - name: standard.illness_onset_date
+    csvFields: [{name: Illness_onset_date}]
+
   - name: standard.specimen_collection_date_time
     csvFields: [{name: Specimen_collection_date_time}]
+
+  - name: standard.order_test_date
+    csvFields: [{name: Order_test_date}]
 
   - name: standard.test_result_date
     csvFields: [{name: Test_date, format: yyyyMMdd}]
@@ -105,6 +111,11 @@ elements:
 
   - name: standard.patient_county
     csvFields: [{name: Patient_county}]
+
+    # Eg, Staff, Resident, Visitor, Student
+  - name: patient_role
+    type: TEXT
+    csvFields: [{name: Patient_role}]
 
   - name: standard.employed_in_healthcare
     csvFields: [{name: Employed_in_healthcare}]

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -49,8 +49,14 @@ elements:
   - name: standard.test_result
     csvFields: [{name: Test_result_code}]
 
+  - name: standard.illness_onset_date
+    csvFields: [{name: Illness_onset_date}]
+
   - name: standard.specimen_collection_date_time
     csvFields: [{name: Specimen_collection_date_time}]
+
+  - name: standard.order_test_date
+    csvFields: [{name: Order_test_date}]
 
   - name: standard.test_result_date
     csvFields: [{name: Test_date, format: yyyyMMdd}]
@@ -90,6 +96,11 @@ elements:
 
   - name: standard.patient_county
     csvFields: [{name: Patient_county}]
+
+    # Eg, Staff, Resident, Visitor, Student
+  - name: patient_role
+    type: TEXT
+    csvFields: [{name: Patient_role}]
 
   - name: standard.employed_in_healthcare
     csvFields: [{name: Employed_in_healthcare}]

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -611,7 +611,7 @@ elements:
 
   - name: specimen_role
     type: CODE
-    valueSet: covid-19/specimen_role
+    valueSet: common/specimen_role
     natFlatFileField: Role
     hhsGuidanceField:
     hl7Field: SPM-11

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -796,8 +796,7 @@ elements:
 
   - name: testing_lab_clia
     type: ID_CLIA
-    # Dangerous Hack:  this default is the CLIA ID for Via Elegante, Tucson Mountains.  If another lab sends empty, it'll look like it came from Tucson Mountains!
-    default:  03D2159846
+    # Example: 03D2159846
     natFlatFileField: Testing_lab_id
     hhsGuidanceField:
     hl7Field: #OBX-23-10

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -222,7 +222,7 @@ class Report {
         }
 
         fun formFileName(id: ReportId, schemaName: String, fileFormat: OrganizationService.Format?, createdDateTime: OffsetDateTime): String {
-            val formatter = DateTimeFormatter.ofPattern("YYYYMMDDhhmmss")
+            val formatter = DateTimeFormatter.ofPattern("YYYYMMddHHmmss")
             val namePrefix = "${Schema.formBaseName(schemaName)}-${id}-${formatter.format(createdDateTime)}"
             val nameSuffix = fileFormat?.toExt() ?: OrganizationService.Format.CSV.toExt()
             return "$namePrefix.$nameSuffix"

--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -15,9 +15,8 @@ const val blobContainerName = "reports"
 
 class BlobAccess {
     fun uploadBody(report: Report): Pair<String, String> {
-        val blobFilename = createBodyFilename(report)
         val (bodyFormat, blobBytes) = createBodyBytes(report)
-        val blobUrl = uploadBlob(blobFilename, blobBytes)
+        val blobUrl = uploadBlob(report.name, blobBytes)
         return Pair(bodyFormat, blobUrl)
     }
 
@@ -28,10 +27,6 @@ class BlobAccess {
             OrganizationService.Format.CSV -> CsvConverter.write(report, outputStream)
         }
         return Pair(getBodyFormat(report).toString(), outputStream.toByteArray())
-    }
-
-    private fun createBodyFilename(report: Report): String {
-        return "${report.name}.${report.destination?.format?.toExt() ?: OrganizationService.Format.CSV.toExt()}"
     }
 
     private fun getBodyFormat(report: Report): OrganizationService.Format {


### PR DESCRIPTION
This PR adds the three additional columns expected by Pima.

## Changes
- Add three more columns: order_test_date, illness_onset_date, patient_role, to both PDI and Pima.
- Add in a few device_type SimpleReport might send us, to the Pima mapping.
- Fixed weirdness in our filename timestamps
- Fixed .csv.csv file extensions.

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Issue

- #104 

## To Be Done

- Consider having an optional ability to "just pass on the string as is" for CODE value mappings, in cases where the incoming value is missing from our tables.   Could do this for both code -> display and display -> code mappings.
