### PR TITLE
Remove Setting Fxn App Keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,24 +74,6 @@ jobs:
       - name: Restart Azure Functions App
         run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.RESOURCE_GROUP }}
 
-      - name: Set Azure Function Default Key
-        run: |
-              az functionapp function keys set \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name ${{ env.RESOURCE_GROUP }} \
-              --function-name reports \
-              --key-name default \
-              --key-value ${{ env.AZ_FXNS_DEFAULT_KEY }}
-
-      - name: Set Azure Function SimpleReport Key
-        run: |
-              az functionapp function keys set \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name ${{ env.RESOURCE_GROUP }} \
-              --function-name reports \
-              --key-name SimpleReport \
-              --key-value ${{ env.AZ_FXNS_SIMPLEREPORT_KEY }}
-
       - name: Set PostgreSQL Environment Variables
         run: | 
               az functionapp config appsettings set \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
                    echo "Deploying to the production environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-prod
                    echo >> $GITHUB_ENV ACR_REPO=primedatahubprod.azurecr.io
-                   echo >> $GITHUB_ENV AZ_FXNS_DEFAULT_KEY=${{ secrets.AZ_FXNS_PROD_DEFAULT_KEY }}
-                   echo >> $GITHUB_ENV AZ_FXNS_SIMPLEREPORT_KEY=${{ secrets.AZ_FXNS_PROD_SIMPLEREPORT_KEY }}
                    echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_PROD_USER }}
                    echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_PROD_PWD }}
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=prod
@@ -32,8 +30,6 @@ jobs:
                    echo "Deploying to the test environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-test
                    echo >> $GITHUB_ENV ACR_REPO=primedatahubtest.azurecr.io
-                   echo >> $GITHUB_ENV AZ_FXNS_DEFAULT_KEY=${{ secrets.AZ_FXNS_TEST_DEFAULT_KEY }}
-                   echo >> $GITHUB_ENV AZ_FXNS_SIMPLEREPORT_KEY=${{ secrets.AZ_FXNS_TEST_SIMPLEREPORT_KEY }}
                    echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_TEST_USER }}
                    echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_TEST_PWD }}
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=test


### PR DESCRIPTION
Setting the function app keys is now removed.  This will cause the occasional failure if the function app does not restart quickly enough.  Since a restart does not destroy the keys - they do not need to be set with each deploy.  Instead, they can be managed via the Azure portal.