### PR TITLE
Data Source Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ hs_err_pid*
 # IDEA files
 **/.idea/**
 **/*.iml
+**/.run/**
 
 # Play files
 **/result_files/*.csv

--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -25,8 +25,8 @@
           numberPerDay: 1440 # Every minute
           initialBatch: 00:00
           timeZone: ARIZONA
-        transport:
-            type: SFTP
+        transports:
+          - type: SFTP
             host: sftp
             port: 22
             filePath: ./upload
@@ -76,8 +76,8 @@
          - "matches(ordering_facility_state, TX)"
          - "matches(processing_mode_code, T)"
         transforms: { deidentify: false }
-        transport:
-          type: SFTP
+        transports:
+        - type: SFTP
           host: sftp
           port: 22
           filePath: ./upload

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -27,8 +27,8 @@
           timeZone: ARIZONA
         address: http://localhost:1181/
         format: CSV
-        transport:
-          type: SFTP
+        transports:
+        - type: SFTP
           host: prime-data-hub-test.eastus.azurecontainer.io
           port: 22
           filePath: ./upload

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -25,6 +25,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.time.OffsetDateTime
 import java.util.UUID
+import javax.sql.DataSource
 
 const val databaseVariable = "POSTGRES_URL"
 const val userVariable = "POSTGRES_USER"
@@ -35,8 +36,9 @@ typealias DataAccessTransaction = Configuration
 /**
  * A data access layer for the database. Hides JOOQ, Hikari, JDBC and other low-level abstractions.
  */
-class DatabaseAccess(private val connection: Connection = getConnection()) {
-    private val create: DSLContext = DSL.using(connection, SQLDialect.POSTGRES)
+class DatabaseAccess(private val create: DSLContext) {
+    constructor(dataSource: DataSource) : this(DSL.using(dataSource, SQLDialect.POSTGRES))
+    constructor(connection: Connection) : this(DSL.using(connection, SQLDialect.POSTGRES))
 
     data class Header(val task: Task, val sources: List<TaskSource>)
 
@@ -243,9 +245,7 @@ class DatabaseAccess(private val connection: Connection = getConnection()) {
             dataSource
         }
 
-        fun getConnection(): Connection {
-            return hikariDataSource.connection
-        }
+        public val dataSource: DataSource get() = hikariDataSource
 
         fun toSource(taskSource: TaskSource): Source {
             return when {

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -23,7 +23,7 @@ class WorkflowEngine(
     val csvConverter: CsvConverter = WorkflowEngine.csvConverter,
     val translator: Translator = Translator(metadata),
     // New connection for every function
-    val db: DatabaseAccess = DatabaseAccess(connection = DatabaseAccess.getConnection()),
+    val db: DatabaseAccess = DatabaseAccess(dataSource = DatabaseAccess.dataSource),
     val blob: BlobAccess = BlobAccess(csvConverter, hl7Converter),
     val queue: QueueAccess = QueueAccess(),
 ) {

--- a/prime-router/src/scripts/loop.sh
+++ b/prime-router/src/scripts/loop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in $(seq 1000)
+do
+    curl -X POST -H "Content-Type:text/csv"  --data-binary @result_files/fake-pdi-covid-19.csv 'http://localhost:7071/api/reports?client=simple_report'
+    echo "Post $i times"
+    sleep .5
+done


### PR DESCRIPTION
This PR fixes a problem where the database connections would become exhausted in Azure. 

## Problem Description

This problem was found in production and reproduced locally. My local build would exhaust after 10 successful requests. The connection pool was also set to a connection size of 10 — more than a coincidence.  The code was not releasing database connections as expected. The fix was to switch Jooq to use a data source provider. Data sources are what is used if you have a connection pool. The fix was tested by posting 1000 times to my local instance. 

## Changes
- Use a data-source configuration in Jooq
- Fixed organization-local.yml to support the new multi-transport

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [x] Added a test?
- [ ] Did you check for sensitive data and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

