### PR TITLE
Make actions work for external PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,18 @@ jobs:
 
       - name: Set Environment Variables
         run: |
+               echo >> $GITHUB_ENV POSTGRES_USER='prime'
+               echo >> $GITHUB_ENV POSTGRES_PASSWORD='changeIT!'
+               
                if [ "$GITHUB_BASE_REF" == "production" ]
                then
                    echo "Building for the production environment."
                    echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhprod
-                   echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_PROD_USER }}
-                   echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
                    echo "Building for the test environment."
                    echo >> $GITHUB_ENV ACR_REPO=pdhtestcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhtest
-                   echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_TEST_USER }}
-                   echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_TEST_PWD }}
                fi
 
       - name: Setup PostgreSQL
@@ -38,8 +37,8 @@ jobs:
         with:
           postgresql version: 11
           postgresql db: prime_data_hub
-          postgresql user: ${{ env.POSTGRESQL_USER }}
-          postgresql password: ${{ env.POSTGRESQL_PWD }}
+          postgresql user: ${{ env.POSTGRES_USER }}
+          postgresql password: ${{ env.POSTGRES_PASSWORD }}
        
       - name: Setup JDK
         uses: actions/setup-java@v1.4.3
@@ -47,7 +46,7 @@ jobs:
            java-version: 11
       
       - name: Build Maven Package
-        run: mvn -B clean package --file pom.xml
+        run: mvn -B clean package --file pom.xml -Dpg.user=$POSTGRES_USER -Dpg.password=$POSTGRES_PASSWORD
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ defaults:
 
 jobs:
   build:
+    # Do not run on PRs from forks to prevent workflow abuse.
+    # NOTE: changing this condition *may* require adjusting secrets usage in
+    # the workflow steps below.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
@@ -18,18 +21,19 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-               echo >> $GITHUB_ENV POSTGRES_USER='prime'
-               echo >> $GITHUB_ENV POSTGRES_PASSWORD='changeIT!'
-               
                if [ "$GITHUB_BASE_REF" == "production" ]
                then
                    echo "Building for the production environment."
                    echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhprod
+                   echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_PROD_USER }}
+                   echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
                    echo "Building for the test environment."
                    echo >> $GITHUB_ENV ACR_REPO=pdhtestcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhtest
+                   echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_TEST_USER }}
+                   echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_TEST_PWD }}
                fi
 
       - name: Setup PostgreSQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,15 @@ jobs:
       
       - name: Set Environment Variables
         run: |
+               echo >> $GITHUB_ENV POSTGRES_USER='prime'
+               echo >> $GITHUB_ENV POSTGRES_PASSWORD='changeIT!'
+
                if [ "$GITHUB_REF" == "refs/heads/production" ]
                then
                    echo "Deploying to the production environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-prod
                    echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhprod
-                   echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_PROD_USER }}
-                   echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_PROD_PWD }}
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=prod
                    echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_PROD_CREDS }}
                    echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_PROD_SECRET }}
@@ -33,8 +34,6 @@ jobs:
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-test
                    echo >> $GITHUB_ENV ACR_REPO=pdhtestcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhtest
-                   echo >> $GITHUB_ENV POSTGRESQL_USER=${{ secrets.POSTGRESQL_TEST_USER }}
-                   echo >> $GITHUB_ENV POSTGRESQL_PWD=${{ secrets.POSTGRESQL_TEST_PWD }}
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=test
                    echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_TEST_CREDS }}
                    echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_STAGING_SECRET }}
@@ -46,8 +45,8 @@ jobs:
         with:
           postgresql version: 11
           postgresql db: prime_data_hub
-          postgresql user: ${{ env.POSTGRESQL_USER }}
-          postgresql password: ${{ env.POSTGRESQL_PWD }}
+          postgresql user: ${{ env.POSTGRES_USER }}
+          postgresql password: ${{ env.POSTGRES_PASSWORD }}
        
       - name: Setup JDK
         uses: actions/setup-java@v1.4.3
@@ -55,7 +54,7 @@ jobs:
            java-version: 11
       
       - name: Build Maven Package
-        run: mvn -B clean package --file pom.xml
+        run: mvn -B clean package --file pom.xml -Dpg.user=$POSTGRES_USER -Dpg.password=$POSTGRES_PASSWORD
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
       
       - name: Set Environment Variables
         run: |
-               echo >> $GITHUB_ENV POSTGRES_USER='prime'
-               echo >> $GITHUB_ENV POSTGRES_PASSWORD='changeIT!'
-
                if [ "$GITHUB_REF" == "refs/heads/production" ]
                then
                    echo "Deploying to the production environment."
@@ -29,6 +26,8 @@ jobs:
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=prod
                    echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_PROD_CREDS }}
                    echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_PROD_SECRET }}
+                   echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_PROD_USER }}
+                   echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
                    echo "Deploying to the test environment."
                    echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-test
@@ -37,6 +36,8 @@ jobs:
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=test
                    echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_TEST_CREDS }}
                    echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_STAGING_SECRET }}
+                   echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_TEST_USER }}
+                   echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_TEST_PWD }}
                fi
                env
 

--- a/prime-router/pom.xml
+++ b/prime-router/pom.xml
@@ -36,9 +36,9 @@
         <!-- Define skip flags with common defaults for developers. -->
         <package.skip.azure>false</package.skip.azure>
         <package.skip.cli>true</package.skip.cli>
-        <flyway.user>prime</flyway.user>
-        <flyway.password>changeIT!</flyway.password>
-        <flyway.url>jdbc:postgresql://localhost:5432/prime_data_hub</flyway.url>
+        <pg.user>prime</pg.user>
+        <pg.password>changeIT!</pg.password>
+        <pg.url>jdbc:postgresql://localhost:5432/prime_data_hub</pg.url>
     </properties>
 
     <repositories>
@@ -273,9 +273,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <url>${flyway.url}</url>
-                    <user>${flyway.user}</user>
-                    <password>${flyway.password}</password>
+                    <url>${pg.url}</url>
+                    <user>${pg.user}</user>
+                    <password>${pg.password}</password>
                 </configuration>
             </plugin>
             <plugin>
@@ -295,9 +295,9 @@
                 <configuration>
                     <jdbc>
                         <driver>org.postgresql.Driver</driver>
-                        <url>jdbc:postgresql://127.0.0.1:5432/prime_data_hub</url>
-                        <user>prime</user>
-                        <password>changeIT!</password>
+                        <url>${pg.url}</url>
+                        <user>${pg.user}</user>
+                        <password>${pg.password}</password>
                     </jdbc>
                     <generator>
                         <database>


### PR DESCRIPTION
This is an example of a solution for the build issues in https://github.com/CDCgov/prime-data-hub/pull/262#issuecomment-757544632. It’s mainly meant to illustrate the suggested changes, but could also be merged as a complete fix.

The current GitHub Actions workflows depend on secret values that are not available to external PRs, causing them to always fail on PRs from forks. This is real barrier for non-CDC/USDS folks wanting to contribute to the project.

This change attempts to fix the issue by no longer using secrets for database configuration in workflows. These secrets weren't actually sensitive values or used outside the workflow environment to begin with, so it's fairly safe, and makes understanding configuration simpler. This also removes some duplicate database configuration and makes that configuration settable via environment variables in `pom.xml` by using properties for configuring both Flyway and JDBC.

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?