### PR TITLE
PA Download

### DIFF
--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -187,9 +187,9 @@
         format: REDOX
 
   - name: pa-chester-phd
-    description: Chester County, Pennsylvania, Department of Health
+    description: Health Department - Chester County, Pennsylvania
     services:
-      - name: elr-chester-download
+      - name: elr-chester-download-local
         topic: covid-19
         schema: strac/strac-covid-19
         jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Chester, Delaware)" ]
@@ -199,9 +199,9 @@
         format: CSV
 
   - name: pa-montgomery-phd
-    description: Montgomery County, Pennsylvania, Department of Health
+    description: Office of Public Health - Montgomery County, Pennsylvania
     services:
-      - name: elr-montgomery-download
+      - name: elr-montgomery-download-local
         topic: covid-19
         schema: strac/strac-covid-19
         jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Montgomery)" ]

--- a/prime-router/metadata/organizations-local.yml
+++ b/prime-router/metadata/organizations-local.yml
@@ -186,6 +186,30 @@
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
 
+  - name: pa-chester-phd
+    description: Chester County, Pennsylvania, Department of Health
+    services:
+      - name: elr-chester-download
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Chester, Delaware)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+        format: CSV
+
+  - name: pa-montgomery-phd
+    description: Montgomery County, Pennsylvania, Department of Health
+    services:
+      - name: elr-montgomery-download
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+        format: CSV
+
   - name: prime
     description: Prime Test Receiver
     services:

--- a/prime-router/metadata/organizations-prod.yml
+++ b/prime-router/metadata/organizations-prod.yml
@@ -150,3 +150,33 @@
         transports:
           - type: REDOX
             apiKey: 9e7f9bd1-a876-4f10-9d17-0833dc7bf60d # Redox prod
+
+  - name: pa-chester-phd
+    description: Health Department - Chester County, Pennsylvania
+    services:
+      - name: elr-chester-download
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Chester, Delaware)" ]
+        transforms: { deidentify: false }
+        format: CSV
+        batch:
+          operation: MERGE
+          numberPerDay: 1 # Every day
+          initialBatch: 00:00
+          timeZone: EASTERN
+
+  - name: pa-montgomery-phd
+    description: Office of Public Health - Montgomery County, Pennsylvania
+    services:
+      - name: elr-montgomery-download
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Montgomery)" ]
+        transforms: { deidentify: false }
+        format: CSV
+        batch:
+          operation: MERGE
+          numberPerDay: 1 # Every day
+          initialBatch: 00:00
+          timeZone: EASTERN

--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -166,3 +166,37 @@
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
         format: REDOX
+
+  - name: pa-chester-phd
+    description: Health Department - Chester County, Pennsylvania
+    services:
+      - name: elr-chester-download-test
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Chester, Delaware)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+        format: CSV
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+          timeZone: EASTERN
+
+  - name: pa-montgomery-phd
+    description: Office of Public Health - Montgomery County, Pennsylvania
+    services:
+      - name: elr-montgomery-download-test
+        topic: covid-19
+        schema: strac/strac-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Montgomery)" ]
+        transforms: { deidentify: false }
+        defaults:
+          processing_mode_code: T
+        format: CSV
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+          timeZone: EASTERN

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -122,15 +122,15 @@ elements:
         code: 455371000124106
     csvFields: [{name: patient_positive, format: $alt}]
 
-  #
-  # These are the mapping of these fields into
-  #
-
-  # Base all LIVD values on this mapper
+  # Base all LVID values on this mapper
   - name: equipment_model_name
     mapper:
     default: BinaxNOW COVID-19 Ag Card
+    csvFields: [{name: equipment_model_name }]
 
+  #
+  # These are the mapping of these fields into
+  #
   - name: ordered_test_code
 
   - name: ordered_test_name


### PR DESCRIPTION
This PR adds the support requested by the Chester and Montgomery counties.

## Changes
- Adds a `model` field to STRAC schema
- Adds Chester and Montgomery 
Note: Chester support both Chester and Delaware counties

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

#501 
#496 



