### PR TITLE
Rick/hl7 batch fix2

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -253,7 +253,13 @@ class Report {
     fun split(): List<Report> {
         return itemIndices.map {
             val row = getRow(it)
-            Report(schema, values = listOf(row), sources = fromThisReport("split"), destination = destination)
+            Report(
+                schema = schema,
+                values = listOf(row),
+                sources = fromThisReport("split"),
+                destination = destination,
+                bodyFormat = bodyFormat
+            )
         }
     }
 
@@ -328,8 +334,15 @@ class Report {
 
     companion object {
         fun merge(inputs: List<Report>): Report {
-            if (inputs.isEmpty()) error("Cannot merge an empty report list")
-            if (inputs.size == 1) return inputs[0]
+            if (inputs.isEmpty())
+                error("Cannot merge an empty report list")
+            if (inputs.size == 1)
+                return inputs[0]
+            if (!inputs.all { it.destination == inputs[0].destination })
+                error("Cannot merge reports with different destinations")
+            if (!inputs.all { it.bodyFormat == inputs[0].bodyFormat })
+                error("Cannot merge reports with different bodyFormats")
+
             val head = inputs[0]
             val tail = inputs.subList(1, inputs.size)
 
@@ -345,8 +358,7 @@ class Report {
 
             // Build sources
             val sources = inputs.map { ReportSource(it.id, "merge") }
-
-            return Report(schema, newTable, sources)
+            return Report(schema, newTable, sources, destination = head.destination, bodyFormat = head.bodyFormat)
         }
 
         fun formFilename(

--- a/prime-router/src/main/kotlin/Translator.kt
+++ b/prime-router/src/main/kotlin/Translator.kt
@@ -87,7 +87,7 @@ class Translator(private val metadata: Metadata) {
                 }
             }
         }
-        return transformed.copy(destination = receiver)
+        return transformed.copy(destination = receiver, bodyFormat = receiver.format)
     }
 
     /**

--- a/prime-router/src/main/kotlin/azure/BatchFunction.kt
+++ b/prime-router/src/main/kotlin/azure/BatchFunction.kt
@@ -60,7 +60,7 @@ class BatchFunction {
                     else -> mergedReports
                 }
                 outReports.forEach {
-                    val outReport = it.copy(destination = receiver)
+                    val outReport = it.copy(destination = receiver, bodyFormat = receiver.format)
                     val outEvent = ReportEvent(Event.EventAction.SEND, outReport.id)
                     workflowEngine.dispatchReport(outEvent, outReport, txn)
                     actionHistory.trackCreatedReport(outEvent, outReport, receiver)


### PR DESCRIPTION
This PR does another set of fixes for the HL7 Batch work. Thanks to @jimduff-usds for finding these bugs. 

## Changes
- Set the `bodyFormat` to the destination's format when processing a batch 
- Looking around for similar bugs, found split and merge functions that didn't set `bodyFormat` correctly

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


