### PR TITLE
Actually connect to DB when checking connections

### DIFF
--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -44,7 +44,7 @@ class DatabaseAccess(private val create: DSLContext) {
     data class Header(val task: Task, val sources: List<TaskSource>)
 
     fun checkConnection() {
-        create.selectFrom(TASK).where(TASK.REPORT_ID.eq(UUID.randomUUID()))
+        create.selectFrom(TASK).where(TASK.REPORT_ID.eq(UUID.randomUUID())).fetch()
     }
 
     /**


### PR DESCRIPTION
👋 Howdy, this is my first PR for this project. This is a pretty small fix for an issue I noticed while first getting the application running.

If you check connections by requesting `POST /api/reports?option=CheckConnections`, the response is an error if the database is down and the application has never connected to it before, but it *succeeds* if the database has gone down *after* the application has previously connected to it.

This resolves the issue by making sure we actually try to transact with the database when checking its connection.

To reproduce:
1. Start Postgres
2. Start application
3. Request `POST /api/reports?option=CheckConnections`. You should receive a 200 response.
4. Stop Postgres
5. Request `POST /api/reports?option=CheckConnections`. Before applying this patch, you should receive a 200 response. After applying, you should receive a 500 response.

I’m not sure how to effectively write a test for this; if anyone has advice on how to do so, I’m happy to add one.

(Apologies for not submitting this as an issue first, but it seemed so small that it wouldn’t be worthwhile. Please let me know if you’d rather I do so for similar things in the future!)

## Checklist
- [x] Tested locally?
- [x] Added new dependencies? (No)
- [x] Updated the docs? (N/A)
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [x] Are there potential vulnerabilities or licensing issues with any new dependencies introduced? (N/A)