### PR TITLE
Break CLI into multiple subcommands

### DIFF
--- a/prime-router/quick-test.sh
+++ b/prime-router/quick-test.sh
@@ -99,7 +99,7 @@ function compare_files {
 if [ $RUN_STANDARD -ne 0 ]
 then
   echo First run our canned test file simplereport.csv thru the gauntlet
-  text=$(./prime --input_schema $starter_schema --input ./src/test/csv_test_files/input/simplereport.csv --output_dir $outputdir --route)
+  text=$(./prime data --input-schema $starter_schema --input ./src/test/csv_test_files/input/simplereport.csv --output-dir $outputdir --route)
 fi
 
 AZ_FILE_SEARCH_STR="/az.*\.csv"
@@ -121,26 +121,26 @@ then
   # Now read the data back in to their own schema and export again.
   # AZ again
   echo Test sending AZ data into its own Schema:
-  text=$(./prime --input_schema az/az-covid-19 --input $actual_az --output_dir $outputdir)
+  text=$(./prime data --input-schema az/az-covid-19 --input $actual_az --output-dir $outputdir)
   parse_prime_output_for_filename "$text" $AZ_FILE_SEARCH_STR
   actual_az2=$filename
   compare_files "AZ->AZ" $expected_az $actual_az2
 
   # Pima again
   echo Test sending Pima data into its own Schema:
-  text=$(./prime --input_schema az/pima-az-covid-19 --input $actual_pima --output_dir $outputdir)
+  text=$(./prime data --input-schema az/pima-az-covid-19 --input $actual_pima --output-dir $outputdir)
   parse_prime_output_for_filename "$text" $PIMA_FILE_SEARCH_STR
   actual_pima2=$filename
   compare_files "PIMA->PIMA" $expected_pima $actual_pima2
 
   echo And now generate some fake simplereport data
-  text=$(./prime --input_fake 50 --input_schema $starter_schema --output_dir $outputdir)
+  text=$(./prime data --input-fake 50 --input-schema $starter_schema --output-dir $outputdir)
   parse_prime_output_for_filename "$text" "/pdi-covid-19"
   fake_data=$filename
 
   echo Now send that fake data thru the router.
   # Note that there's no actuals to compare to here.
-  text=$(./prime --input_schema $starter_schema --input $fake_data --output_dir $outputdir --route)
+  text=$(./prime data --input-schema $starter_schema --input $fake_data --output-dir $outputdir --route)
   # Find the AZ file
   parse_prime_output_for_filename "$text" $AZ_FILE_SEARCH_STR
   actual_az3=$filename
@@ -151,14 +151,14 @@ then
   echo Now send _those_ results back in to their own schema and export again!
   # AZ again again.  This time we can compare the two actuals.
   echo Test sending AZ data generated from fake data into its own Schema:
-  text=$(./prime --input_schema az/az-covid-19 --input $actual_az3 --output_dir $outputdir)
+  text=$(./prime data --input-schema az/az-covid-19 --input $actual_az3 --output-dir $outputdir)
   parse_prime_output_for_filename "$text" $AZ_FILE_SEARCH_STR
   actual_az4=$filename
   compare_files "AZ->AZ" $actual_az3 $actual_az4
 
   # Pima again again.  Compare the two actuals
   echo Test sending Pima data generated from fake data into its own Schema:
-  text=$(./prime --input_schema az/pima-az-covid-19 --input $actual_pima3 --output_dir $outputdir)
+  text=$(./prime data --input-schema az/pima-az-covid-19 --input $actual_pima3 --output-dir $outputdir)
   parse_prime_output_for_filename "$text" $PIMA_FILE_SEARCH_STR
   actual_pima4=$filename
   compare_files "PIMA->PIMA" $actual_pima3 $actual_pima4
@@ -170,18 +170,18 @@ then
   FL_FILE_SEARCH_STR="/fl.*\.csv"
   # FLORIDA, MAN
   echo Generate fake FL data
-  text=$(./prime --input_fake 50 --input_schema fl/fl-covid-19 --output_dir $outputdir --target-state FL)
+  text=$(./prime data --input-fake 50 --input-schema fl/fl-covid-19 --output-dir $outputdir --target-state FL)
   parse_prime_output_for_filename "$text" $FL_FILE_SEARCH_STR
   fake_fl=$filename
 
   echo Now send that fake FL data through the router.
-  text=$(./prime --input_schema fl/fl-covid-19 --input $fake_fl --output_dir $outputdir)
+  text=$(./prime data --input-schema fl/fl-covid-19 --input $fake_fl --output-dir $outputdir)
   parse_prime_output_for_filename "$text" $FL_FILE_SEARCH_STR
   fake_fl2=$filename
   compare_files "Fake FL Orig -> Fake FL2" $fake_fl $fake_fl2
 
   echo Now send _those_ FL results back in to their own schema and export again!
-  text=$(./prime --input_schema fl/fl-covid-19 --input $fake_fl2 --output_dir $outputdir)
+  text=$(./prime data --input-schema fl/fl-covid-19 --input $fake_fl2 --output-dir $outputdir)
   fake_fl3=$filename
   compare_files "FakeFL2 -> FakeFL3" $fake_fl2 $fake_fl3
 fi
@@ -204,22 +204,22 @@ then
   numitems=5
   echo Merge testing.  First, generate some fake STRAC data
    # Hack: put some unique strings in each one, so we can count lines.
-  text=$(./prime --input_fake $numitems --input_schema strac/strac-covid-19 --output_dir $outputdir --target-county lilliput)
+  text=$(./prime data --input-fake $numitems --input-schema strac/strac-covid-19 --output-dir $outputdir --target-county lilliput)
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake1=$filename
 
  echo More fake STRAC data
-  text=$(./prime --input_fake $numitems --input_schema strac/strac-covid-19 --output_dir $outputdir --target-county brobdingnag)
+  text=$(./prime data --input-fake $numitems --input-schema strac/strac-covid-19 --output-dir $outputdir --target-county brobdingnag)
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake2=$filename
 
  echo 3rd file of fake STRAC data
-  text=$(./prime --input_fake $numitems --input_schema strac/strac-covid-19 --output_dir $outputdir --target-county houyhnhnm)
+  text=$(./prime data --input-fake $numitems --input-schema strac/strac-covid-19 --output-dir $outputdir --target-county houyhnhnm)
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake3=$filename
 
   echo Now testing merge:
-  text=$(./prime --merge $fake1,$fake2,$fake3 --input_schema strac/strac-covid-19 --output_dir $outputdir )
+  text=$(./prime data --merge $fake1,$fake2,$fake3 --input-schema strac/strac-covid-19 --output-dir $outputdir )
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   merged_file=$filename
 

--- a/prime-router/src/main/kotlin/DocumentationFactory.kt
+++ b/prime-router/src/main/kotlin/DocumentationFactory.kt
@@ -82,10 +82,19 @@ ${element.documentation}
         return sb.toString()
     }
 
