### PR TITLE
Record the receiving of a report

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -77,6 +77,7 @@ class ReportFunction {
                 }
             }
             context.logger.info("Successfully reported: ${validatedRequest.report!!.id}.")
+            workflowEngine.receiveReport(validatedRequest.report)
             val destinations = mutableListOf<String>()
             routeReport(context, workflowEngine, validatedRequest, destinations)
             return createdResponse(request, validatedRequest, destinations)

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -36,6 +36,21 @@ class WorkflowEngine(
     }
 
     /**
+     * Receive a report.
+     */
+    fun receiveReport(report: Report, txn: Configuration? = null) {
+        val (bodyFormat, bodyUrl) = blob.uploadBody(report)
+        try {
+            val action = ReportEvent(Event.Action.NONE, report.id)
+            db.insertHeader(report, bodyFormat, bodyUrl, action, txn)
+        } catch (e: Exception) {
+            // Clean up
+            blob.deleteBlob(bodyUrl)
+            throw e
+        }
+    }
+
+    /**
      * Place a report into the workflow
      */
     fun dispatchReport(nextAction: Event, report: Report, txn: Configuration? = null) {


### PR DESCRIPTION
This PR makes the report end-point save the received report as well as translating and routing the report to destinations. Keeping the received report around is a safety measure. Note: the current prod deployment keeps received reports, but it is running old code. The recording of received reports was lost in a recent rework of the report end-point function. 

## Changes
- receiveReport method for the WorkflowEngine 
- Tests

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [x] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


