### PR TITLE
PA PROD values

### DIFF
--- a/prime-router/metadata/organizations-prod.yml
+++ b/prime-router/metadata/organizations-prod.yml
@@ -97,51 +97,48 @@
         transforms: { deidentify: false }
         format: CSV
 
-#  - name: pa-phd
-#    description: Pennsylvania Department of Health
-#    services:
-#      - name: elr-bucks-staging
-#        topic: covid-19
-#        schema: pa/pa-covid-19-redox
-#        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
-#        transforms: { deidentify: false }
-#        defaults:
-#          processing_mode_code: T
-#          redox_destination_id: e0d33443-c134-4e5f-9c15-69f9ba6340bf
-#          redox_destination_name: "CDC Bucks County PDH Destination (s)"
-#          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
-#          redox_source_name: "Prime Data Hub (Staging)"
-#        format: REDOX
-#        transports:
-#          - type: REDOX
-#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
-#      - name: elr-chester-staging
-#        topic: covid-19
-#        schema: pa/pa-covid-19-redox
-#        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
-#        transforms: { deidentify: false }
-#        defaults:
-#          processing_mode_code: T
-#          redox_destination_id: 86aa61ac-8864-417f-860e-d83ae46c951f
-#          redox_destination_name: "CDC Chester County PDH Destination (s)"
-#          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
-#          redox_source_name: "Prime Data Hub (Staging)"
-#        format: REDOX
-#        transports:
-#          - type: REDOX
-#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
-#      - name: elr-montgomery-staging
-#        topic: covid-19
-#        schema: pa/pa-covid-19-redox
-#        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
-#        transforms: { deidentify: false }
-#        defaults:
-#          processing_mode_code: T
-#          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
-#          redox_destination_name: "CDC Montgomery County PDH Destination (s)"
-#          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
-#          redox_source_name: "Prime Data Hub (Staging)"
-#        format: REDOX
-#        transports:
-#          - type: REDOX
-#            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox staging
+  - name: pa-phd
+    description: Pennsylvania Department of Health
+    services:
+      - name: elr-bucks-prod
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
+        transforms: { deidentify: false }
+        defaults:
+          redox_destination_id: fcafe93a-9e04-4e3f-9aac-203518f6c4c9
+          redox_destination_name: "CDC Bucks County PDH Destination (p)"
+          redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5
+          redox_source_name: "Prime Data Hub (Prod)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox prod
+      - name: elr-chester-prod
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
+        transforms: { deidentify: false }
+        defaults:
+          redox_destination_id: 5e841ef0-447b-46d0-8a60-49ca4defaf00
+          redox_destination_name: "CDC Chester County PDH Destination (p)"
+          redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5
+          redox_source_name: "Prime Data Hub (Prod)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox prod
+      - name: elr-montgomery-prod
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          redox_destination_id: bb2947af-28dd-470d-9997-7445eb42252f
+          redox_destination_name: "CDC Montgomery County PDH Destination (p)"
+          redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5
+          redox_source_name: "Prime Data Hub (Prod)"
+        format: REDOX
+        transports:
+          - type: REDOX
+            apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox prod

--- a/prime-router/metadata/organizations-prod.yml
+++ b/prime-router/metadata/organizations-prod.yml
@@ -106,6 +106,7 @@
         jurisdictionalFilter: [ "filterByCounty(PA, Bucks)" ]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: P
           redox_destination_id: fcafe93a-9e04-4e3f-9aac-203518f6c4c9
           redox_destination_name: "CDC Bucks County PDH Destination (p)"
           redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5
@@ -120,6 +121,7 @@
         jurisdictionalFilter: [ "filterByCounty(PA, Chester)" ]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: P
           redox_destination_id: 5e841ef0-447b-46d0-8a60-49ca4defaf00
           redox_destination_name: "CDC Chester County PDH Destination (p)"
           redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5
@@ -134,6 +136,7 @@
         jurisdictionalFilter: [ "filterByCounty(PA, Montgomery)" ]
         transforms: { deidentify: false }
         defaults:
+          processing_mode_code: P
           redox_destination_id: bb2947af-28dd-470d-9997-7445eb42252f
           redox_destination_name: "CDC Montgomery County PDH Destination (p)"
           redox_source_id: a3834c9d-e3ff-4602-b360-dcb0ad08fce5

--- a/prime-router/src/main/kotlin/serializers/RedoxSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/RedoxSerializer.kt
@@ -1,5 +1,7 @@
 package gov.cdc.prime.router.serializers
 
+import ca.uhn.hl7v2.parser.DefaultEscaping
+import ca.uhn.hl7v2.parser.EncodingCharacters
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonGenerator
 import gov.cdc.prime.router.Element
@@ -29,6 +31,8 @@ class RedoxSerializer(val metadata: Metadata) {
 
     private val factory = JsonFactory()
     private val fields = mutableMapOf<String, List<JsonField>>()
+    private val hl7EncodingCharacters = EncodingCharacters('|', null)
+    private val hl7DefaultEscaping = DefaultEscaping()
 
     fun write(report: Report, outputStream: OutputStream) {
         val fields = getFields(report.schema)
@@ -172,7 +176,9 @@ class RedoxSerializer(val metadata: Metadata) {
                 to.writeString(e164)
             }
             else -> {
-                to.writeString(value)
+                // Escaping handles the case where the value contains an "|" or "&" which will mess up Redox's HL7 generation
+                val escaped = hl7DefaultEscaping.escape(value, hl7EncodingCharacters)
+                to.writeString(escaped)
             }
         }
     }


### PR DESCRIPTION
This PR adds the connections to PA PROD and fix for Binax Now kit id transmission

## Changes
- PA PROD services 
- A workaround for Redox's inability to handle HL7 escaped characters. 

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

