### PR TITLE
Fix for Terraform plan suggesting changes

### DIFF
--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -78,6 +78,16 @@ resource "azurerm_monitor_diagnostic_setting" "storageaccount_access_log" {
       enabled = false
     }
   }
+
+  metric {
+    category = "Capacity"
+    enabled  = false
+
+    retention_policy {
+      days = 0
+      enabled = false
+    }
+  }
 }
 
 output "storage_account_name" {


### PR DESCRIPTION
This PR fixes an issue where Terraform suggests making a change to the storage log diagnostic setting. The issue was a missing metric type in the Terraform module.

## Changes
-
- 

## Checklist
- [ ] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

- #issue

## To Be Done

- #issue 

