### PR TITLE
Added docker-based PostgreSQL infrastructure option.

### DIFF
--- a/prime-router/devenv-infrastructure.sh
+++ b/prime-router/devenv-infrastructure.sh
@@ -1,0 +1,2 @@
+# Start up supporting infrastructure
+docker-compose -f ./docker-prime-infra.yml up --detach

--- a/prime-router/docker-infrastructure.yml
+++ b/prime-router/docker-infrastructure.yml
@@ -1,0 +1,28 @@
+# This docker compose is intended to setup developer infrastructure
+version: "3.3"
+services:
+  # local PostgreSQL instance with config and persistent volume
+  db_pgsql:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: "changeIT!"
+      POSTGRES_USER: "prime"
+      POSTGRES_DB: "prime_data_hub"
+
+    ports:
+      - "5432:5432"
+    volumes:
+      - vol_prime_db:/var/lib/postgresql/data
+
+  # local web-based SQL tool for looking in db_pgsql
+  db_adminer:
+    image: adminer
+    restart: always
+    ports:
+      - "8080:8080"
+
+volumes:
+  # For storing a local postegres database
+  vol_prime_db:
+

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -28,8 +28,15 @@ Change the working directory to the `prime-router` directory.
 cd <your_path>/prime-router
 ```
 
-You need a running local PostgreSQL database to compile the project. 
-One way is to use brew again to get this database. 
+### Dependencies
+
+#### PostgreSQL
+
+You need a running local PostgreSQL database to **compile** the project.
+
+##### Option 1: PostgreSQL via Brew
+
+One way is to use [brew](https://brew.sh) again to get this database. (Mac or Linux)
 ```
 brew install postgresql@11
 brew install flyway
@@ -42,6 +49,8 @@ createuser -P prime
 createdb --owner=prime prime_data_hub
 ```
 
+##### Option 2: PostgreSQL via `apt` on Ubuntu/Debian
+
 Installing PostgreSQL and Flyway on Ubuntu
 ```
 sudo apt install postgresql
@@ -52,6 +61,19 @@ wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/7.3.0/f
 sudo -u postgres createuser -P prime
 sudo -u postgres createdb --owner=prime prime_data_hub
 ```
+
+##### Option 3: PostgreSQL via Docker
+
+In [`devenv-infrastructure.sh`](../devenv-infrastructure.sh)
+```sh
+docker-compose -f ./docker-prime-infra.yml up --detach
+```
+
+If you need need Flyway, you can install it via `apt` or `brew` as above.
+
+
+
+### Compiling
 
 You should be able to compile the project now. Check if it works. 
 


### PR DESCRIPTION
This PR adds an option to run PostgreSQL infrastructure from Docker instead of on the developer machine itself. Supporting docker-based PostgreSQL infrastructure also enables testing the prime-data-hub system against new releases and alternate configurations of the database.

## Changes
- Added `docker-infrastructure.yml` docker-compose configuration
- Added `docker-infrastructure.sh` shell script to document the `docker-compose -f docker-infrastructure.yml up --detach` command.
- Updated `docs/getting-started.md` to reflect the three options for running PostgreSQL.

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [x] Updated the docs?
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [x] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
