### PR TITLE
Fixed hardcoded .csv extension in sftp send.   Added a bunch of logging

### DIFF
--- a/prime-router/src/main/kotlin/transport/ITransport.kt
+++ b/prime-router/src/main/kotlin/transport/ITransport.kt
@@ -1,5 +1,7 @@
 package gov.cdc.prime.router.transport
 
+import com.microsoft.azure.functions.ExecutionContext
+import gov.cdc.prime.router.OrganizationService
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.TransportType
 
@@ -7,7 +9,7 @@ interface ITransport {
     /**
      * Send the content on the specific transport. Return retry information, if needed. Null, if not.
      *
-     * @param orgName the service name that is being sent.
+     * @param orgService obj representing the organization and service to send to.
      * @param transportType the type of the transport (should always match the class)
      * @param contents being sent
      * @param reportId from which the byte array sends
@@ -15,10 +17,11 @@ interface ITransport {
      * @return null, if successful. RetryItems if not successful.
      */
     fun send(
-        orgName: String,
+        orgService: OrganizationService,
         transportType: TransportType,
         contents: ByteArray,
         reportId: ReportId,
         retryItems: RetryItems?,
+        context: ExecutionContext,
     ): RetryItems?
 }

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -1,5 +1,7 @@
 package gov.cdc.prime.router.transport
 
+import com.microsoft.azure.functions.ExecutionContext
+import gov.cdc.prime.router.OrganizationService
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.SFTPTransportType
 import gov.cdc.prime.router.TransportType
@@ -8,27 +10,31 @@ import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.xfer.InMemorySourceFile
 import java.io.IOException
 import java.io.InputStream
+import java.util.logging.Level
 
 class SftpTransport : ITransport {
     override fun send(
-        orgName: String,
+        orgService: OrganizationService,
         transportType: TransportType,
         contents: ByteArray,
         reportId: ReportId,
-        retryItems: RetryItems?
+        retryItems: RetryItems?,
+        context: ExecutionContext
     ): RetryItems? {
+        val sftpTransportType = transportType as SFTPTransportType
+        val host: String = sftpTransportType.host
+        val port: String = sftpTransportType.port
         return try {
-            val sftpTransportType = transportType as SFTPTransportType
+            val (user, pass) = lookupCredentials(orgService.fullName)
+            val extension = orgService.format.toExt()
+            val fileName = "${orgService.fullName.replace('.', '-')}-$reportId.$extension"
 
-            val (user, pass) = lookupCredentials(orgName)
-
-            val fileName = "${orgName.replace('.', '-')}-$reportId.csv"
-            val host: String = sftpTransportType.host
-            val port: String = sftpTransportType.port
-
+            context.logger.log(Level.INFO, "About to sftp upload $fileName to $user at $host:$port (orgService = ${orgService.fullName})")
             uploadFile(host, port, user, pass, sftpTransportType.filePath, fileName, contents)
+            context.logger.log(Level.INFO, "Successful sftp upload of $fileName")
             null
         } catch (ioException: IOException) {
+            context.logger.log(Level.WARNING, "FAILED Sftp upload of reportId $reportId to $host:$port  (orgService = ${orgService.fullName})\"")
             RetryToken.allItems
         } // let non-IO exceptions be caught by the caller
     }

--- a/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
@@ -77,7 +77,7 @@ class SendFunctionTests {
             nextEvent = block(header, null, null)
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any()) }.returns(null)
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any()) }.returns(null)
 
         // Invoke
         val event = ReportEvent(Event.Action.SEND, reportId)
@@ -99,7 +99,7 @@ class SendFunctionTests {
             nextEvent = block(header, null, null)
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
 
         // Invoke
         val event = ReportEvent(Event.Action.SEND, reportId)
@@ -124,7 +124,7 @@ class SendFunctionTests {
             nextEvent = block(header, RetryToken(2, listOf(RetryTransport(0, RetryToken.allItems))), null)
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
 
         // Invoke
         val event = ReportEvent(Event.Action.SEND, reportId)
@@ -154,7 +154,7 @@ class SendFunctionTests {
             nextEvent = block(header, RetryToken(100, listOf(RetryTransport(0, RetryToken.allItems))), null)
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any()) }.returns(RetryToken.allItems)
 
         // Invoke
         val event = ReportEvent(Event.Action.SEND, reportId)


### PR DESCRIPTION
This PR fixes a problem that the .csv extension was hardcoded in sftp send.  Also added logging to better see failures.   This is all part of getting ready to send hl7 data to AZ.    (This release also includes Redox send for the first time.)

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

