### PR TITLE
Synthetic Data Improvements

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -5,9 +5,11 @@ import tech.tablesaw.api.StringColumn
 import tech.tablesaw.api.Table
 import tech.tablesaw.columns.Column
 import tech.tablesaw.selection.Selection
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import kotlin.random.Random
 
 /**
  * Report id
@@ -288,7 +290,26 @@ class Report {
                     // can be one of three values right now:
                     // empty column, shuffle column, pass through column untouched
                     SynthesizeStrategy.SHUFFLE -> {
-                        val shuffledValues = table.column(it.name).asStringColumn().shuffled()
+                        // if the field is date of birth, then we can break it apart and make
+                        // a pseudo-random date
+                        val shuffledValues = if (it.name == "patient_dob") {
+                            // shuffle all the DOBs
+                            val dobs = table.column(it.name).asStringColumn().shuffled().map { dob ->
+                                // parse the date
+                                val parsedDate = LocalDate.parse(dob, DateTimeFormatter.ofPattern(Element.datePattern))
+                                // get the year and date
+                                val (year, day) = listOf(parsedDate.year, parsedDate.dayOfYear)
+                                // fake a month
+                                val month = Random.nextInt(1, 12)
+                                // return with a different month and day
+                                "$year$month$day"
+                            }
+                            // return our list of days
+                            dobs
+                        } else {
+                            // return the string column shuffled
+                            table.column(it.name).asStringColumn().shuffled()
+                        }
                         StringColumn.create(it.name, shuffledValues)
                     }
                     SynthesizeStrategy.FAKE -> {

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -298,11 +298,12 @@ class Report {
                                 // parse the date
                                 val parsedDate = LocalDate.parse(dob, DateTimeFormatter.ofPattern(Element.datePattern))
                                 // get the year and date
-                                val (year, day) = listOf(parsedDate.year, parsedDate.dayOfYear)
+                                val year = parsedDate.year
                                 // fake a month
                                 val month = Random.nextInt(1, 12)
+                                val day = Random.nextInt(1, 28)
                                 // return with a different month and day
-                                "$year$month$day"
+                                Element.dateFormatter.format(LocalDate.of(year, month, day))
                             }
                             // return our list of days
                             dobs

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -304,12 +304,14 @@ class ProcessData : CliktCommand(
         // synthesize the data here
         // todo: put these strategies into metadata so we can load them from a file
         val synthesizeStrategies = mapOf(
-            "patient_last_name" to Report.SynthesizeStrategy.SHUFFLE,
-            "patient_first_name" to Report.SynthesizeStrategy.SHUFFLE,
+            "patient_last_name" to Report.SynthesizeStrategy.FAKE,
+            "patient_first_name" to Report.SynthesizeStrategy.FAKE,
+            "patient_middle_name" to Report.SynthesizeStrategy.FAKE,
+            "patient_middle_initial" to Report.SynthesizeStrategy.FAKE,
             "patient_gender" to Report.SynthesizeStrategy.SHUFFLE,
             "patient_race" to Report.SynthesizeStrategy.SHUFFLE,
             "patient_ethnicity" to Report.SynthesizeStrategy.SHUFFLE,
-            "patient_dob" to Report.SynthesizeStrategy.FAKE,
+            "patient_dob" to Report.SynthesizeStrategy.SHUFFLE,
             "patient_phone_number" to Report.SynthesizeStrategy.FAKE,
             "patient_street" to Report.SynthesizeStrategy.FAKE,
             "patient_state" to Report.SynthesizeStrategy.FAKE,


### PR DESCRIPTION
This PR changes the way we synthesize the names of patients and DOBs to afford more protection for patients by
- Always faking the names
- Converting the DOB to a different day and month, but preserving the year so the age graph is approximately the same shape

## Checklist
- [ ] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #484 
