### PR TITLE
PA and STRAC changes

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -142,15 +142,47 @@
   - name: pa-phd
     description: Pennsylvania Department of Health
     services:
-      - name: elr-redox-debug
+      - name: elr-bucks-local
         topic: covid-19
         schema: pa/pa-covid-19-redox
-        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
+        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
         transforms: { deidentify: false }
         defaults:
           processing_mode_code: T
-          redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
-          redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
+          redox_destination_id: e0d33443-c134-4e5f-9c15-69f9ba6340bf
+          redox_destination_name: "CDC Bucks County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: some_key
+            baseUrl: http://redox:1080
+      - name: elr-chester-local
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 86aa61ac-8864-417f-860e-d83ae46c951f
+          redox_destination_name: "CDC Chester County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: some_key
+            baseUrl: http://redox:1080
+      - name: elr-chester-local
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
+          redox_destination_name: "CDC Montgomery County PDH Destination (s)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX

--- a/prime-router/metadata/organizations-prod.yml
+++ b/prime-router/metadata/organizations-prod.yml
@@ -97,21 +97,51 @@
         transforms: { deidentify: false }
         format: CSV
 
-#  When PA gives use a prod
 #  - name: pa-phd
 #    description: Pennsylvania Department of Health
 #    services:
-#      - name: elr-redox-prod
+#      - name: elr-bucks-staging
 #        topic: covid-19
 #        schema: pa/pa-covid-19-redox
-#        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
+#        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
 #        transforms: { deidentify: false }
 #        defaults:
-#          redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
-#          redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
+#          processing_mode_code: T
+#          redox_destination_id: e0d33443-c134-4e5f-9c15-69f9ba6340bf
+#          redox_destination_name: "CDC Bucks County PDH Destination (s)"
 #          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
 #          redox_source_name: "Prime Data Hub (Staging)"
 #        format: REDOX
 #        transports:
 #          - type: REDOX
-#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox prod
+#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
+#      - name: elr-chester-staging
+#        topic: covid-19
+#        schema: pa/pa-covid-19-redox
+#        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
+#        transforms: { deidentify: false }
+#        defaults:
+#          processing_mode_code: T
+#          redox_destination_id: 86aa61ac-8864-417f-860e-d83ae46c951f
+#          redox_destination_name: "CDC Chester County PDH Destination (s)"
+#          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+#          redox_source_name: "Prime Data Hub (Staging)"
+#        format: REDOX
+#        transports:
+#          - type: REDOX
+#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
+#      - name: elr-chester-staging
+#        topic: covid-19
+#        schema: pa/pa-covid-19-redox
+#        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
+#        transforms: { deidentify: false }
+#        defaults:
+#          processing_mode_code: T
+#          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
+#          redox_destination_name: "CDC Montgomery County PDH Destination (s)"
+#          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+#          redox_source_name: "Prime Data Hub (Staging)"
+#        format: REDOX
+#        transports:
+#          - type: REDOX
+#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -116,15 +116,45 @@
   - name: pa-phd
     description: Pennsylvania Department of Health
     services:
-      - name: elr-redox-staging
+      - name: elr-bucks-staging
         topic: covid-19
         schema: pa/pa-covid-19-redox
-        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
+        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
         transforms: { deidentify: false }
         defaults:
           processing_mode_code: T
-          redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
-          redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
+          redox_destination_id: e0d33443-c134-4e5f-9c15-69f9ba6340bf
+          redox_destination_name: "CDC Bucks County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging
+      - name: elr-chester-staging
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 86aa61ac-8864-417f-860e-d83ae46c951f
+          redox_destination_name: "CDC Chester County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging
+      - name: elr-chester-staging
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
+          redox_destination_name: "CDC Montgomery County PDH Destination (s)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX

--- a/prime-router/metadata/organizations.yml
+++ b/prime-router/metadata/organizations.yml
@@ -110,14 +110,39 @@
   - name: pa-phd
     description: Pennsylvania Department of Health
     services:
-      - name: elr-redox-debug
+      - name: elr-bucks-debug
         topic: covid-19
         schema: pa/pa-covid-19-redox
-        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)"]
+        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
         transforms: { deidentify: false }
         defaults:
-          redox_destination_id: cd019512-8a58-40e5-a416-4e597404f9b8
-          redox_destination_name: "CDC Pennsylvania Dept of Health Destination (s)"
+          processing_mode_code: T
+          redox_destination_id: e0d33443-c134-4e5f-9c15-69f9ba6340bf
+          redox_destination_name: "CDC Bucks County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+      - name: elr-chester-debug
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 86aa61ac-8864-417f-860e-d83ae46c951f
+          redox_destination_name: "CDC Chester County PDH Destination (s)"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+      - name: elr-chester-debug
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
+          redox_destination_name: "CDC Montgomery County PDH Destination (s)"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX

--- a/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
@@ -4,3 +4,7 @@ description: Pennsylvania Department of Health REDOX messages
 referenceUrl:
 topic: covid-19
 extends: covid-19-redox
