### PR TITLE
Secrets Management: Local Hashicorp Vault Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ prime-router/source.mry
 # PRIME test files
 prime-router/result_files/*
 prime-router/routed_files/*
+
+# Hashicorp Vault Secrets
+prime-router/.vault/env/**

--- a/prime-router/.vault/config/init.sh
+++ b/prime-router/.vault/config/init.sh
@@ -25,7 +25,7 @@ else
   UNSEAL_KEY=`sed '1!d' /tmp/init.log | sed 's/Unseal Key 1: //g'`
   ROOT_TOKEN=`sed '3!d' /tmp/init.log | sed 's/Initial Root Token: //g'`
   echo "$UNSEAL_KEY" > /vault/env/key
-  echo "VAULT_ROOT_TOKEN=\"$ROOT_TOKEN\"" > /vault/env/.local.env
+  echo "VAULT_ROOT_TOKEN=\"$ROOT_TOKEN\"" > /vault/env/.env.local
 fi
 
 printf "\n"

--- a/prime-router/.vault/config/init.sh
+++ b/prime-router/.vault/config/init.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -e
+
+printf "Initialize Vault for developer use..."
+
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_API_ADDR=http://127.0.0.1:8200
+
+# Start the Vault server in the background
+vault server -config /vault/config/local.json &
+sleep 3
+printf "\n"
+
+if [ -f /vault/env/key ]; then
+  printf "Existing key found in .vault/env. Using key to initialize Vault...\n\n"
+  vault operator unseal "$(cat /vault/env/key)"
+else
+  printf "No key found in .vault/env. Creating a new key set...\n\n"
+  
+  # Generate a key for the vault
+  vault operator init -key-shares=1 -key-threshold=1 > /tmp/init.log
+  printf "\n$(cat /tmp/init.log)"
+
+  # Capture the vault keys
+  UNSEAL_KEY=`sed '1!d' /tmp/init.log | sed 's/Unseal Key 1: //g'`
+  ROOT_TOKEN=`sed '3!d' /tmp/init.log | sed 's/Initial Root Token: //g'`
+  echo "$UNSEAL_KEY" > /vault/env/key
+  echo "VAULT_ROOT_TOKEN=\"$ROOT_TOKEN\"" > /vault/env/.local.env
+fi
+
+printf "\n"
+
+# Bring Vault back to the foreground
+wait $!

--- a/prime-router/.vault/config/local.json
+++ b/prime-router/.vault/config/local.json
@@ -1,0 +1,8 @@
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}
+
+storage "file" {
+  path = "/vault/file"
+}

--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -65,3 +65,21 @@ services:
       - type: bind
         source: ./src/test/redox
         target: /config
+
+  # Secrets management
+  vault:
+    image: vault
+    cap_add:
+      # Allows protected memory
+      - IPC_LOCK
+    volumes:
+      # Contains script for bootstrapping the Docker container
+      - .vault/config:/vault/config
+      # Location to store the vault keys
+      - .vault/env:/vault/env
+      # Vault database persisted as a Docker volume
+      - vault:/vault/file
+    command: "/vault/config/init.sh"
+
+volumes:
+  vault:

--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -79,7 +79,9 @@ services:
       - .vault/env:/vault/env
       # Vault database persisted as a Docker volume
       - vault:/vault/file
+    # Override the command with our custom init script
     command: "/vault/config/init.sh"
 
 volumes:
+  # For storing a local encrypted secrets database
   vault:

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -184,3 +184,28 @@ Or you can add this line in your `~/.bash_profile` to ensure your local builds w
 ```bash
 export PRIME_DATA_HUB_INSECURE_SSL=true
 ```
+
+## Managing the local Hashicorp Vault secrets database
+
+Our `docker-compose.yml` includes Hashicorp Vault alongside our other containers to enable local secrets storage. Under normal circumstances, developers will not have to interact directly with the Vault configuration, but some helpful guidance is provided below for troubleshooting.
+
+### Initialize the Vault
+
+When starting up our containers with `docker-compose up` on first-run, the container will create a new Vault database and store the following files in `.vault/env`:
+
+* `key` - unseal key for decrypting the database
+* `.env.local` - the root token in envfile format for using the Vault api / command line
+
+The database is stored in a docker-compose container `vault` that persists across up and down events. All files are excluded in `.gitignore` and should never be persisted to source control.
+
+## Re-initialize the Vault
+
+If you would like to start with a fresh Vault database, you can clear the Vault database with the following commands:
+
+```bash
+cd prime_router
+docker-compose down -v
+rm -rf .vault/env/{key,.env.local}
+```
+
+Note: The `docker-compose down -v` option deletes all volumes associated with our docker-compose file.


### PR DESCRIPTION
This PR begins work on Secrets Management (#190) by adding a local Hashicorp Vault (#292). This PR only addresses standing up a local Hashicorp Vault instance; at this time the Vault is not used for anything, but it will in follow-on PRs.

## Changes
- Adds the official Hashicorp Vault Docker image to our `docker-compose.yml`
- Creates a persistent Docker volume to store the encrypted local Vault
  - This will allow the secrets to persist locally across `docker-compose up` and `docker-compose down` actions
- Configures Vault to use the file storage engine, leveraging the persistent Docker volume
- Adds a custom Vault startup script to automatically initialize and unseal the Vault, reducing developer burdon for running Vault locally
- Stores vault keys and tokens in `.vault/env` and adds the path to `.gitignore` to prevent developers from committing
  - `.vault/env/key` contains the unseal key, allowing Vault to decrypt the secrets database when starting up
  - `.vault/env/.env.local` contains the root token in envfile format, allowing us to inject the root token into the application in #294 to use the Vault api to store/retrieve secrets
- Adds documentation to `getting_started.md` explaining how Vault works and documents common troubleshooting methods

## Checklist
- [x] Tested locally?
- [x] Added new dependencies?
- [x] Updated the docs?
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- Next steps are to leverage the Vault by building out a `ConnectionCredentialStorageService` in #294

