### PR TITLE
Fixed Patient_ID issue in AZ

### DIFF
--- a/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
@@ -139,7 +139,9 @@ elements:
   - name: standard.symptomatic_for_disease
     csvFields: [{name: Symptomatic_for_disease}]
 
-  - name: standard.testing_lab_name
+  # Nonstandard
+  - name: organization_and_lab
+    mapper: 'concat(organization_name, standard.testing_lab_name)'
     csvFields: [{name: Testing_lab_name}]
 
   - name: standard.testing_lab_clia

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -17,12 +17,12 @@ elements:
     csvFields: [{name: Patient_suffix}]
 
   # Patient ID is generated internally by SimpleReport
-  - name: simple_report_patient_id
+  - name: standard.patient_id
     type: TEXT
     csvFields: [{name: Patient_ID}]
 
   # In SimpleReport, lookup_id is the ID the user entered into the app.
-  - name: standard.patient_id
+  - name: patient_lookup_id
     csvFields: [{name: Patient_lookup_ID}]
 
   - name: standard.test_performed_code


### PR DESCRIPTION
This PR temporarily rolls back the Patient_ID change, while we work with SimpleReport on how best to do IDs. 

They are NOT currently sending a Patient_Lookup_ID

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


