### PR TITLE
Bug Fix: Chester and Montgomery County

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -174,7 +174,7 @@
           - type: REDOX
             apiKey: some_key
             baseUrl: http://redox:1080
-      - name: elr-chester-local
+      - name: elr-montgomery-local
         topic: covid-19
         schema: pa/pa-covid-19-redox
         jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]

--- a/prime-router/metadata/organizations-prod.yml
+++ b/prime-router/metadata/organizations-prod.yml
@@ -130,7 +130,7 @@
 #        transports:
 #          - type: REDOX
 #            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
-#      - name: elr-chester-staging
+#      - name: elr-montgomery-staging
 #        topic: covid-19
 #        schema: pa/pa-covid-19-redox
 #        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -146,7 +146,7 @@
         transports:
           - type: REDOX
             apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging
-      - name: elr-chester-staging
+      - name: elr-montgomery-staging
         topic: covid-19
         schema: pa/pa-covid-19-redox
         jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]

--- a/prime-router/metadata/organizations.yml
+++ b/prime-router/metadata/organizations.yml
@@ -134,7 +134,7 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-      - name: elr-chester-debug
+      - name: elr-montgomery-debug
         topic: covid-19
         schema: pa/pa-covid-19-redox
         jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]

--- a/prime-router/src/main/kotlin/Metadata.kt
+++ b/prime-router/src/main/kotlin/Metadata.kt
@@ -285,14 +285,28 @@ class Metadata {
     }
 
     fun loadOrganizationList(organizations: List<Organization>): Metadata {
-        this.organizationStore = organizations
-        this.organizationClientStore = organizations.flatMap { it.clients }
-        this.organizationServiceStore = organizations.flatMap { it.services }
+        organizationStore = organizations
+        organizationClientStore = organizations.flatMap { it.clients }
+        organizationServiceStore = organizations.flatMap { it.services }
         // Check values
-        this.organizationServiceStore.forEach { service ->
+        val clientNames = mutableSetOf<String>()
+        organizationClientStore.forEach {
+            if (clientNames.contains(it.fullName))
+                error("Metadata Error: Duplicate ${it.fullName} in organization clients")
+            else
+                clientNames.add(it.fullName)
+        }
+        val serviceNames = mutableSetOf<String>()
+        organizationServiceStore.forEach {
+            if (serviceNames.contains(it.fullName))
+                error("Metadata Error: Duplicate ${it.fullName} in organization services")
+            else
+                serviceNames.add(it.fullName)
+        }
+        organizationServiceStore.forEach { service ->
             service.batch?.let {
                 if (!it.isValid())
-                    error("Internal Error: improper batch value for ${service.fullName}")
+                    error("Metadata Error: improper batch value for ${service.fullName}")
             }
         }
         return this

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -1,9 +1,6 @@
 package gov.cdc.prime.router
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.*
 
 class MetadataTests {
     @Test
@@ -86,5 +83,18 @@ class MetadataTests {
         metadata.loadOrganizations("./metadata/organizations.yml")
         val client = metadata.findClient("simple_report")
         assertNotNull(client)
+    }
+
+    @Test
+    fun `test duplicate service name`() {
+        val metadata = Metadata()
+        val org1 = Organization(
+            "test", "test",
+            services = listOf(
+                OrganizationService("service1", "topic1", "schema1"),
+                OrganizationService("service1", "topic1", "schema1")
+            )
+        )
+        assertFails { metadata.loadOrganizationList(listOf(org1)) }
     }
 }


### PR DESCRIPTION
This PR fixes a bug in our PA Organization Services where two services had the same name. 

## Changes
- Removed the duplicate service name "pa-chester-staging" 
- Added validation code to catch this error at build time. 

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [x] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
