### PR TITLE
Minor fixes

### DIFF
--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -81,6 +81,10 @@ class ActionHistory {
         this.context = context
     }
 
+    fun setActionType(taskAction: TaskAction) {
+        action.actionName = taskAction
+    }
+
     fun trackActionParams(request: HttpRequestMessage<String?>) {
         val factory = JsonFactory()
         val outStream = ByteArrayOutputStream()
@@ -250,6 +254,7 @@ class ActionHistory {
         reportsOut[reportFile.reportId] = reportFile
     }
 
+    @Deprecated("Not sure we really need this")
     fun trackFailedReport(service: OrganizationService, sentReportId: ReportId, params: String, msg: String) {
         trackSentReport(service, sentReportId, null, params, msg, 0)
     }

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -7,6 +7,7 @@ import com.microsoft.azure.functions.annotation.StorageAccount
 import gov.cdc.prime.router.RedoxTransportType
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.SFTPTransportType
+import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.transport.RetryToken
 import gov.cdc.prime.router.transport.RetryTransport
 import java.time.OffsetDateTime
@@ -53,6 +54,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
                     .transports
                     .filterIndexed { i, _ -> retryToken == null || retryToken.transports.find { it.index == i } != null }
                 if (transports.isEmpty()) {
+                    actionHistory.setActionType(TaskAction.send_error)
                     actionHistory.trackActionResult("Not sending $inputReportId to $serviceName: No transports defined")
                 }
                 transports.forEachIndexed { i, transport ->
@@ -93,7 +95,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
                         nextRetryTransports.add(RetryTransport(i, nextRetryItems))
                     }
                 }
-                handleRetry(nextRetryTransports, inputReportId, serviceName, retryToken, context)
+                handleRetry(nextRetryTransports, inputReportId, serviceName, retryToken, context, actionHistory)
             }
             // For debugging and auditing purposes
         } catch (t: Throwable) {
@@ -106,7 +108,8 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
         reportId: ReportId,
         serviceName: String,
         retryToken: RetryToken?,
-        context: ExecutionContext
+        context: ExecutionContext,
+        actionHistory: ActionHistory,
     ): ReportEvent {
         return if (nextRetryTransports.isEmpty()) {
             // All OK
@@ -117,14 +120,18 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
             val nextRetryCount = (retryToken?.retryCount ?: 0) + 1
             if (nextRetryCount >= maxRetryCount) {
                 // Stop retrying and just put the task into an error state
-                context.logger.info("All retries failed.  Send Error report for: $reportId to $serviceName")
+                val msg = "All retries failed.  Send Error report for: $reportId to $serviceName"
+                actionHistory.trackActionResult(msg)
+                context.logger.info(msg)
                 ReportEvent(Event.EventAction.SEND_ERROR, reportId)
             } else {
                 // retry using a back-off strategy
                 val waitMinutes = retryDuration.getOrDefault(nextRetryCount, maxDurationValue)
                 val nextRetryTime = OffsetDateTime.now().plusMinutes(waitMinutes)
                 val nextRetryToken = RetryToken(nextRetryCount, nextRetryTransports)
-                context.logger.info("Send Failed.  Will retry sending report: $reportId to $serviceName} in $waitMinutes minutes, at $nextRetryTime")
+                val msg = "Send Failed.  Will retry sending report: $reportId to $serviceName} in $waitMinutes minutes, at $nextRetryTime"
+                context.logger.info(msg)
+                actionHistory.trackActionResult(msg)
                 ReportEvent(Event.EventAction.SEND, reportId, nextRetryTime, nextRetryToken)
             }
         }

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -6,6 +6,7 @@ import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.SFTPTransportType
 import gov.cdc.prime.router.TransportType
 import gov.cdc.prime.router.azure.ActionHistory
+import gov.cdc.prime.router.azure.db.enums.TaskAction
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.xfer.InMemorySourceFile
@@ -41,12 +42,14 @@ class SftpTransport : ITransport {
             actionHistory.trackSentReport(orgService, sentReportId, fileName, sftpTransportType.toString(), msg, -1)
             null
         } catch (ioException: IOException) {
-            val msg = "FAILED Sftp upload of inputReportId $inputReportId to $sftpTransportType (orgService = ${orgService.fullName})\""
+            val msg = "FAILED Sftp upload of inputReportId $inputReportId to $sftpTransportType (orgService = ${orgService.fullName})"
             context.logger.log(
                 Level.WARNING, msg, ioException
             )
+            actionHistory.setActionType(TaskAction.send_error)
             actionHistory.trackActionResult(msg)
-            actionHistory.trackFailedReport(orgService, sentReportId, sftpTransportType.toString(), msg)
+            // Ambivalent about this - seems not useful to track a file that does not exist.   Removing for now.
+// delete this            actionHistory.trackFailedReport(orgService, sentReportId, sftpTransportType.toString(), msg)
             RetryToken.allItems
         } // let non-IO exceptions be caught by the caller
     }


### PR DESCRIPTION
This PR fixes these issues with linage tracking related to failed sftps:
- fixes a bug where failed sftps were of type `send` instead of `send_error`.
- fixes a bug where failed sftp were generating new rows in the report_file table, which seems unnecessary and confusing.
- improves the database information tracking in the action_result column, when a failed sftp occurs.

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?



