### PR TITLE
Redox ResultsStatus typo

### DIFF
--- a/prime-router/metadata/schemas/covid-19-redox.schema
+++ b/prime-router/metadata/schemas/covid-19-redox.schema
@@ -172,7 +172,7 @@ elements:
 
   # Redox only handles corrected and final. Everything is
   - name: test_result_status
-    redoxOutputFields: ["Orders[0].ResultStatus", "Orders[0].Results[0].Status"]
+    redoxOutputFields: ["Orders[0].ResultsStatus", "Orders[0].Results[0].Status"]
     altValues:
       - display: Corrected
         code: C


### PR DESCRIPTION
This PR fixes a typo in the Redox JSON. 

## Changes
- `Orders[].ResultsStatus` was `Orders[].ResultStatus`

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


