### PR TITLE
Hotfix: Add Key Vault access policies for the function app

### DIFF
--- a/operations/app/src/modules/function_app/variables.tf
+++ b/operations/app/src/modules/function_app/variables.tf
@@ -88,3 +88,13 @@ variable "eventhub_manage_auth_rule_id" {
     type = string
     description = "Event Hub Manage Authorization Rule ID"
 }
+
+variable "app_config_key_vault_id" {
+    type = string
+    description = "Key Vault used for function app configuration"
+}
+
+variable "client_config_key_vault_id" {
+    type = string
+    description = "Key Vault used for client credential secrets"
+}

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -52,6 +52,8 @@ module "function_app" {
     ai_instrumentation_key = module.application_insights.instrumentation_key
     eventhub_namespace_name = module.event_hub.eventhub_namespace_name
     eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+    app_config_key_vault_id = module.key_vault.app_config_key_vault_id
+    client_config_key_vault_id = module.key_vault.client_config_key_vault_id
 }
 
 module "database" {


### PR DESCRIPTION
- Adds missing access policies for the Key Vaults / Function App
- Note: There is a bug in the Terraform module for function apps. I have a workaround, but it requires two deploys. See my comment in the code for more info.