### PR TITLE
Disable PR

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -110,10 +110,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: some_key
-            baseUrl: http://redox:1080
 
   - name: tx-phd
     description: Texas Department of State Health Services
@@ -165,10 +161,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: some_key
-            baseUrl: http://redox:1080
       - name: elr-chester-local
         topic: covid-19
         schema: pa/pa-covid-19-redox
@@ -181,10 +173,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: some_key
-            baseUrl: http://redox:1080
       - name: elr-montgomery-local
         topic: covid-19
         schema: pa/pa-covid-19-redox
@@ -197,7 +185,3 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: some_key
-            baseUrl: http://redox:1080

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -133,9 +133,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging
       - name: elr-chester-staging
         topic: covid-19
         schema: pa/pa-covid-19-redox
@@ -148,9 +145,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging
       - name: elr-montgomery-staging
         topic: covid-19
         schema: pa/pa-covid-19-redox
@@ -163,6 +157,3 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6 # Redox staging

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -117,9 +117,6 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
-        transports:
-          - type: REDOX
-            apiKey: e54eae82-c7e3-4969-913a-94abbed941a6
 
   - name: pa-phd
     description: Pennsylvania Department of Health


### PR DESCRIPTION
This PR removes the test environment's connection to PA and CO since both are in production. 

## Background
We have been using our test environment as a staging environment. Both PA and CO were configured to send data to the PHDs. This PR removes these connections, so the test deployment does not send data anywhere. 

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

