### PR TITLE
Add a patient_id for STRAC when none exists

### DIFF
--- a/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
@@ -8,3 +8,46 @@ elements:
   # override the default cardinality: The CLIA is held by the county.
   - name: testing_lab_clia
     cardinality: ZERO_OR_ONE
+
+  # PA wants a county code instead of a name
+  # TODO: For the schema redesign, consider what is being done here. Could we have a formatting field which
+  # changes output much like the mapper field changes input?
+  - name: testing_lab_county
+    redoxOutputFields: []
+
+  - name: testing_lab_county_code
+    type: TABLE
+    table: fips-county
+    tableColumn: FIPS
+    mapper: lookup(testing_lab_state, testing_lab_county)
+    redoxOutputFields: [ "Orders[0].Results[0].Producer.Address.County" ]
+
+  - name: ordering_provider_county
+    redoxOutputFields: []
+
+  - name: ordering_provider_county_code
+    type: TABLE
+    table: fips-county
+    tableColumn: FIPS
+    mapper: lookup(ordering_provider_state, ordering_provider_county)
+    redoxOutputFields: ["Orders[0].Provider.Address.County"]
+
+  - name: ordering_facility_county
+    redoxOutputFields: []
+
+  - name: ordering_facility_county_code
+    type: TABLE
+    table: fips-county
+    tableColumn: FIPS
+    mapper: lookup(ordering_facility_state, ordering_facility_county)
+    redoxOutputFields: [ "Orders[0].Extensions.ordering-facility-address.address.county" ]
+
+  - name: patient_county
+    redoxOutputFields: []
+
+  - name: patient_county_code
+    type: TABLE
+    table: fips-county
+    tableColumn: FIPS
+    mapper: lookup(patient_state, patient_county)
+    redoxOutputFields: [ "Patient.Demographics.Address.County" ]

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -156,3 +156,11 @@ elements:
 
   - name: testing_lab_name
     mapper: use(ordering_facility_name)
+
+  # To be compatible with Redox we must have an patient_id
+  # After some discussion, the placer_order_id was the best choice until STRAC provides a true patient_id
+  - name: patient_id
+    mapper: use(placer_order_id)
+
+  - name: patient_id_type
+    mapper: ifPresent(patient_id, PI)

--- a/prime-router/src/main/kotlin/serializers/RedoxSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/RedoxSerializer.kt
@@ -26,11 +26,9 @@ class RedoxSerializer(val metadata: Metadata) {
     }
 
     private enum class JsonGroupType { END_OBJECT, END_ARRAY, START_OBJECT, START_ARRAY }
-    private data class JsonGroup(val type: JsonGroupType, val name: String? = null)
 
     private val factory = JsonFactory()
     private val fields = mutableMapOf<String, List<JsonField>>()
-    private val transitions = mutableMapOf<String, List<List<JsonGroup>>>()
 
     fun write(report: Report, outputStream: OutputStream) {
         val fields = getFields(report.schema)
@@ -100,7 +98,7 @@ class RedoxSerializer(val metadata: Metadata) {
     }
 
     private fun writeTransition(to: JsonGenerator, field: JsonField, previousField: JsonField) {
-        var (ending, starting) = diff(previousField.base, field.base)
+        val (ending, starting) = diff(previousField.base, field.base)
         val isArrayTransition = ending.isNotEmpty() && starting.isNotEmpty() &&
             ending[0].endsWith(']') && starting[0].endsWith(']') &&
             ending[0].substringBefore('[') == starting[0].substringBefore('[')


### PR DESCRIPTION
This PR adds a patient_id element for a STRAC app result, even if one doesn't exist. 

## Background

The STRAC app does not have the concept of a patient id. Redox requires a Paitent ID (fails if it is not present). After some discussion, it was decided to use a per-test id the placer_order_id to make Redox happy. Redox will not pass this ID to PA when it generates the HL7 message, so PA will be happy. 

## Changes
- Define patient_id as the placer_order_number for Redox
- Change patient_county to the FIPS county code per PA's request
- Code clean-up on the RedoxSerializer 

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


