### PR TITLE
Fixed bug in itemCount in destinations report

### DIFF
--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -6,6 +6,7 @@ import com.microsoft.azure.functions.ExecutionContext
 import com.microsoft.azure.functions.HttpRequestMessage
 import com.microsoft.azure.functions.HttpResponseMessage
 import gov.cdc.prime.router.ClientSource
+import gov.cdc.prime.router.Metadata
 import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.OrganizationService
 import gov.cdc.prime.router.Report
@@ -424,8 +425,7 @@ class ActionHistory {
      *
      * This works by side-effect on jsonGen.
      */
-    fun prettyPrintDestinationsJson(jsonGen: JsonGenerator) {
-        val metadata = WorkflowEngine.metadata
+    fun prettyPrintDestinationsJson(jsonGen: JsonGenerator, metadata: Metadata) {
         var destinationCounter = 0
         jsonGen.writeArrayFieldStart("destinations")
         if (reportsOut.isNotEmpty()) {
@@ -435,7 +435,8 @@ class ActionHistory {
                 val fullname = reportFile.receivingOrg + "." + reportFile.receivingOrgSvc
                 val orgSvc = metadata.findService(fullname) ?: return@forEach
                 if (reportFile.itemCount == 1) {
-                    var previous = singles.putIfAbsent(fullname, DestinationData(orgSvc, 0, reportFile.nextActionAt))
+                    var previous =
+                        singles.putIfAbsent(fullname, DestinationData(orgSvc, 1, reportFile.nextActionAt))
                     if (previous != null) previous.count++
                 } else {
                     prettyPrintDestinationJson(jsonGen, orgSvc, reportFile.nextActionAt, reportFile.itemCount)
@@ -457,7 +458,6 @@ class ActionHistory {
         sendingAt: OffsetDateTime?,
         countToPrint: Int
     ) {
-        val metadata = WorkflowEngine.metadata
         jsonGen.writeStartObject()
         // jsonGen.writeStringField("id", reportFile.reportId.toString())   // TMI?
         jsonGen.writeStringField("organization", orgSvc.organization.description)

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -299,7 +299,7 @@ class ReportFunction {
                 it.writeNumberField("reportItemCount", result.report.itemCount)
             } else
                 it.writeNullField("id")
-            actionHistory?.prettyPrintDestinationsJson(it)
+            actionHistory?.prettyPrintDestinationsJson(it, WorkflowEngine.metadata)
 
             it.writeNumberField("warningCount", result.warnings.size)
             it.writeNumberField("errorCount", result.errors.size)

--- a/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
@@ -1,18 +1,25 @@
 package gov.cdc.prime.router.azure
 
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import gov.cdc.prime.router.ClientSource
+import gov.cdc.prime.router.Metadata
 import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.OrganizationService
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.ResultDetail
 import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.azure.db.enums.TaskAction
+import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
 import io.mockk.spyk
 import io.mockk.verify
 import org.jooq.DSLContext
 import org.jooq.tools.jdbc.MockConnection
 import org.jooq.tools.jdbc.MockDataProvider
 import org.jooq.tools.jdbc.MockResult
+import java.io.ByteArrayOutputStream
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.Test
@@ -142,5 +149,95 @@ class ActionHistoryTests {
 //            connection.transaction(block = any() as TransactionalRunnable)
         }
 //        confirmVerified(connection)
+    }
+
+    @Test
+    fun `test prettyPrintDestinations`() {
+        val org0 =
+            Organization(
+                name = "org0",
+                description = "foo bar",
+                clients = listOf(),
+                services = listOf(
+                    OrganizationService("service0", "topic", "schema", format = Report.Format.REDOX)
+                )
+            )
+        val org1 =
+            Organization(
+                name = "org1",
+                description = "blah blah",
+                clients = listOf(),
+                services = listOf(
+                    OrganizationService("service1", "topic", "schema", format = Report.Format.HL7)
+                )
+            )
+        val metadata = Metadata().loadOrganizationList(listOf(org0, org1))
+        val actionHistory = ActionHistory(TaskAction.batch)
+        val r0 = ReportFile()
+        r0.reportId = UUID.randomUUID()
+        r0.receivingOrg = org0.name
+        r0.receivingOrgSvc = org0.services[0].name
+        r0.itemCount = 17
+        actionHistory.reportsOut[r0.reportId] = r0
+        val r1 = ReportFile()
+        r1.reportId = UUID.randomUUID()
+        r1.receivingOrg = org1.name
+        r1.receivingOrgSvc = org1.services[0].name
+        r1.nextActionAt = OffsetDateTime.now()
+        r1.itemCount = 1
+        actionHistory.reportsOut[r1.reportId] = r1
+
+        val factory = JsonFactory()
+        var outStream = ByteArrayOutputStream()
+        factory.createGenerator(outStream).use {
+            it.writeStartObject()
+            // Finally, we're ready to run the test:
+            actionHistory.prettyPrintDestinationsJson(it, metadata)
+            it.writeEndObject()
+        }
+
+        // Expecting this json:
+        // {"destinations":[
+        //   {"organization":"foo bar","organization_id":"org0",
+        //    "service":"service0","sending_at":"immediately","itemCount":17},
+        //   {"organization":"blah blah","organization_id":"org1","service":"service1",
+        //    "sending_at":"2021-02-13T17:30:33.847022-05:00","itemCount":1}],
+        //   "destinationCount":2}
+
+        val json = outStream.toString()
+        assertTrue { json.isNotEmpty() }
+        var tree: JsonNode? = jacksonObjectMapper().readTree(json)
+        assertNotNull(tree)
+        assertTrue(tree["destinationCount"].isInt)
+        assertEquals(2, tree["destinationCount"].intValue())
+        val arr = tree["destinations"] as ArrayNode
+        assertEquals(2, arr.size())
+
+        assertEquals("foo bar", arr[0]["organization"].textValue())
+        assertEquals("immediately", arr[0]["sending_at"].textValue())
+        assertEquals(17, arr[0]["itemCount"].intValue())
+
+        assertEquals("org1", arr[1]["organization_id"].textValue())
+        assertEquals("service1", arr[1]["service"].textValue())
+        assertEquals(1, arr[1]["itemCount"].intValue())
+
+        // Another test, this time add a 3rd ReportFile with same org as the one of the others.
+        val r2 = ReportFile(r1)
+        r2.reportId = UUID.randomUUID()
+        actionHistory.reportsOut[r2.reportId] = r2
+        outStream = ByteArrayOutputStream()
+        factory.createGenerator(outStream).use {
+            it.writeStartObject()
+            actionHistory.prettyPrintDestinationsJson(it, metadata)
+            it.writeEndObject()
+        }
+        val json2 = outStream.toString()
+        assertTrue { json2.isNotEmpty() }
+        var tree2: JsonNode? = jacksonObjectMapper().readTree(json2)
+        assertNotNull(tree2)
+        assertEquals(2, tree2["destinationCount"].intValue()) // still 2 destinations, even with 3 ReportFile
+        val arr2 = tree2["destinations"] as ArrayNode
+        assertEquals(2, arr2.size()) // still 2 destinations, even with 3 ReportFile
+        assertEquals(2, arr2[1]["itemCount"].intValue()) // second destination now has 2 items instead of 1.
     }
 }


### PR DESCRIPTION
This PR fixes an off by one bug in the itemCount field in the destinations response json.

The fix was literally one character, but I wrapped it with a gigantic test as a mea culpa.

## Checklist
- [X] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [X] Added an enormous test?
- [X] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