-    // write all the documentation for a schema
+    /**
+     * Write markdown documentation for a schema to a file.
+     *
+     * @param schema The schema to document.
+     * @param outputDir The directory to write the file to. If this directory
+     *        doesn't exist, it will be created.
+     * @param outputFileName Name of the file to write in `outputDir`. If not
+     *        set, the file will be named after the schema.
+     * @param includeTimestamps Append the current date to the filename.
+     */
     fun writeDocumentationForSchema(
         schema: Schema,
-        outputDir: String? = null,
+        outputDir: String = ".",
         outputFileName: String? = null,
         includeTimestamps: Boolean = false
     ) {
@@ -100,14 +109,12 @@ ${element.documentation}
             ".md"
         }
 
-        val oDir = (outputDir ?: "docs/schema_documentation")
-        val path = Paths.get(oDir)
+        val path = Paths.get(outputDir)
         if (!Files.exists(path)) {
             Files.createDirectory(path)
         }
 
-        val outputPath = "$oDir/$oName"
-        File(outputPath).writeText(getSchemaDocumentation(schema))
+        File(outputDir, oName).writeText(getSchemaDocumentation(schema))
     }
 
     private fun appendLabelAndData(appendable: Appendable, label: String, value: Any?) {

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -112,8 +112,7 @@ class ProcessData : CliktCommand(
         if (listOfFiles.isNullOrEmpty()) error("No files to merge.")
         val files = listOfFiles.split(",", " ").filter { ! it.isNullOrBlank() }
         if (files.isEmpty()) error("No files to merge found in comma separated list.  Need at least one file.")
-        val reports = files.map { readReportFromFile(metadata, it) }.filter { report -> report != null }
-        if (reports.isEmpty()) error("Unable to merge.  All reports failed validation")
+        val reports = files.map { readReportFromFile(metadata, it) }
         echo("Merging ${reports.size} reports.")
         return Report.merge(reports)
     }
@@ -279,7 +278,7 @@ class ListSchemas : CliktCommand(
             println(
                 formatTemplate.format(
                     it.organization.name, it.name, it.schema,
-                    it.jurisdictionalFilter.joinToString { it -> it }
+                    it.jurisdictionalFilter.joinToString()
                 )
             )
         }

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -3,6 +3,7 @@
 package gov.cdc.prime.router.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.convert
@@ -33,44 +34,74 @@ sealed class InputSource {
 
 class RouterCli : CliktCommand(
     name = "prime",
-    help = "Send health messages to their destinations",
+    help = "Tools and commands that support the PRIME Data Hub.",
     printHelpOnEmptyArgs = true,
 ) {
+    override fun run() = Unit
+}
+
+class ProcessData : CliktCommand(
+    name = "data",
+    help = """
+    process data
+     
+    Use this command to process data in a variety of ways, similar to how the
+    REST service might handle data sent to it.
+    
+    You must always specify input data (via --input, --input-dir, --merge, or
+    --input-fake to generate random data) and --input-schema.
+    
+    The data can then be transformed to a new schema (using --route, --route-to,
+    or --output-schema) and written to a given location. Output will be written
+    in CSV format unless otherwise specified.
+    
+    If no output location is set, files are written to the current working
+    directory.
+    
+    To generate test data for later use, use --input-fake with no
+    transformations. For example, to generate 5 rows of test data using the
+    Florida COVID-19 schema:
+    > prime data --input-fake 5 --input-schema fl/fl-covid-19 --output florida-data.csv
+    """
+) {
+    // Input
     private val inputSource: InputSource? by mutuallyExclusiveOptions(
-        option("--merge", help = "list of comma-separated files to merge").convert { InputSource.ListOfFilesSource(it) },
-        option("--input", help = "<file1>").convert { InputSource.FileSource(it) },
-        option("--input_fake", help = "fake the input.  Pass a numeric arg - the number of rows/items to create").int().convert { InputSource.FakeSource(it) },
-        option("--input_dir", help = "<dir>").convert { InputSource.DirSource(it) },
+        option("--merge", metavar = "<paths>", help = "list of comma-separated CSV files to merge as input").convert { InputSource.ListOfFilesSource(it) },
+        option("--input", metavar = "<path>", help = "path to CSV file to read").convert { InputSource.FileSource(it) },
+        option("--input-fake", metavar = "<int>", help = "generate N rows of random input according to --input-schema. The value is the number of rows to generate.").int().convert { InputSource.FakeSource(it) },
+        option("--input-dir", metavar = "<dir>", help = "path to directory of files").convert { InputSource.DirSource(it) },
     ).single()
-    private val inputSchema by option("--input_schema", help = "<schema_name>")
+    private val inputSchema by option("--input-schema", metavar = "<schema_name>", help = "interpret input according to this schema")
+
+    // Actions
     private val validate by option("--validate", help = "Validate stream").flag(default = true)
-    private val route by option("--route", help = "route to receivers lists").flag(default = false)
-    private val list by option("--list", help = "list all schemas.  Ignores other parameters").flag(default = false)
-    private val send by option("--send", help = "send to a receiver if specified").flag(default = false)
-    private val routeTo by option("--route_to", help = "route a receiver")
+    private val send by option("--send", help = "send output to receivers").flag(default = false)
 
-    private val outputFileName by option("--output", help = "<file> not compatible with route or partition")
-    private val outputDir by option("--output_dir", help = "<directory>")
-    private val outputSchema by option("--output_schema", help = "<schema_name> or use input schema if not specified")
-    private val outputHl7 by option("--output_hl7", help = "True for HL7 output").flag(default = false)
+    // Output schema
+    private val route by option("--route", help = "transform output to the schemas for each receiver the input would be routed to").flag(default = false)
+    private val routeTo by option("--route-to", metavar = "<receiver>", help = "transform output to the schema for the given receiver")
+    private val outputSchema by option("--output-schema", metavar = "<name>", help = "transform output to the given schema")
 
-    private val generateDocumentation by
-    option("--generate-docs", help = "generate documentation from the provided schema.  If no --input_schema is specified, generate for all schemas")
-        .flag(default = false)
-    private val includeTimestamps by
-    option("--include-timestamps", help = "includes creation time stamps when generating documentation")
-        .flag(default = false)
+    // Output format
+    private val outputHl7 by option("--output-hl7", help = "format output as HL7 instead of CSV").flag(default = false)
+
+    // Output location
+    private val outputFileName by option("--output", metavar = "<path>", help = "write output to this file. Do not use with --route, which generates multiple outputs.")
+    private val outputDir by option("--output-dir", metavar = "<path>", help = "write output files to this directory instead of the working directory. Ignored if --output is set.")
+
+    // Fake data configuration
     private val targetState: String? by
     option(
         "--target-state",
-        help = "specifies a state to generate test data for. " +
-            "This is only used when generating test data, and has no meaning in other contexts"
+        metavar = "<abbrev>",
+        help = "when using --input-fake, fill geographic fields using this state. " +
+            "This should be a two-letter abbreviation, e.g. 'FL' for Florida."
     )
     private val targetCounty: String? by
     option(
         "--target-county",
-        help = "specifies a county string to generate test data for. " +
-            "This is only used when generating test data, and has no meaning in other contexts"
+        metavar = "<name>",
+        help = "when using --input-fake, fill county-related fields with this county name."
     )
 
     private fun mergeReports(
@@ -136,6 +167,7 @@ class RouterCli : CliktCommand(
         }
     }
 
+    // NOTE: This exists to support not-yet-implemented functionality.
     private fun postHttp(address: String, block: (stream: OutputStream) -> Unit) {
         echo("Sending to: $address")
         val urlObj = URL(address)
@@ -152,62 +184,6 @@ class RouterCli : CliktCommand(
         }
     }
 
-    fun listSchemas(metadata: Metadata) {
-        println("Current Hub Schema Library")
-        var formatTemplate = "%-25s\t%-10s\t%s"
-        println(formatTemplate.format("Schema Name", "Topic", "Description"))
-        metadata.schemas.forEach {
-            println(formatTemplate.format(it.name, it.topic, it.description))
-        }
-    }
-
-    fun listOrganizations(metadata: Metadata) {
-        println("Current Clients (Senders to the Hub)")
-        var formatTemplate = "%-18s\t%-10s\t%s"
-        println(formatTemplate.format("Organization Name", "Client Name", "Schema Sent to Hub"))
-        metadata.organizationClients.forEach {
-            println(formatTemplate.format(it.organization.name, it.name, it.schema))
-        }
-        println()
-        println("Current Services (Receivers from the Hub)")
-        formatTemplate = "%-18s\t%-10s\t%-25s\t%s"
-        println(formatTemplate.format("Organization Name", "Service Name", "Schema Sent by Hub", "Filters Applied"))
-        metadata.organizationServices.forEach {
-            println(
-                formatTemplate.format(
-                    it.organization.name, it.name, it.schema,
-                    it.jurisdictionalFilter.joinToString { it -> it }
-                )
-            )
-        }
-    }
-
-    fun generateSchemaDocumentation(metadata: Metadata) {
-        if (inputSchema.isNullOrBlank()) {
-            println("Generating documentation for all schemas")
-            metadata.schemas.forEach {
-                DocumentationFactory.writeDocumentationForSchema(
-                    it,
-                    outputDir,
-                    outputFileName,
-                    includeTimestamps
-                )
-                println(it.name)
-            }
-        } else {
-            val schemaName = inputSchema?.toLowerCase() ?: ""
-            val schema = metadata.findSchema(schemaName)
-            if (schema == null) {
-                echo("$schemaName not found. Did you mean one of these?")
-                listSchemas(metadata)
-                return
-            }
-            // start generating documentation
-            echo("Generating documentation for $schemaName")
-            DocumentationFactory.writeDocumentationForSchema(schema, outputDir, outputFileName, includeTimestamps)
-        }
-    }
-
     override fun run() {
         // Load the schema and receivers
         val metadata = Metadata(Metadata.defaultMetadataDirectory)
@@ -215,19 +191,6 @@ class RouterCli : CliktCommand(
         val hl7Serializer = Hl7Serializer(metadata)
         val redoxSerializer = RedoxSerializer(metadata)
         echo("Loaded schema and receivers")
-
-        if (list) {
-            println()
-            listSchemas(metadata)
-            println()
-            listOrganizations(metadata)
-            println()
-            return
-        }
-        if (generateDocumentation) {
-            generateSchemaDocumentation(metadata)
-            return
-        }
 
         // Gather input source
         val inputReport: Report = when (inputSource) {
@@ -248,6 +211,9 @@ class RouterCli : CliktCommand(
                 error("input source must be specified")
             }
         }
+
+        if (!validate) TODO("validation cannot currently be disabled")
+        if (send) TODO("--send is not implemented")
 
         // Transform reports
         val translator = Translator(metadata)
@@ -284,4 +250,97 @@ class RouterCli : CliktCommand(
     }
 }
 
-fun main(args: Array<String>) = RouterCli().main(args)
+fun listSchemas(metadata: Metadata) {
+    println("Current Hub Schema Library")
+    var formatTemplate = "%-25s\t%-10s\t%s"
+    println(formatTemplate.format("Schema Name", "Topic", "Description"))
+    metadata.schemas.forEach {
+        println(formatTemplate.format(it.name, it.topic, it.description))
+    }
+}
+
+class ListSchemas : CliktCommand(
+    name = "list",
+    help = "list known schemas, clients, and services"
+) {
+    fun listOrganizations(metadata: Metadata) {
+        println("Current Clients (Senders to the Hub)")
+        var formatTemplate = "%-18s\t%-10s\t%s"
+        println(formatTemplate.format("Organization Name", "Client Name", "Schema Sent to Hub"))
+        metadata.organizationClients.forEach {
+            println(formatTemplate.format(it.organization.name, it.name, it.schema))
+        }
+        println()
+        println("Current Services (Receivers from the Hub)")
+        formatTemplate = "%-18s\t%-10s\t%-25s\t%s"
+        println(formatTemplate.format("Organization Name", "Service Name", "Schema Sent by Hub", "Filters Applied"))
+        metadata.organizationServices.forEach {
+            println(
+                formatTemplate.format(
+                    it.organization.name, it.name, it.schema,
+                    it.jurisdictionalFilter.joinToString { it -> it }
+                )
+            )
+        }
+    }
+
+    override fun run() {
+        val metadata = Metadata(Metadata.defaultMetadataDirectory)
+        println()
+        listSchemas(metadata)
+        println()
+        listOrganizations(metadata)
+        println()
+    }
+}
+
+class GenerateDocs : CliktCommand(
+    help = """
+    generate documentation for schemas
+
+    By default, this will generate documentation for all known schemas. To
+    generate docs for a particular schema, use the --input-schema option.
+    """
+) {
+    private val inputSchema by option("--input-schema", metavar = "<schema_name>", help = "schema to document")
+    private val includeTimestamps by
+    option("--include-timestamps", help = "include creation time in file names")
+        .flag(default = false)
+    private val outputFileName by option("--output", metavar = "<path>", help = "write documentation to this file (should not include extension)")
+    private val outputDir by option("--output-dir", metavar = "<path>", help = "interpret `--output` relative to this directory")
+
+    fun generateSchemaDocumentation(metadata: Metadata) {
+        if (inputSchema.isNullOrBlank()) {
+            println("Generating documentation for all schemas")
+            metadata.schemas.forEach {
+                DocumentationFactory.writeDocumentationForSchema(
+                    it,
+                    outputDir,
+                    outputFileName,
+                    includeTimestamps
+                )
+                println(it.name)
+            }
+        } else {
+            val schemaName = inputSchema?.toLowerCase() ?: ""
+            val schema = metadata.findSchema(schemaName)
+            if (schema == null) {
+                echo("$schemaName not found. Did you mean one of these?")
+                listSchemas(metadata)
+                return
+            }
+            // start generating documentation
+            echo("Generating documentation for $schemaName")
+            DocumentationFactory.writeDocumentationForSchema(schema, outputDir, outputFileName, includeTimestamps)
+        }
+    }
+
+    override fun run() {
+        val metadata = Metadata(Metadata.defaultMetadataDirectory)
+        generateSchemaDocumentation(metadata)
+    }
+}
+
+fun main(args: Array<String>) = RouterCli()
+    .subcommands(ProcessData(), ListSchemas(), GenerateDocs())
+    .main(args)

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
@@ -307,7 +308,9 @@ class GenerateDocs : CliktCommand(
     option("--include-timestamps", help = "include creation time in file names")
         .flag(default = false)
     private val outputFileName by option("--output", metavar = "<path>", help = "write documentation to this file (should not include extension)")
-    private val outputDir by option("--output-dir", metavar = "<path>", help = "interpret `--output` relative to this directory")
+    private val defaultOutputDir = "docs/schema_documentation"
+    private val outputDir by option("--output-dir", metavar = "<path>", help = "interpret `--output` relative to this directory (default: \"$defaultOutputDir\")")
+        .default(defaultOutputDir)
 
     fun generateSchemaDocumentation(metadata: Metadata) {
         if (inputSchema.isNullOrBlank()) {

--- a/prime-router/test-ingest.sh
+++ b/prime-router/test-ingest.sh
@@ -44,7 +44,7 @@ printf "\nRun this to submit a test report locally:\n"
 printf "     $boilerplate_glop $localfile_glop $local_url\n"
 
 printf "\nTo run the prime cli locally:\n"
-printf "     ./prime --input_schema primedatainput/pdi-covid-19 --input ./src/test/csv_test_files/input/simplereport.csv --route --output_dir . \n"
+printf "     ./prime data --input-schema primedatainput/pdi-covid-19 --input ./src/test/csv_test_files/input/simplereport.csv --route --output-dir . \n"
 
 
 


### PR DESCRIPTION
The CLI had several options that were mutually exclusive, as well as options that behaved differently depending on some of those exclusive options (for example, `--output` behaved differently depending on whether `--generate_docs` was set). This breaks the CLI up into multiple subcommands, both to clarify behavior for users and to make the implementation a bit more organized.

The new commands are:
- `data` (the "main" command that most options used to apply to — **I’d love some feedback on whether this is a good name; the right answer here is less clear to me than the other two**)
- `list`
- `generate-docs`

I've also tried to rework the help text here to be clearer and more informative. Unsupported options that are placeholders for future behavior now throw errors when used rather than silently failing. I’d **love** any feedback on these docs.

Otherwise, I’ve tried not to change the various options or functionality in any big way, although I *did* make all options kebab-case so they were more consistent (some were snake_case and some were kebab-case).

Example command to generate fake data now:

```sh
$ ./prime data --input-fake 5 --input-schema fl/fl-covid-19 --output florida-data.csv
```

Docs for all commands:

```
$ ./prime
Usage: prime [OPTIONS] COMMAND [ARGS]...

  Tools and commands that support the PRIME Data Hub.

Options:
  -h, --help  Show this message and exit

Commands:
  data           process data
  list           list known schemas, clients, and services
  generate-docs  generate documentation for schemas
```

```
$ ./prime data --help
Usage: prime data [OPTIONS]

  process data

  Use this command to process data in a variety of ways, similar to how the
  REST service might handle data sent to it.

  You must always specify input data (via --input, --input-dir, --merge, or
  --input-fake to generate random data) and --input-schema.

  The data can then be transformed to a new schema (using --route, --route-to,
  or --output-schema) and written to a given location. Output will be written
  in CSV format unless otherwise specified.

  If no output location is set, files are written to the current working
  directory.

  To generate test data for later use, use --input-fake with no
  transformations. For example, to generate 5 rows of test data using the
  Florida COVID-19 schema: > prime data --input-fake 5 --input-schema
  fl/fl-covid-19 --output florida-data.csv

Options:
  --merge <paths>               list of comma-separated CSV files to merge as
                                input
  --input <path>                path to CSV file to read
  --input-fake <int>            generate N rows of random input according to
                                --input-schema. The value is the number of
                                rows to generate.
  --input-dir <dir>             path to directory of files
  --input-schema <schema_name>  interpret input according to this schema
  --validate                    Validate stream
  --send                        send output to receivers
  --route                       transform output to the schemas for each
                                receiver the input would be routed to
  --route-to <receiver>         transform output to the schema for the given
                                receiver
  --output-schema <name>        transform output to the given schema
  --output-hl7                  format output as HL7 instead of CSV
  --output <path>               write output to this file. Do not use with
                                --route, which generates multiple outputs.
  --output-dir <path>           write output files to this directory instead
                                of the working directory
  --target-state <abbrev>       when using --input-fake, fill geographic
                                fields using this state. This should be a
                                two-letter abbreviation, e.g. 'FL' for
                                Florida.
  --target-county <name>        when using --input-fake, fill county-related
                                fields with this county name.
  -h, --help                    Show this message and exit
```

```
$ ./prime list --help
Usage: prime list [OPTIONS]

  list known schemas, clients, and services

Options:
  -h, --help  Show this message and exit
```

```
$ ./prime generate-docs --help
Usage: prime generate-docs [OPTIONS]

  generate documentation for schemas

  By default, this will generate documentation for all known schemas. To
  generate docs for a particular schema, use the --input-schema option.

Options:
  --input-schema <schema_name>  schema to document
  --include-timestamps          include creation time in file names
  --output <path>               write documentation to this file (should not
                                include extension)
  --output-dir <path>           interpret `--output` relative to this
                                directory (default:
                                "docs/schema_documentation")
  -h, --help                    Show this message and exit
```

## Other Questions

This really helped me get a better grasp on how a few things work, but did leave me with some questions about things that might be worth addressing further in this or another PR:

1. The relationship between `--output` and `--output-dir` is a little complex (both in `data` and `generate-docs`)
    - In `data`, it might be good to add a warning or error if `--output` is when multiple files are being generated, or if both are set (since one will be ignored).
    - In `generate-docs`, I think it might be clearer and simpler to remove `--output-dir` and treat `--output` as a directory. It *does* remove some functionality, but I’m not sure that would really be bad.

2. `--validate` is always true and cannot be disabled, so it seems like a meaningless option.
    - Should we drop it?
    - Should it conceptually be more like `--validate-only` and stop the logic early? It *might* be better as a separate command in this case.
    - Should this actually control validation output, and cause warnings & errors not to print? In that case, if we want the current default, it might be better to make the option `--no-validate` and default to false.

3. I think it would be good to rename `--output-schema` to `--transform` or `--transform-schema` to clarify its role and the fact that it is an alternative to `--route` and `--route-to`.

4. There is logic for REDOX output, but CLI option. Should we have `--output-format csv|hl7|redox` instead of `--output-hl7`, or should I add `--output-redox`? (I think I’d vote for the former, given my understanding so far.)

5. I was also hoping to add `./prime --version`, but wasn’t sure how best to read in the current version programmatically. Would love any advice here, including if version info is not worthwhile to have. (It’s been a while since I’ve done a lot of Java dev, and don’t have a whole lot of Kotlin experience.)


## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [x] Updated the docs?
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