+elements:
+  # override the default cardinality: The CLIA is held by the county.
+  - name: testing_lab_clia
+    cardinality: ZERO_OR_ONE

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -18,7 +18,8 @@ elements:
   - name: ordering_facility_name
     csvFields: [{name: Ordering_Facility_Name}]
 
-  - name: ordering_facility_phone_number
+  # Yes, PA wants the facility phone number mapped to provider
+  - name: ordering_provider_phone_number
     csvFields: [{name: Ordering_Facility_Phone_Number}]
 
   - name: ordering_facility_street
@@ -42,11 +43,11 @@ elements:
   - name: ordering_provider_zip_code
     csvFields: [{name: Ordering_Provider_ZIP, format: $zipFive}]
 
-  - name: strac_id
+  - name: placer_order_id
     type: ID
     csvFields: [{name: id}]
 
-  - name: strac_kit_id
+  - name: filler_order_id
     type: ID
     csvFields: [{name: kit_id}]
 
@@ -148,13 +149,10 @@ elements:
   - name: specimen_received_date_time
     mapper: use(strac_patient_appt_datetime)
 
-  - name: testing_lab_clia
-    mapper: use(reporting_facility_clia)
-
-  - name: testing_lab_name
-    mapper: use(reporting_facility_name)
-
   - name: abnormal_flag
 
   - name: test_result_status
     default: F
+
+  - name: testing_lab_name
+    mapper: use(ordering_facility_name)

--- a/prime-router/metadata/schemas/covid-19-redox.schema
+++ b/prime-router/metadata/schemas/covid-19-redox.schema
@@ -121,6 +121,11 @@ elements:
   - name: patient_email
     redoxOutputFields: ["Patient.Demographics.EmailAddresses"]
 
+
+  # The Placer is the person or service that requests or places the order for an observation. Examples of placers include the physician, the practice, clinic, or ward service, that orders a lab test, X-ray, vital signs.
+  - name: placer_order_id
+    redoxOutputFields: [ "Orders[0].ID" ]
+
   - name: ordering_facility_name
     redoxOutputFields: ["Orders[0].Extensions.ordering-facility-name.string"]
 
@@ -143,13 +148,16 @@ elements:
     redoxOutputFields: ["Orders[0].Extensions.ordering-facility-address.address.country"]
 
   - name: ordering_facility_phone_number
+    cardinality: ZERO_OR_ONE
 
   - name: ordering_facility_email
+    cardinality: ZERO_OR_ONE
 
   - name: order_test_date
     redoxOutputFields: ["Orders[0].Extensions.ordered-date-time.dateTime"]
 
-  - name: placer_order_id
+  # The Filler (aka Producer) is the person, or service, who produces the observations (fills the order) requested by the requestor.
+  - name: filler_order_id
     redoxOutputFields: ["Orders[0].ApplicationOrderID"]
 
   - name: specimen_received_date_time
@@ -260,7 +268,7 @@ elements:
     redoxOutputFields: [ "Orders[0].Results[0].Producer.ID" ]
 
   - name: redox_test_lab_id_type
-    default: "CLIA"
+    mapper: ifPresent(testing_lab_clia, CLIA)
     redoxOutputFields: [ "Orders[0].Results[0].Producer.IDType" ]
 
   - name: testing_lab_name

--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -16,10 +16,10 @@ class FakeReport(val metadata: Metadata) {
 
         val state = reportState ?: randomChoice("FL", "PA", "TX", "AZ", "CO")
         val county = findLookupTable("fips-county")?.let {
-            if (state == "AZ") {
-                randomChoice("Pima", "Yuma")
-            } else {
-                randomChoice(it.filter("State", state, "County"))
+            when (state) {
+                "AZ" -> randomChoice("Pima", "Yuma")
+                "PA" -> randomChoice("Bucks", "Chester", "Montgomery")
+                else -> randomChoice(it.filter("State", state, "County"))
             }
         }
     }

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -223,7 +223,8 @@ class RouterCli : CliktCommand(
                 FakeReport(metadata).build(
                     schema,
                     (inputSource as InputSource.FakeSource).count,
-                    FileSource("fake")
+                    FileSource("fake"),
+                    targetState
                 )
             }
             else -> {

--- a/prime-router/src/main/resources/log4j2.xml
+++ b/prime-router/src/main/resources/log4j2.xml
@@ -9,6 +9,8 @@
         <!-- Uncomment to get SQL statements logged from JOOQ -->
         <!-- <Logger name="org.jooq.tools.LoggerListener" level="debug"></Logger> -->
 
+        <Logger name="gov.cdc.prime.router.transport.RedoxTransport" level="info"></Logger>
+
         <Root level="WARN">
             <AppenderRef ref="Console"/>
         </Root>


### PR DESCRIPTION
This PR supports the changes requested by PA as well as the changes requested by Redox

## Changes
- One destination per PA county. Initially provisioning 3 counties. 
- STRAC's ID and KIT ID mapped placer and filler order number
- Filling the producer field with the school name
- Better logging in the Redox transport functions. 

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## To Be Done

- There is an issue on how to report the County PHD CLIA that is being resolved by Redox

