### PR TITLE
SSL Validation Override

### DIFF
--- a/prime-router/Dockerfile_dev
+++ b/prime-router/Dockerfile_dev
@@ -11,6 +11,13 @@ ARG JAVA_VERSION=11
 # This Debian image additionally contains function core tools – useful when using custom extensions
 FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION-core-tools 
 
+# Disable SSL verification for agencies that re-sign SSL connections
+ARG INSECURE_SSL=false
+RUN if [ -n "$INSECURE_SSL" ] && [ "$INSECURE_SSL" = "true" ]; then \
+        touch /etc/apt/apt.conf.d/99verify-peer.conf && \
+        echo >>/etc/apt/apt.conf.d/99verify-peer.conf "Acquire { https::Verify-Peer false }"; \
+    fi
+
 # Standard stuff needed for Azure setup
 RUN apt update && \
     apt upgrade -y && \

--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile_dev
+      args:
+        INSECURE_SSL: "${PRIME_DATA_HUB_INSECURE_SSL}"
     volumes: # Attach the PWD into the image
       - type: bind
         source: ./target

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -59,6 +59,8 @@ You should be able to compile the project now. Check if it works.
 mvn clean package
 ```
 
+If you see any SSL errors during this step, follow the directions in [Getting Around SSL Errors](#getting-around-ssl-errors).
+
 Check out the database if you like:
 ```
 psql prime_data_hub
@@ -103,7 +105,7 @@ To orchestrate running the Azure function code and Azurite, Docker Compose is a 
 mvn clean package  
 docker-compose up
 ```
-Docker-compose will build a `prime_dev` container with the output of the `mvn package` command and launch an Azurite container. The first time you run this command, it builds a whole new image, which may take a while. However, after the first time `docker-compse` is run, `docker-compose` should start up in a few seconds. The output should look like:
+Docker-compose will build a `prime_dev` container with the output of the `mvn package` command and launch an Azurite container. The first time you run this command, it builds a whole new image, which may take a while. However, after the first time `docker-compose` is run, `docker-compose` should start up in a few seconds. The output should look like:
 
 ![Docker Compose](assets/docker_compose_log.png)
 
@@ -148,3 +150,19 @@ docker push rhawesprimedevregistry.azurecr.io/prime-data-hub
 ## Using local configuration for organizations.yml
 
 By default, the functions will pull their configuration for organizations from the `organizations.yml` file.  You can override this locally or in test by declaring an environment variable `PRIME_ENVIRONMENT`.  If you declare something like, `export PRIME_ENVIRONMENT=mylocal` then the system will look for a configuration file `organizations-mylocal.yml` and will use that, even if the `organizations.yml` file exists.  In this way, you can set up local SFTP routing, etc. without impacting the production (`organizations.yml`) config.  Note that depending on the OS - case matters.
+
+## Getting Around SSL Errors
+
+If your agency's network intercepts SSL requests, you might have to disable SSL verifications to get around invalid certificate errors.
+
+This can be accomplished by setting an environment variable `PRIME_DATA_HUB_INSECURE_SSL=true`. You can pass this in as a one-off when you build a component, for example:
+
+```bash
+PRIME_DATA_HUB_INSECURE_SSL=true docker-compose up
+```
+
+Or you can add this line in your `~/.bash_profile` to ensure your local builds will always disable SSL verification:
+
+```bash
+export PRIME_DATA_HUB_INSECURE_SSL=true
+```

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -155,6 +155,22 @@ By default, the functions will pull their configuration for organizations from t
 
 If your agency's network intercepts SSL requests, you might have to disable SSL verifications to get around invalid certificate errors.
 
+### Maven Builds
+
+For Maven builds, you can add the parameter `-Dmaven.wagon.http.ssl.insecure=true` as follows:
+
+```bash
+mvn clean package -Dmaven.wagon.http.ssl.insecure=true
+```
+
+If you want to permanently set this, add the following to your `.bash_profile`:
+
+```bash
+export MAVEN_OPTS="-Dmaven.wagon.http.ssl.insecure=true $MAVEN_OPTS"
+```
+
+### Docker Builds
+
 This can be accomplished by setting an environment variable `PRIME_DATA_HUB_INSECURE_SSL=true`. You can pass this in as a one-off when you build a component, for example:
 
 ```bash

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -111,6 +111,8 @@ Docker-compose will build a `prime_dev` container with the output of the `mvn pa
 
 Looking at the log above, you may notice that container has a debug open at port `5005`. This configuration allows you to attach a Java debugger to debug your code.
 
+If you see any SSL errors during this step, follow the directions in [Getting Around SSL Errors](#getting-around-ssl-errors).
+
 ## Setup Azure to deploy your locally built container
 
 Each developer is given an Azure resource group in the project's Azure subscription. 


### PR DESCRIPTION
This PR adds the ability to disable SSL validations when downloading dependencies locally. Some agencies like CMS intercept SSL requests and re-sign the certificate, breaking the SSL signature.

## Changes
- Documented how to disable SSL validation for Maven builds
- Adds a build arg `INSECURE_SSL` to our `Dockerfile_dev` to disable SSL validation
- Adds an environment variable `PRIME_DATA_HUB_INSECURE_SSL` to our docker-compose to set the build arg `INSECURE_SSL`
- Documents how to disable SSL validation for Docker builds

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [x] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

