### PR TITLE
Deploy master to staging environment during pentesting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: Prime Data Hub
 
 on:
   pull_request:
-    # Disable master branch for pentesting
-    # branches: [ master, production ]
-    branches: [ production ]
+    branches: [ master, production ]
     paths-ignore:
       - 'prime-router/docs/**'
 
@@ -40,8 +38,8 @@ jobs:
                    echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
                    echo "Building for the test environment."
-                   echo >> $GITHUB_ENV ACR_REPO=pdhtestcontainerregistry.azurecr.io
-                   echo >> $GITHUB_ENV PREFIX=pdhtest
+                   echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
+                   echo >> $GITHUB_ENV PREFIX=pdhstaging
                    echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_TEST_USER }}
                    echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_TEST_PWD }}
                fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,7 @@ name: Prime Data Hub
 
 on:
   push:
-    # Disable master branch for pentesting
-    # branches: [ master, production ]
-    branches: [ production ]
-  workflow_dispatch:
+    branches: [ master, production ]
 
 defaults:
   run:
@@ -33,9 +30,9 @@ jobs:
                    echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
                    echo "Deploying to the test environment."
-                   echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-test
-                   echo >> $GITHUB_ENV ACR_REPO=pdhtestcontainerregistry.azurecr.io
-                   echo >> $GITHUB_ENV PREFIX=pdhtest
+                   echo >> $GITHUB_ENV RESOURCE_GROUP=prime-data-hub-staging
+                   echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
+                   echo >> $GITHUB_ENV PREFIX=pdhstaging
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=test
                    echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_TEST_CREDS }}
                    echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_STAGING_SECRET }}


### PR DESCRIPTION
While the `prime-data-hub-test` resource group is being pentested, we want to deploy our testable changes to the `prime-data-hub-staging` resource group.  This PR updates the CI/CD workflow to do so.