### PR TITLE
Fixed yet another az column to include organization_name

### DIFF
--- a/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
@@ -14,7 +14,9 @@ elements:
     csvFields:
     - name: Sending_Application_ID
 
-  - name: standard.testing_lab_name
+  # Nonstandard
+  - name: organization_and_lab
+    mapper: 'concat(organization_name, standard.testing_lab_name)'
     csvFields:
     - name: Lab_Name
 


### PR DESCRIPTION
Turns out there are two places in the AZ data that show Lab/Org/Facility names.


## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

