### PR TITLE
Fix FakeReport for Telephone types

### DIFF
--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -72,7 +72,7 @@ class FakeReport {
                         else -> TODO()
                     }
                 }
-                Element.Type.TELEPHONE -> faker.numerify("##########") // faker.phoneNumber().cellPhone()
+                Element.Type.TELEPHONE -> faker.numerify("##########:1:") // faker.phoneNumber().cellPhone()
                 Element.Type.EMAIL -> "${patientName.username()}@email.com"
                 null -> error("Invalid element type for ${element.name}")
             }

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -222,7 +222,7 @@ class Report {
         }
 
         fun formFileName(id: ReportId, schemaName: String, fileFormat: OrganizationService.Format?, createdDateTime: OffsetDateTime): String {
-            val formatter = DateTimeFormatter.ofPattern("YYYYMMDDhhmmss")
+            val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
             val namePrefix = "${Schema.formBaseName(schemaName)}-${id}-${formatter.format(createdDateTime)}"
             val nameSuffix = fileFormat?.toExt() ?: OrganizationService.Format.CSV.toExt()
             return "$namePrefix.$nameSuffix"

--- a/prime-router/src/test/kotlin/FakeReportTests.kt
+++ b/prime-router/src/test/kotlin/FakeReportTests.kt
@@ -2,6 +2,7 @@ package gov.cdc.prime.router
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 internal class FakeReportTests {
     @Test
@@ -12,5 +13,21 @@ internal class FakeReportTests {
                     ValueSet("fake", ValueSet.SetSystem.LOCAL, values = listOf(ValueSet.Value(code = "AZ")))
         )
         assertEquals("AZ", FakeReport.buildColumn(state) { valueSets[it] })
+    }
+
+    @Test
+    fun `test a coded fake telephone`() {
+        val phone = Element("standard.patient_state", type = Element.Type.TELEPHONE)
+        val fake = FakeReport.buildColumn(phone) { null }
+        val formatted = phone.toFormatted(fake, Element.CsvField("test", Element.defaultPhoneFormat))
+        assertEquals(10, formatted.length)
+    }
+
+    @Test
+    fun `test a bunch of fake fields`() {
+        Metadata.loadSchemaCatalog("./src/test/unit_test_files")
+        val schema = Metadata.findSchema("lab_test_results_schema") ?: fail("Should be have a schema")
+        val fakeReport = FakeReport.build(schema, 10, TestSource)
+        assertEquals(10, fakeReport.itemCount)
     }
 }


### PR DESCRIPTION
This PR does fixes a bug in the `FakeReport` module caused by the telephone normalization work that I did yesterday. 

## Changes
- FakeReport for the TELEPHONE type adds country code
- A couple of tests for FakeReport so this mistake cannot happen again
- Report.name gets the date right

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [x] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 


## To Be Done


