### PR TITLE
Simple Stop Batch or Send Support

### DIFF
--- a/prime-router/docs/playbooks/Stop_a_batch_or_send.md
+++ b/prime-router/docs/playbooks/Stop_a_batch_or_send.md
@@ -1,0 +1,26 @@
+## Conditions
+
+There is a batch or send operation that has been queued, but we would
+like to prevent these operations from taking place. In other words, we want
+to disrupt the normal workflow. 
+
+## Prerequisites
+
+1. Connection to production database
+2. PSQL or equivalent tool that supports DB queries
+
+## Actions
+
+1. Find report id to act on. 
+
+    ```
+    SELECT report_id, next_action, created_at FROM task WHERE retry_token is not null;
+    ```
+2. Set the `next_action` column to `none`
+
+    ```
+    UPDATE task
+    SET next_action = 'none'
+    WHERE report_id = '673bcfe9-3d4e-4aaa-97eb-a0f8e173d706';
+    ```
+   

--- a/prime-router/docs/playbooks/readme.md
+++ b/prime-router/docs/playbooks/readme.md
@@ -1,0 +1,1 @@
+A set of operational playbooks

--- a/prime-router/src/main/kotlin/azure/BatchFunction.kt
+++ b/prime-router/src/main/kotlin/azure/BatchFunction.kt
@@ -27,6 +27,10 @@ class BatchFunction {
             context.logger.info("Batch message: $message")
             val workflowEngine = WorkflowEngine()
             val event = Event.parseQueueMessage(message) as ReceiverEvent
+            if (event.action != Event.Action.BATCH) {
+                context.logger.warning("Batch function received a $message")
+                return
+            }
             val receiver = workflowEngine.metadata.findService(event.receiverName)
                 ?: error("Internal Error: receiver name ${event.receiverName}")
             val maxBatchSize = receiver.batch?.maxReportCount ?: defaultBatchSize

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -32,8 +32,11 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
     ) {
         try {
             context.logger.info("Started Send Function: $message")
-
             val event = Event.parseQueueMessage(message) as ReportEvent
+            if (event.action != Event.Action.SEND) {
+                context.logger.warning("Send function received a $message")
+                return
+            }
             workflowEngine.handleReportEvent(event) { header, retryToken, _ ->
                 val service = workflowEngine.metadata.findService(header.task.receiverName)
                     ?: error("Internal Error: could not find ${header.task.receiverName}")

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -74,14 +74,19 @@ class WorkflowEngine(
 
     /**
      * Handle a single report event. Callback returns the next action for the report.
+     *
+     * @param messageEvent received from the message queue
+     * @param updateBlock is wrapped in a DB transaction and called
      */
     fun handleReportEvent(
-        event: ReportEvent,
+        messageEvent: ReportEvent,
         updateBlock: (header: DatabaseAccess.Header, retryToken: RetryToken?, txn: Configuration?) -> ReportEvent,
     ) {
         db.transact { txn ->
-            val header = db.fetchAndLockHeader(event.reportId, txn)
+            val header = db.fetchAndLockHeader(messageEvent.reportId, txn)
             val currentAction = Event.Action.parseQueueMessage(header.task.nextAction.literal)
+            // Ignore messages that are not consistent with the current header
+            if (currentAction != messageEvent.action) return@transact
             val retryToken = RetryToken.fromJSON(header.task.retryToken?.data())
             val nextAction = updateBlock(header, retryToken, txn)
             val retryJson = nextAction.retryToken?.toJSON()
@@ -91,19 +96,22 @@ class WorkflowEngine(
     }
 
     /**
-     * Handle a receiver specific event. Fetch all pending tasks for the specified receiver.
-     * The next action for the tasks are assumed to be NONE.
+     * Handle a receiver specific event. Fetch all pending tasks for the specified receiver and nextAction
+     *
+     * @param messageEvent that was received
+     * @param maxCount of headers to process
+     * @param updateBlock called with headers to process
      */
     fun handleReceiverEvent(
-        event: ReceiverEvent,
+        messageEvent: ReceiverEvent,
         maxCount: Int,
         updateBlock: (headers: List<DatabaseAccess.Header>, txn: Configuration?) -> Unit,
     ) {
         db.transact { txn ->
             val headers = db.fetchAndLockHeaders(
-                event.action.toTaskAction(),
-                event.at,
-                event.receiverName,
+                messageEvent.action.toTaskAction(),
+                messageEvent.at,
+                messageEvent.receiverName,
                 maxCount,
                 txn
             )


### PR DESCRIPTION
This PR adds the simple ability to stop a queued Batch or Send task by directly manipulating the DB. 

## Background

If a mistake is made in production, operators would like the ability to stop a batch or a send task in production by hand. Today this is accomplished by deleting the entire report task row in the database. 

## Operations

To stop a pending send, an operator with a DB connection can change the `next_action` value to `none`. Note: this is an improvement over deleting the row and the records associated with it.

An example query to find all tasks with pending retries.
```
SELECT report_id, next_action, created_at FROM task WHERE retry_token is not null;
```

An example query to stop pending send. 
```
UPDATE task
SET next_action = 'none'
WHERE report_id = '673bcfe9-3d4e-4aaa-97eb-a0f8e173d706';
```

## Changes
- Function checks to ensure that the queue message matched what the function expects
- Workflow check to ensure that the action in the DB matches what was received. If not, do nothing.  

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #267 Add the ability to stop a retry sequence

## To Be Done

This is a minimal fix for the moment. One could imagine a CLI or Web Site that allowed senders to stop their own reports. These types of fixes would need per client authentication and new end-points to implement the logic. 

