### PR TITLE
Fix for the HL7 Batch

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -96,7 +96,7 @@ class Report {
     /**
      * A format for the body or use the destination format
      */
-    val bodyFormat: Format get() = this.destination?.format ?: Format.INTERNAL
+    val bodyFormat: Format
 
     /**
      * A pointer to where the Report is stored.
@@ -117,12 +117,14 @@ class Report {
         values: List<List<String>>,
         sources: List<Source>,
         destination: OrganizationService? = null,
+        bodyFormat: Format? = null
     ) {
         this.id = UUID.randomUUID()
         this.schema = schema
         this.sources = sources
         this.createdDateTime = OffsetDateTime.now()
         this.destination = destination
+        this.bodyFormat = bodyFormat ?: destination?.format ?: Format.INTERNAL
         this.table = createTable(schema, values)
     }
 
@@ -132,11 +134,13 @@ class Report {
         values: List<List<String>>,
         source: TestSource,
         destination: OrganizationService? = null,
+        bodyFormat: Format? = null,
     ) {
         this.id = UUID.randomUUID()
         this.schema = schema
         this.sources = listOf(source)
         this.destination = destination
+        this.bodyFormat = bodyFormat ?: destination?.format ?: Format.INTERNAL
         this.createdDateTime = OffsetDateTime.now()
         this.table = createTable(schema, values)
     }
@@ -147,10 +151,12 @@ class Report {
         values: List<List<String>>,
         source: OrganizationClient,
         destination: OrganizationService? = null,
+        bodyFormat: Format? = null,
     ) {
         this.id = UUID.randomUUID()
         this.schema = schema
         this.sources = listOf(ClientSource(source.organization.name, source.name))
+        this.bodyFormat = bodyFormat ?: destination?.format ?: Format.INTERNAL
         this.destination = destination
         this.createdDateTime = OffsetDateTime.now()
         this.table = createTable(schema, values)
@@ -160,13 +166,15 @@ class Report {
         schema: Schema,
         table: Table,
         sources: List<Source>,
-        destination: OrganizationService? = null
+        destination: OrganizationService? = null,
+        bodyFormat: Format? = null,
     ) {
         this.id = UUID.randomUUID()
         this.schema = schema
         this.table = table
         this.sources = sources
         this.destination = destination
+        this.bodyFormat = bodyFormat ?: destination?.format ?: Format.INTERNAL
         this.createdDateTime = OffsetDateTime.now()
     }
 
@@ -186,23 +194,14 @@ class Report {
     /**
      * Does a shallow copy of this report. Will have a new id and create date.
      */
-    fun copy(destination: OrganizationService?): Report {
+    fun copy(destination: OrganizationService? = null, bodyFormat: Format? = null): Report {
         // Dev Note: table is immutable, so no need to duplicate it
         return Report(
             this.schema,
             this.table,
             fromThisReport("copy"),
-            destination
-        )
-    }
-
-    fun copy(): Report {
-        // Dev Note: table is immutable, so no need to duplicate it
-        return Report(
-            this.schema,
-            this.table,
-            fromThisReport("copy"),
-            this.destination
+            destination ?: this.destination,
+            bodyFormat ?: this.bodyFormat
         )
     }
 

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -249,7 +249,7 @@ class ReportFunction {
             service.batch != null -> {
                 val time = service.batch.nextBatchTime()
                 // Always force a batched report to be saved in our INTERNAL format
-                val batchReport = report.copy(destination = null)
+                val batchReport = report.copy(bodyFormat = Report.Format.INTERNAL)
                 destinations += "Sending ${batchReport.itemCount} items to $serviceDescription at $time"
                 val event = ReceiverEvent(Event.EventAction.BATCH, service.fullName, time)
                 workflowEngine.dispatchReport(event, batchReport, txn)


### PR DESCRIPTION
This PR does fixes a mistake that the HL7 Batching PR had.

## Changes
- Report.bodyFormat can be overridden to the INTERNAL format rather than the destination format. 
- 

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?



