### PR TITLE
Move ACR Push to Release Phase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,14 +50,4 @@ jobs:
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}:latest
-      
-      - name: Login to Azure CLI
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
         
-      - name: ACR Login
-        run: az acr login --name ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}
-          
-      - name : Push Docker Image
-        run: docker push ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
                then
                    echo "Deploying to the production environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-prod
+                   echo >> $GITHUB_ENV ACR_REPO=primedatahubprod.azurecr.io
                    echo >> $GITHUB_ENV AZ_FXNS_DEFAULT_KEY=${{ secrets.AZ_FXNS_PROD_DEFAULT_KEY }}
                    echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_PROD_USER }}
                    echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_PROD_PWD }}
@@ -23,6 +24,7 @@ jobs:
                else
                    echo "Deploying to the test environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-test
+                   echo >> $GITHUB_ENV ACR_REPO=primedatahubtest.azurecr.io
                    echo >> $GITHUB_ENV AZ_FXNS_DEFAULT_KEY=${{ secrets.AZ_FXNS_TEST_DEFAULT_KEY }}
                    echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_TEST_USER }}
                    echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_TEST_PWD }}
@@ -31,10 +33,35 @@ jobs:
                fi
                env
 
+      - name: Setup PostgreSQL
+        uses: Harmon758/postgresql-action@0be19fa37850b22cb4c9bbf28a03abbf44abd863
+        with:
+          postgresql version: 11
+          postgresql db: prime_data_hub
+          postgresql user: ${{ env.POSTGRESQL_USER }}
+          postgresql password: ${{ env.POSTGRESQL_PWD }}
+       
+      - name: Setup JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+           java-version: 11
+      
+      - name: Build Maven Package
+        run: mvn -B clean package --file pom.xml
+
+      - name: Build Docker Image
+        run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}:latest
+      
       - name: Login to Azure CLI
         uses: azure/login@v1
         with:
           creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
+        
+      - name: ACR Login
+        run: az acr login --name ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}
+          
+      - name : Push Docker Image
+        run: docker push ${{ env.ACR_REPO }}/${{ env.RESOURCE_GROUP }}:latest
 
       - name: Restart Azure Functions App
         run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.RESOURCE_GROUP }}


### PR DESCRIPTION
Due to limitations in passing a build artifact between workflows, I updated the CI/CD workflow to redo the build stage within the release workflow.  This will prevent and upstream PR from building and pushing a docker image that is not in sync with the one that is to be deployed by the release workflow as all are referencing the `latest` image tag.  This can be iterated upon, but for now this will avoid any unwanted by-products of multiple builds happening at the same time.