### PR TITLE
CO/Redox Fix

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -103,6 +103,10 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: some_key
+            baseUrl: http://redox:1080
 
   - name: tx-phd
     description: Texas Department of State Health Services

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -112,6 +112,9 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6
 
   - name: pa-phd
     description: Pennsylvania Department of Health

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -22,6 +22,7 @@ class RedoxTransport() : ITransport {
     private val redoxSecret = "secret"
     private val redoxAccessToken = "accessToken"
     private val jsonMimeType = "application/json"
+    private val redoxMessageId = "messageId"
 
     override fun send(
         orgService: OrganizationService,
@@ -108,11 +109,15 @@ class RedoxTransport() : ITransport {
         // TODO: store the result id when we get line level tracking
         return when (result) {
             is Result.Success -> {
-                context.logger.log(Level.INFO, "Successfully posted Redox msg: $id")
+                val messageId = result.value.obj()
+                    .getJSONObject("Meta")
+                    .getJSONObject("Message")
+                    .getInt("ID")
+                context.logger.log(Level.INFO, "Successfully posted $id to Redox msg $messageId")
                 true
             }
             is Result.Failure -> {
-                context.logger.log(Level.WARNING, "FAILED to post Redox msg: $id")
+                context.logger.log(Level.WARNING, "FAILED to post $id to Redox")
                 false
             }
             else -> false

--- a/prime-router/src/test/redox/initializerJson.json
+++ b/prime-router/src/test/redox/initializerJson.json
@@ -7,7 +7,7 @@
       "headers": {
         "Content-Type": ["application/json"]
       },
-      "body": "{\"accessToken\":\"69f653f0-6ff3-4a5c-9c57-73db9d575950\",\"expires\":\"2081-01-01T04:22:48.093Z\",\"refreshToken\":\"bc71b74e-4aca-46fe-a498-93a2474cff71\"}"
+      "body": {"accessToken":"69f653f0-6ff3-4a5c-9c57-73db9d575950","expires":"2081-01-01T04:22:48.093Z","refreshToken":"bc71b74e-4aca-46fe-a498-93a2474cff71"}
     }
   },
   {
@@ -18,7 +18,7 @@
       "headers": {
         "Content-Type": ["application/json"]
       },
-      "body": "{\"Meta\":{\"DataModel\":\"Results\",\"EventType\":\"NewUnsolicited\",\"Message\":{\"ID\":5911323776},\"Source\":{\"ID\":\"d89d4057-930f-4c5b-bb39-8cddb326e928\",\"Name\":\"Prime Data Hub (Staging)\"},\"Destinations\":[{\"ID\":\"cd019512-8a58-40e5-a416-4e597404f9b8\",\"Name\":\"CDC Pennsylvania Dept of Health Destination (s)\"}]}}"
+      "body": {"Meta":{"DataModel":"Results","EventType":"NewUnsolicited","Message":{"ID":5911323776},"Source":{"ID":"d89d4057-930f-4c5b-bb39-8cddb326e928","Name":"Prime Data Hub (Staging)"},"Destinations":[{"ID":"cd019512-8a58-40e5-a416-4e597404f9b8","Name":"CDC Pennsylvania Dept of Health Destination (s)"}]}}
     }
   }
 ]


### PR DESCRIPTION
The CO services did not have a transport specified. This PR adds the Redox transport information


## Changes
- Logging of Redox MessageId
- Clean up of Redox emulator JSON

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

