### PR TITLE
Rename NAT Gateway Public IP

### DIFF
--- a/operations/app/src/modules/nat_gateway/main.tf
+++ b/operations/app/src/modules/nat_gateway/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 resource "azurerm_public_ip" "nat_gateway_ip" {
-  name = "${var.resource_prefix}-publicip.natgateway"
+  name = "${var.resource_prefix}-publicip"
   location = var.location
   resource_group_name = var.resource_group
   allocation_method = "Static"


### PR DESCRIPTION
Rename the public IP for the NAT Gateway back to the original (generic) naming.  Azure currently doesn't support renaming an IP address without destroying and re-creating.  Since we don't want the static IP to change, the name is being reverted.