### PR TITLE
Add a PR check to verify that docs are up-to-date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Prime Data Hub
 on:
   pull_request:
     branches: [ master, production ]
+    paths-ignore:
+      - 'prime-router/docs/**'
 
 defaults:
   run:
@@ -43,14 +45,98 @@ jobs:
           postgresql db: prime_data_hub
           postgresql user: ${{ env.POSTGRES_USER }}
           postgresql password: ${{ env.POSTGRES_PASSWORD }}
-       
+
       - name: Setup JDK
         uses: actions/setup-java@v1.4.3
         with:
            java-version: 11
-      
+
+      - name: Cache Maven Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('prime-router/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
       - name: Build Maven Package
         run: mvn -B clean package --file pom.xml -Dpg.user=$POSTGRES_USER -Dpg.password=$POSTGRES_PASSWORD
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
+
+      - name: Save Build Target
+        uses: actions/upload-artifact@v2
+        with:
+          name: build_target
+          path: prime-router/target
+
+  update_docs:
+    name: Update Docs
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Explicitly use the head_ref here (which is a branch name, rather
+          # than a commit hash) so we can commit and push back to it.
+          ref: ${{ github.head_ref }}
+
+      - name: Setup JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+           java-version: 11
+
+      - name: Restore Build Target
+        uses: actions/download-artifact@v2
+        with:
+          name: build_target
+          path: prime-router/target
+
+      - name: Generate New Docs
+        run: |
+          # Clean the docs before regenerating
+          rm -rf docs/schema_documentation/*
+          ./prime generate-docs
+
+      - name: Check for Uncommited Docs
+        id: check_changes
+        continue-on-error: true
+        run: |
+          CHANGED_FILES=$(git status --short docs)
+          if [[ -n "$CHANGED_FILES" ]]; then
+            echo "Updated documentation:"
+            git diff docs
+
+            # Escape line breaks so they can be used in step output.
+            # See: https://github.community/t/set-output-truncates-multiline-strings/16852
+            FILES_ESCAPED="$CHANGED_FILES"
+            FILES_ESCAPED="${FILES_ESCAPED//'%'/'%25'}"
+            FILES_ESCAPED="${FILES_ESCAPED//$'\n'/'%0A'}"
+            FILES_ESCAPED="${FILES_ESCAPED//$'\r'/'%0D'}"
+            echo "::set-output name=files::$FILES_ESCAPED"
+
+            # End with an error
+            false
+          fi
+
+      - name: Add diff as PR comment
+        if: ${{ steps.check_changes.outcome == 'failure' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            The changes you’ve made modify the documentation, but you haven’t included new generated documentation in your commits!
+
+            Please run `./prime generate-docs` to generate updated documentation, then commit the results.
+
+            Expected changes in files:
+
+            ```sh
+            ${{ steps.check_changes.outputs.files }}
+            ```
+
+      - name: Fail if there were changes
+        if: ${{ steps.check_changes.outcome == 'failure' }}
+        run: |
+          false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,14 @@ jobs:
         uses: actions/setup-java@v1.4.3
         with:
            java-version: 11
-      
+
+      - name: Cache Maven Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('prime-router/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
       - name: Build Maven Package
         run: mvn -B clean package --file pom.xml -Dpg.user=$POSTGRES_USER -Dpg.password=$POSTGRES_PASSWORD
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -21,6 +21,102 @@ An example of the ID is 03D2159846
 
 ---
 
+**Name**: testing_lab_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: testing_lab_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: ordering_provider_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: ordering_provider_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: ordering_facility_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: ordering_facility_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: patient_county
+
+**Type**: TABLE_OR_BLANK
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: patient_county_code
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
 **Name**: redox_source_id
 
 **Cardinality**: [0..1]
@@ -347,18 +443,6 @@ The patient's zip code
 
 ---
 
-**Name**: patient_county
-
-**Type**: TABLE_OR_BLANK
-
-**Cardinality**: [1..1]
-
-**Table**: fips-county
-
-**Table Column**: County
-
----
-
 **Name**: patient_country
 
 **Type**: TEXT
@@ -458,18 +542,6 @@ The state of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 
@@ -726,18 +798,6 @@ The state of the provider
 **Documentation**:
 
 The zip code of the provider
-
----
-
-**Name**: ordering_provider_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 
@@ -1068,18 +1128,6 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: OBX-24-5
 
 **Cardinality**: [0..1]
-
----
-
-**Name**: testing_lab_county
-
-**Type**: TABLE
-
-**Cardinality**: [0..1]
-
-**Table**: fips-county
-
-**Table Column**: County
 
 ---
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -98,6 +98,18 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: Ordering_Facility_County
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
 **Name**: Ordering_Facility_ZIP
 
 **Type**: POSTAL_CODE
@@ -741,5 +753,25 @@ Z|No record of this patient
 **Documentation**:
 
 The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: patient_id
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-5
+
+**Cardinality**: [0..1]
 
 ---


### PR DESCRIPTION
After seeing #344, I noticed that, even though we have some autogenerated docs in the repo, they are not always kept up-to-date. This adds an action to the build workflow that fails if there are uncommitted docs updates in a PR.

It will add a check like:

<img width="743" alt="Screen Shot 2021-01-23 at 2 49 51 PM" src="https://user-images.githubusercontent.com/74178/105616397-6a49f080-5d8b-11eb-9793-a0b074d07cc4.png">

And post comments to the PR like:

<img width="732" alt="Screen Shot 2021-01-23 at 2 49 33 PM" src="https://user-images.githubusercontent.com/74178/105616402-77ff7600-5d8b-11eb-99be-4a71120fbb0f.png">

The comments include a list of files it expected to see changed (basically the output of `git status docs`), since displaying a full diff seemed excessive. To see a full diff, you can click the “details” link on the status check to look at the workflow’s logs:

<img width="1277" alt="Screen Shot 2021-01-23 at 2 55 03 PM" src="https://user-images.githubusercontent.com/74178/105616437-bb59e480-5d8b-11eb-8894-04f418aecc01.png">

**This is focused on a pass/fail approach, but we could do something different and auto-commit the generated docs.** @jimduff-usds suggested this and I tried it out, but committing to the PR branch is not so great: either you re-run the build a second time, or you don’t run the workflow again and the build/unit test status checks disappear from the PR (since the latest commit didn’t run any jobs/checks). If we wanted to auto-commit the docs, this might be better to run after pushes to the `master` or `production` branches (e.g. add it to the `release` workflow).

If helpful, auto-committing the changes instead of commenting would mean replacing the “Add diff as PR comment” step with this (tested):


```yaml
      - name: Commit Changes
        if: ${{ steps.check_changes.outcome == 'failure' }}
        run: |
          # Alter these however you want so commits are attributed in a useful way.
          git config user.name 'GitHub Actions Bot'
          git config user.email 'github.actions.bot@example.com'

          git add docs
          git commit -m 'Generate updated docs'
          git push
```


### Other Changes

While I was at it, I added dependency caching to both workflows to speed up builds a little bit.

This also includes some docs updates! This PR’s new checks would fail for the PR if I didn’t, and illustrate exactly why it’s useful. 😉


## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [x] Updated the docs?
- [ ] Added a test?
- [x] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
