### PR TITLE
Added Corrected_result_id, per #344

### DIFF
--- a/prime-router/docs/releases/next-release.md
+++ b/prime-router/docs/releases/next-release.md
@@ -1,0 +1,14 @@
+#  Hub Release Notes
+
+*NO DATE SET*
+
+## General useful links:
+
+- All Schemas are documented here:  [Link to detailed schema dictionaries](../schema_documentation)
+- The Hub API is documented here: [Hub OpenApi Spec](../openapi.yml)
+- [Click here for all release notes](../releases)
+
+## Changes to the Schemas, including for SimpleReport:
+
+Added optional field `Corrected_result_ID`, a pointer/link to the unique Result_ID of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the ResultID of the prior item.
+

--- a/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
@@ -1903,6 +1903,18 @@ unique id to track the usage of the message
 
 ---
 
+**Name**: previous_message_id
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
 **Name**: reason_for_study
 
 **Type**: TEXT

--- a/prime-router/docs/schema_documentation/covid-19.md
+++ b/prime-router/docs/schema_documentation/covid-19.md
@@ -1869,6 +1869,18 @@ unique id to track the usage of the message
 
 ---
 
+**Name**: previous_message_id
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
 **Name**: message_profile_id
 
 **Type**: EI

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
@@ -1889,6 +1889,18 @@ unique id to track the usage of the message
 
 ---
 
+**Name**: previous_message_id
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
 **Name**: message_profile_id
 
 **Type**: EI

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -21,6 +21,102 @@ An example of the ID is 03D2159846
 
 ---
 
+**Name**: testing_lab_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: testing_lab_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: ordering_provider_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: ordering_provider_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: ordering_facility_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: ordering_facility_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: patient_county
+
+**Type**: TABLE_OR_BLANK
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: patient_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
 **Name**: redox_source_id
 
 **Cardinality**: [0..1]
@@ -347,18 +443,6 @@ The patient's zip code
 
 ---
 
-**Name**: patient_county
-
-**Type**: TABLE_OR_BLANK
-
-**Cardinality**: [1..1]
-
-**Table**: fips-county
-
-**Table Column**: County
-
----
-
 **Name**: patient_country
 
 **Type**: TEXT
@@ -458,18 +542,6 @@ The state of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 
@@ -726,18 +798,6 @@ The state of the provider
 **Documentation**:
 
 The zip code of the provider
-
----
-
-**Name**: ordering_provider_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 
@@ -1068,18 +1128,6 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: OBX-24-5
 
 **Cardinality**: [0..1]
-
----
-
-**Name**: testing_lab_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 

--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -182,6 +182,18 @@ unique id to track the usage of the message
 
 ---
 
+**Name**: Corrected_result_ID
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
 **Name**: placer_order_id
 
 **Type**: ID

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -98,6 +98,18 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: Ordering_Facility_County
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
 **Name**: Ordering_Facility_ZIP
 
 **Type**: POSTAL_CODE
@@ -741,5 +753,25 @@ Z|No record of this patient
 **Documentation**:
 
 The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: patient_id
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-5
+
+**Cardinality**: [0..1]
 
 ---

--- a/prime-router/docs/schema_documentation/tx-tx-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/tx-tx-covid-19-hl7.md
@@ -1889,6 +1889,18 @@ unique id to track the usage of the message
 
 ---
 
+**Name**: previous_message_id
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
 **Name**: message_profile_id
 
 **Type**: EI

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -45,6 +45,9 @@ elements:
     cardinality: ONE
     csvFields: [{name: Result_ID}]
 
+  - name: previous_message_id
+    csvFields: [{name: Corrected_result_ID}]
+
   - name: placer_order_id
     mapper: use(message_id)
 

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -700,6 +700,11 @@ elements:
     cardinality: ONE
     documentation: unique id to track the usage of the message
 
+  - name: previous_message_id
+    type: ID
+    cardinality: ZERO_OR_ONE
+    documentation: pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
   - name: message_profile_id
     type: EI
     hl7Field: MSH-21


### PR DESCRIPTION
This PR added Corrected_result_ID to the columns we read from SimpleReport, in support of their sending corrections to prior tests.  (The Test_result_status field is also needed for this, but its already in the schema)

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [X] Updated the docs?
- [ ] Added a test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #344 

## To Be Done

- SimpleReport has asked for two potential follow-on features:
1. Optionally prevent redundant submissions by validating that every Result_ID is unique.  That is, validate that each Result_ID has not been previously submitted.
2. Optionally confirm that a Corrected_result_ID does indeed point to a valid previous Result_ID.

These need discussion, prioritization, and are dependent on other work first.
