### PR TITLE
Fix unselected prime.cdc.gov domain

### DIFF
--- a/operations/app/src/environments/dev/main.tf
+++ b/operations/app/src/environments/dev/main.tf
@@ -25,4 +25,5 @@ module "prime_data_hub" {
   okta_client_id = var.okta_client_id
   az_phd_user = var.az_phd_user
   az_phd_password = var.az_phd_password
+  https_cert_name = null
 }

--- a/operations/app/src/environments/prod/main.tf
+++ b/operations/app/src/environments/prod/main.tf
@@ -35,4 +35,5 @@ module "prime_data_hub" {
   okta_client_id = var.okta_client_id
   az_phd_user = var.az_phd_user
   az_phd_password = var.az_phd_password
+  https_cert_name = "prime-cdc-gov"
 }

--- a/operations/app/src/environments/test/main.tf
+++ b/operations/app/src/environments/test/main.tf
@@ -35,4 +35,5 @@ module "prime_data_hub" {
   okta_client_id = var.okta_client_id
   az_phd_user = var.az_phd_user
   az_phd_password = var.az_phd_password
+  https_cert_name = "test-prime-cdc-gov"
 }

--- a/operations/app/src/modules/front_door/main.tf
+++ b/operations/app/src/modules/front_door/main.tf
@@ -7,6 +7,7 @@ locals {
     functionapp_address = "${var.resource_prefix}-functionapp.azurewebsites.net"
     metabase_address = "${var.resource_prefix}-metabase.azurewebsites.net"
     prod_condition = var.environment == "prod" ? [1] : []
+    frontend_endpoints = var.environment == "prod" ? ["DefaultFrontendEndpoint", "prime-cdc-gov"] : ["DefaultFrontendEndpoint"]
     https_cert_secret_name = "prime-cdc-gov"
 }
 
@@ -100,7 +101,7 @@ resource "azurerm_frontdoor" "front_door" {
 
     routing_rule {
         name = "HttpToHttpsRedirect"
-        frontend_endpoints = ["DefaultFrontendEndpoint"]
+        frontend_endpoints = local.frontend_endpoints
         accepted_protocols = ["Http"]
         patterns_to_match = [
             "/",
@@ -119,7 +120,7 @@ resource "azurerm_frontdoor" "front_door" {
 
     routing_rule {
         name = "download"
-        frontend_endpoints = ["DefaultFrontendEndpoint"]
+        frontend_endpoints = local.frontend_endpoints
         accepted_protocols = ["Https"]
         patterns_to_match = ["/", "/download"]
 
@@ -132,7 +133,7 @@ resource "azurerm_frontdoor" "front_door" {
 
     routing_rule {
       name = "metabase"
-      frontend_endpoints = ["DefaultFrontendEndpoint"]
+      frontend_endpoints = local.frontend_endpoints
       accepted_protocols = ["Https"]
       patterns_to_match = ["/metabase", "/metabase/*"]
 
@@ -145,7 +146,7 @@ resource "azurerm_frontdoor" "front_door" {
 
     routing_rule {
         name = "api"
-        frontend_endpoints = ["DefaultFrontendEndpoint"]
+        frontend_endpoints = local.frontend_endpoints
         accepted_protocols = ["Https"]
         patterns_to_match = ["/*", "/api/*"]
 

--- a/operations/app/src/modules/front_door/variables.tf
+++ b/operations/app/src/modules/front_door/variables.tf
@@ -27,3 +27,8 @@ variable "eventhub_manage_auth_rule_id" {
   type = string
   description = "Event Hub Manage Authorization Rule ID"
 }
+
+variable "https_cert_name" {
+  type = string
+  description = "The HTTPS cert to associate with the front door. Omitting will not associate a domain to the front door."
+}

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -80,6 +80,7 @@ module "front_door" {
     key_vault_id = module.key_vault.application_key_vault_id
     eventhub_namespace_name = module.event_hub.eventhub_namespace_name
     eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+    https_cert_name = var.https_cert_name
 }
 
 module "sftp_container" {

--- a/operations/app/src/modules/prime_data_hub/variables.tf
+++ b/operations/app/src/modules/prime_data_hub/variables.tf
@@ -48,3 +48,8 @@ variable "okta_client_id" {
     description = "Okta Client ID"
     sensitive = true
 }
+
+variable "https_cert_name" {
+    type = string
+    description = "The HTTPS cert to associate with the front door. Omitting will not associate a domain to the front door."
+}


### PR DESCRIPTION
This PR fixes prime.cdc.gov not being selected on the front_door in production. It also configures test.prime.cdc.gov and allows other environments to have certs in the future.

## Changes
- Adds a local variable for frontend_endpoints, which included prime.cdc.gov in production.
- Adds a variable `https_cert_name` that is used to configure the cert on the front door. Null skips the configuration.

## Checklist
- [ ] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

