### PR TITLE
Put destinations into formal JSON

### DIFF
--- a/prime-router/docs/releases/2021-02-12-release-notes.md
+++ b/prime-router/docs/releases/2021-02-12-release-notes.md
@@ -1,0 +1,40 @@
+#  Hub Release Notes
+
+*Feb 12, 2021*
+
+## General useful links:
+
+- All Schemas are documented here:  [Link to detailed schema dictionaries](../schema_documentation)
+- The Hub API is documented here: [Hub OpenApi Spec](../openapi.yml)
+- [Click here for all release notes](../releases)
+
+## For this release
+
+### Changes to api/reports response
+
+This release changes the format of destinations in our return Json from informal sentences
+
+```
+"destinations" : [ "Sending 58 items to Jones County Public Health Dept (prod-elr) at 2021-02-08T12:00-07:00", etc ]
+```
+
+to more formal json:
+```
+  "destinations" : [ {
+    "organization" : "Jones County Public Health Dept",
+    "organization_id" : "prod-phd",
+    "service" : "prod-elr",
+    "sending_at" : "2021-02-08T12:00-07:00",
+    "itemCount" : 58
+  }, {
+```
+
+Also adds a 
+`destinationCount`
+
+If the data is valid, but is going nowhere, you'll see:
+```
+  "destinations" : [ ],
+  "destinationCount" : 0,
+```
+

--- a/prime-router/src/main/kotlin/Metadata.kt
+++ b/prime-router/src/main/kotlin/Metadata.kt
@@ -322,9 +322,13 @@ class Metadata {
 
     fun findService(name: String): OrganizationService? {
         if (name.isBlank()) return null
-        val (orgName, clientName) = parseName(name)
+        val (orgName, svcName) = parseName(name)
+        return findService(orgName, svcName)
+    }
+
+    fun findService(orgName: String, svcName: String): OrganizationService? {
         return findOrganization(orgName)?.services?.find {
-            it.name.equals(clientName, ignoreCase = true)
+            it.name.equals(svcName, ignoreCase = true)
         }
     }
 

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -57,13 +57,13 @@ class DatabaseAccess(private val create: DSLContext) {
         val content: ByteArray?
 
         init {
-            val meta = engine.metadata
+            val metadata = engine.metadata
             orgSvc = if (reportFile.receivingOrg != null && reportFile.receivingOrgSvc != null)
-                meta.findService(reportFile.receivingOrg + "." + reportFile.receivingOrgSvc)
+                metadata.findService(reportFile.receivingOrg, reportFile.receivingOrgSvc)
             else null
 
             schema = if (reportFile.schemaName != null)
-                meta.findSchema(reportFile.schemaName)
+                metadata.findSchema(reportFile.schemaName)
             else null
 
             content = if (reportFile.bodyUrl != null)

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -250,6 +250,7 @@ class ReportFunction {
                 val time = service.batch.nextBatchTime()
                 // Always force a batched report to be saved in our INTERNAL format
                 val batchReport = report.copy(bodyFormat = Report.Format.INTERNAL)
+                // todo remove this.
                 destinations += "Sending ${batchReport.itemCount} items to $serviceDescription at $time"
                 val event = ReceiverEvent(Event.EventAction.BATCH, service.fullName, time)
                 workflowEngine.dispatchReport(event, batchReport, txn)
@@ -257,7 +258,7 @@ class ReportFunction {
                 loggerMsg = "Queue: ${event.toQueueMessage()}"
             }
             service.format == Report.Format.HL7 -> {
-                // todo this 'immediately' is no longer always true.
+                // todo Remove this.   Furthermore, this 'immediately' is no longer always true.
                 destinations += "Sending ${report.itemCount} reports to $serviceDescription immediately"
                 report
                     .split()
@@ -295,7 +296,7 @@ class ReportFunction {
                 it.writeNumberField("reportItemCount", result.report.itemCount)
             } else
                 it.writeNullField("id")
-            actionHistory?.prettyPrintDestinationJson(it)
+            actionHistory?.prettyPrintDestinationsJson(it)
 
             it.writeNumberField("warningCount", result.warnings.size)
             it.writeNumberField("errorCount", result.errors.size)
@@ -311,7 +312,6 @@ class ReportFunction {
                 }
                 it.writeEndArray()
             }
-
             writeDetailsArray("errors", result.errors)
             writeDetailsArray("warnings", result.warnings)
             it.writeEndObject()


### PR DESCRIPTION
This PR changes the format of destinations in our return Json from informal sentences

```
"destinations" : [ "Sending 58 items to Jones County Public Health Dept (prod-elr) at 2021-02-08T12:00-07:00", etc ]
```

to more formal json:
```
  "destinations" : [ {
    "organization" : "Jones County Public Health Dept",
    "organization_id" : "prod-phd",
    "service" : "prod-elr",
    "sending_at" : "2021-02-08T12:00-07:00",
    "itemCount" : 58
  }, {
```

Also adds a 
`destinationCount`

If the data is valid, but is going nowhere, you'll see:
  "destinations" : [ ],
  "destinationCount" : 0,

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- Request from SR.

## To Be Done

- #issue 

