### PR TITLE
Jurisdictional filters to handle STRAC

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -83,6 +83,7 @@
         jurisdictionalFilter: [ "matches(ordering_facility_state, CO)" ]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: T
           redox_destination_id: 62d62d52-3771-4151-aff4-4a3d420a8b7a
           redox_destination_name: "Colorado Dept of Public Health (CDPHE)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
@@ -133,6 +134,7 @@
         jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: T
           redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
           redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -86,12 +86,13 @@
   - name: co-phd
     description: Colorado Department of Health
     services:
-      - name: elr-redox-debug
+      - name: elr-redox-staging
         topic: covid-19
         schema: co/co-covid-19-redox
         jurisdictionalFilter: [ "matches(ordering_facility_state, CO)" ]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: T
           redox_destination_id: 62d62d52-3771-4151-aff4-4a3d420a8b7a
           redox_destination_name: "Colorado Dept of Public Health (CDPHE)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
@@ -107,6 +108,7 @@
         jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: T
           redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
           redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928

--- a/prime-router/metadata/organizations.yml
+++ b/prime-router/metadata/organizations.yml
@@ -102,12 +102,6 @@
   - name: pa-phd
     description: Pennsylvania Department of Health
     services:
-      - name: elr-hl7-debug
-        topic: covid-19
-        schema: pa/pa-covid-19-hl7
-        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
-        transforms: { deidentify: false }
-        format: HL7
       - name: elr-redox-debug
         topic: covid-19
         schema: pa/pa-covid-19-redox

--- a/prime-router/metadata/schemas/covid-19-redox.schema
+++ b/prime-router/metadata/schemas/covid-19-redox.schema
@@ -17,14 +17,18 @@ elements:
   - name: redox_destination_name
     redoxOutputFields: ["Meta.Destinations[0].Name"]
 
-  - name: redox_processing_mode_code
+  - name: processing_mode_code
     redoxOutputFields: ["Meta.Test"]
     type: CODE
     valueSet: hl70103
     default: T
     altValues:
+      - code: D
+        display: true
       - code: T
         display: true
+      - code: P
+        display: false
 
   - name: patient_id
     redoxOutputFields: ["Patient.Identifiers[0].ID"]

--- a/prime-router/src/main/kotlin/Translator.kt
+++ b/prime-router/src/main/kotlin/Translator.kt
@@ -61,6 +61,9 @@ class Translator(private val metadata: Metadata) {
         }
         val filteredReport = input.filter(filterAndArgs)
 
+        // Always succeed in translating an empty report after filtering (even if the mapping process would fail)
+        if (filteredReport.isEmpty()) return buildEmptyReport(receiver, input)
+
         // Apply mapping to change schema
         val toReport: Report = if (receiver.schema != filteredReport.schema.name) {
             val toSchema = metadata.findSchema(receiver.schema)
@@ -128,5 +131,11 @@ class Translator(private val metadata: Metadata) {
             }
         }
         return Mapping(toSchema, fromSchema, useDirectly, useValueSet, useMapper, useDefault, missing)
+    }
+
+    private fun buildEmptyReport(receiver: OrganizationService, from: Report): Report {
+        val toSchema = metadata.findSchema(receiver.schema)
+            ?: error("${receiver.schema} schema is missing from catalog")
+        return Report(toSchema, emptyList(), listOf(ReportSource(from.id, "mapping")))
     }
 }

--- a/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
+++ b/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
@@ -5,6 +5,7 @@ import tech.tablesaw.api.Table
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertTrue
 
 class JurisdictionalFilterTests {
     @Test
@@ -27,6 +28,18 @@ class JurisdictionalFilterTests {
         assertEquals(2, filteredTable2.rowCount())
         assertEquals("B1", filteredTable2.getString(0, "colB"))
         assertEquals("B2", filteredTable2.getString(1, "colB"))
+    }
+
+    @Test
+    fun `test empty Matches`() {
+        val filter = Matches()
+        val table = Table.create(
+            StringColumn.create("BOGUS"),
+        )
+
+        val args1 = listOf("a", "b") // correct # args.
+        // However, table doesn't have the expected columns, so an empty selection
+        assertTrue(filter.getSelection(args1, table).isEmpty)
     }
 
     @Test


### PR DESCRIPTION
This PR improves the edge condition handling of the Jurisdictional Filters. These changes were needed for the STRAC application which has a different schema than SimpleReport. 

Our current jurisdictional filters work for SimpleReport's schema, but we need to make them work for the STRAC schema. The STRAC schema doesn't have the same elements as SR. In particular, elements in filters like `ordering_facility_county` are missing. This is not a problem, because the STRAC report only goes to PA. 

## Changes
- Jurisdictional filters handle the case where the element being matched is not in the input schema.  
- Translation functions always succeed with empty report input. 

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [X] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## To Be Done

- #issue 

