### PR TITLE
Added new Prime organization to organizations-test.yml

### DIFF
--- a/prime-router/metadata/organizations-test.yml
+++ b/prime-router/metadata/organizations-test.yml
@@ -216,3 +216,69 @@
           numberPerDay: 1440 # Every minute
           initialBatch: 00:00
           timeZone: EASTERN
+
+  - name: prime
+    description: Prime Test Receiver
+    services:
+      - name: CSV
+        topic: covid-19
+        schema: fl/fl-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PM)", "matches(ordering_facility_county, CSV)" ]
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+        format: CSV
+        transports:
+          - type: SFTP
+            host: 10.0.2.4
+            port: 22
+            filePath: ./upload
+      - name: HL7
+        topic: covid-19
+        schema: tx/tx-covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PM)", "matches(ordering_facility_county, HL7)" ]
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+        format: HL7
+        transports:
+          - type: SFTP
+            host: 10.0.2.4
+            port: 22
+            filePath: ./upload
+      - name: HL7_BATCH
+        topic: covid-19
+        schema: az/az-covid-19-hl7
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PM)", "matches(ordering_facility_county, HL7_BATCH)" ]
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+        format: HL7_BATCH
+        transports:
+          - type: SFTP
+            host: 10.0.2.4
+            port: 22
+            filePath: ./upload
+      - name: REDOX
+        topic: covid-19
+        schema: pa/pa-covid-19-redox
+        jurisdictionalFilter: [ "matches(ordering_facility_state, PM)", "matches(ordering_facility_county, REDOX)" ]
+        batch:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialBatch: 00:00
+        defaults:
+          processing_mode_code: T
+          redox_destination_id: 21485dc8-8a6e-49d3-8b80-46531e015039
+          redox_destination_name: "CDC Montgomery County PDH Destination (s) TEST ONLY"
+          redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+          redox_source_name: "Prime Data Hub (Staging)"
+        format: REDOX
+        transports:
+          - type: REDOX      # Will fail.
+            apiKey: some_key
+            baseUrl: some_url
+


### PR DESCRIPTION
This PR adds the new Prime organization as a fake public health department to Test.   It now exists in command line, -local, and -test, but not in -prod.

## Checklist
- [ ] Tested locally?    **Cannot test changes to Test locally.**
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- This is part of the overall API hardening work - giving us better ways to test our API.

## To Be Done

- Figure out what to do with Redox tests - should we push to a redox test endpoint, or stand up a mock redox in test?

