### PR TITLE
SimpleReport data dictionary

### DIFF
--- a/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
@@ -12,6 +12,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -21,6 +25,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -83,7 +91,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -193,6 +201,8 @@ Device_id_type is a generated value for the OBX-17 field. It is based on the dev
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -346,6 +356,8 @@ UNK|Unknown
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -376,6 +388,8 @@ Is this the patient's first test for this condition?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 77974-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -398,6 +412,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -419,6 +435,8 @@ Is the patient in the ICU?
 **Type**: DATE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
 
 **Cardinality**: [0..1]
 
@@ -733,7 +751,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -747,7 +765,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -761,9 +779,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -771,15 +793,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -793,7 +821,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -803,7 +831,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -813,7 +841,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -888,6 +916,8 @@ The zip code of the provider
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -1863,7 +1893,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1873,7 +1903,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1883,7 +1913,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1904,6 +1934,8 @@ The patient's zip code
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
 
 **Cardinality**: [0..1]
 
@@ -2017,6 +2049,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -2027,6 +2063,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's CLIA
+
 ---
 
 **Name**: resident_congregate_setting
@@ -2034,6 +2074,8 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
 
 **Cardinality**: [0..1]
 
@@ -2075,7 +2117,7 @@ Does the patient reside in a congregate care setting?
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -2175,11 +2217,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2265,6 +2313,8 @@ The specimen source, such as Blood or Serum
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2430,7 +2480,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2588,6 +2638,10 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: SPM-2-1
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The specimen-id from the testing lab
 
 ---
 

--- a/prime-router/docs/schema_documentation/az-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19.md
@@ -408,7 +408,7 @@ The zip code of the facility which the test was ordered from
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -422,6 +422,8 @@ The first name of the provider who ordered the test
 
 **Type**: PERSON_NAME
 
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
 **Cardinality**: [0..1]
 
 **Documentation**:
@@ -434,7 +436,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -452,6 +454,10 @@ The phone number of the provider
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: Collection_Date
@@ -460,7 +466,7 @@ The phone number of the provider
 
 **Format**: yyyyMMdd
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
@@ -192,6 +192,10 @@ Additional field per request from the County.  HHS lists 4 codes for 'Prior test
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: Test_result_code
@@ -234,6 +238,8 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -244,7 +250,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Format**: yyyy-MM-dd
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -505,6 +511,8 @@ The patient's phone number with area code
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95418-0
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -526,6 +534,8 @@ Is the patient employed in health care?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
 
 **Cardinality**: [0..1]
 
@@ -549,6 +559,8 @@ Does the patient reside in a congregate care setting?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -570,6 +582,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -798,7 +812,7 @@ The phone number of the facility which the test was ordered from
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -812,6 +826,8 @@ The ordering provider’s National Provider Identifier
 
 **Type**: PERSON_NAME
 
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
 **Cardinality**: [0..1]
 
 **Documentation**:
@@ -824,7 +840,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -912,7 +928,7 @@ The zip code of the provider
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -974,7 +990,7 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
@@ -382,7 +382,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -536,7 +536,7 @@ The phone number of the facility which the test was ordered from
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -561,7 +561,7 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -634,7 +634,7 @@ F|Final
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -648,7 +648,7 @@ The ordering provider’s National Provider Identifier
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -661,6 +661,8 @@ The first name of the provider who ordered the test
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -754,7 +756,7 @@ The zip code of the provider
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -996,7 +998,7 @@ N|Normal
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1147,6 +1149,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1199,6 +1203,8 @@ Is the patient pregnant?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -1238,6 +1244,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -1291,6 +1299,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1342,6 +1352,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -1395,6 +1407,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1447,6 +1461,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1498,6 +1514,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/covid-19-redox.md
@@ -382,7 +382,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -536,7 +536,7 @@ The phone number of the facility which the test was ordered from
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -561,7 +561,7 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -634,7 +634,7 @@ F|Final
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -648,7 +648,7 @@ The ordering provider’s National Provider Identifier
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -661,6 +661,8 @@ The first name of the provider who ordered the test
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -754,7 +756,7 @@ The zip code of the provider
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -996,7 +998,7 @@ N|Normal
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1147,6 +1149,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1199,6 +1203,8 @@ Is the patient pregnant?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -1238,6 +1244,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -1291,6 +1299,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1342,6 +1352,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -1395,6 +1407,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1447,6 +1461,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1498,6 +1514,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19.md
+++ b/prime-router/docs/schema_documentation/covid-19.md
@@ -49,7 +49,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -159,6 +159,8 @@ Device_id_type is a generated value for the OBX-17 field. It is based on the dev
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -312,6 +314,8 @@ UNK|Unknown
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -342,6 +346,8 @@ Is this the patient's first test for this condition?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 77974-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -364,6 +370,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -385,6 +393,8 @@ Is the patient in the ICU?
 **Type**: DATE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
 
 **Cardinality**: [0..1]
 
@@ -699,7 +709,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -713,7 +723,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -727,9 +737,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -737,15 +751,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -759,7 +779,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -769,7 +789,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -779,7 +799,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -854,6 +874,8 @@ The zip code of the provider
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -1829,7 +1851,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1839,7 +1861,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1849,7 +1871,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1870,6 +1892,8 @@ The patient's zip code
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
 
 **Cardinality**: [0..1]
 
@@ -1983,6 +2007,10 @@ The message profile identifer
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -1992,6 +2020,10 @@ The message profile identifer
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -2017,6 +2049,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -2027,6 +2063,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's CLIA
+
 ---
 
 **Name**: resident_congregate_setting
@@ -2034,6 +2074,8 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
 
 **Cardinality**: [0..1]
 
@@ -2075,7 +2117,7 @@ Does the patient reside in a congregate care setting?
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -2175,11 +2217,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2265,6 +2313,8 @@ The specimen source, such as Blood or Serum
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2430,7 +2480,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2588,6 +2638,10 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: SPM-2-1
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The specimen-id from the testing lab
 
 ---
 

--- a/prime-router/docs/schema_documentation/fl-fl-covid-19.md
+++ b/prime-router/docs/schema_documentation/fl-fl-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -506,7 +514,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -520,7 +528,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -534,9 +542,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -544,15 +556,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -566,7 +584,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -576,7 +594,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1575,7 +1593,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1585,7 +1603,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1595,7 +1613,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1720,7 +1738,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1732,6 +1750,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1741,6 +1763,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1758,7 +1784,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1858,11 +1884,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2043,7 +2075,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2194,6 +2226,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2264,6 +2300,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2285,6 +2323,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2308,6 +2348,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2329,6 +2371,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2352,6 +2396,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2374,6 +2420,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2383,6 +2431,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2417,6 +2467,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2438,6 +2490,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/la-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/la-la-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -506,7 +514,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -520,7 +528,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -534,9 +542,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -544,15 +556,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -566,7 +584,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -576,7 +594,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1575,7 +1593,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1585,7 +1603,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1595,7 +1613,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1720,7 +1738,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1732,6 +1750,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1741,6 +1763,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1758,7 +1784,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1858,11 +1884,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2043,7 +2075,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2194,6 +2226,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2264,6 +2300,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2285,6 +2323,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2308,6 +2348,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2329,6 +2371,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2352,6 +2396,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2374,6 +2420,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2383,6 +2431,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2417,6 +2467,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2438,6 +2490,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2535,7 +2589,7 @@ UNK|Unknown
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nd-nd-covid-19.md
+++ b/prime-router/docs/schema_documentation/nd-nd-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -506,7 +514,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -520,7 +528,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -534,9 +542,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -544,15 +556,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -566,7 +584,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -576,7 +594,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1575,7 +1593,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1585,7 +1603,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1595,7 +1613,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1720,7 +1738,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1732,6 +1750,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1741,6 +1763,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1758,7 +1784,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1858,11 +1884,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2043,7 +2075,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2194,6 +2226,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2264,6 +2300,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2285,6 +2323,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2308,6 +2348,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2329,6 +2371,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2352,6 +2396,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2374,6 +2420,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2383,6 +2431,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2417,6 +2467,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2438,6 +2490,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -506,7 +514,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -520,7 +528,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -534,9 +542,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -544,15 +556,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -566,7 +584,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -576,7 +594,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1575,7 +1593,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1585,7 +1603,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1595,7 +1613,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1720,7 +1738,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1732,6 +1750,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1741,6 +1763,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1758,7 +1784,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1858,11 +1884,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2043,7 +2075,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2194,6 +2226,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2264,6 +2300,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2285,6 +2323,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2308,6 +2348,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2329,6 +2371,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2352,6 +2396,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2374,6 +2420,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2383,6 +2431,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2417,6 +2467,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2438,6 +2490,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
@@ -12,6 +12,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -21,6 +25,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -69,7 +77,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -179,6 +187,8 @@ Device_id_type is a generated value for the OBX-17 field. It is based on the dev
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -332,6 +342,8 @@ UNK|Unknown
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -362,6 +374,8 @@ Is this the patient's first test for this condition?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 77974-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -384,6 +398,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -405,6 +421,8 @@ Is the patient in the ICU?
 **Type**: DATE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
 
 **Cardinality**: [0..1]
 
@@ -719,7 +737,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -733,7 +751,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -747,9 +765,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -757,15 +779,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -779,7 +807,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -789,7 +817,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -799,7 +827,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -874,6 +902,8 @@ The zip code of the provider
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -1849,7 +1879,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1859,7 +1889,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1869,7 +1899,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1890,6 +1920,8 @@ The patient's zip code
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
 
 **Cardinality**: [0..1]
 
@@ -2017,6 +2049,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -2027,6 +2063,10 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's CLIA
+
 ---
 
 **Name**: resident_congregate_setting
@@ -2034,6 +2074,8 @@ The reference range of the lab result, such as “Negative” or “Normal”. F
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
 
 **Cardinality**: [0..1]
 
@@ -2075,7 +2117,7 @@ Does the patient reside in a congregate care setting?
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -2175,11 +2217,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2265,6 +2313,8 @@ The specimen source, such as Blood or Serum
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2430,7 +2480,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2588,6 +2638,10 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: SPM-2-1
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The specimen-id from the testing lab
 
 ---
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -483,7 +483,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -625,7 +625,7 @@ The phone number of the facility which the test was ordered from
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -650,7 +650,7 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -723,7 +723,7 @@ F|Final
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -737,7 +737,7 @@ The ordering provider’s National Provider Identifier
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -750,6 +750,8 @@ The first name of the provider who ordered the test
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -831,7 +833,7 @@ The zip code of the provider
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1073,7 +1075,7 @@ N|Normal
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1195,6 +1197,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1247,6 +1251,8 @@ Is the patient pregnant?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -1286,6 +1292,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -1339,6 +1347,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1390,6 +1400,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -1443,6 +1455,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1495,6 +1509,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -1546,6 +1562,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19.md
@@ -228,13 +228,17 @@ The patient's ethnicity. There is a valueset defined based on the values in PID-
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: SpecimenCollectedDate
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/pdi-covid-19.md
@@ -1,0 +1,1362 @@
+
+### Schema:         pdi-covid-19
+#### Description:   HL7 data elements resulting from pdi-covid-19
+
+---
+
+**Name**: employed_in_healthcare
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient employed in health care?
+
+---
+
+**Name**: first_test
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is this the patient's first test for this condition?
+
+---
+
+**Name**: illness_onset_date
+
+**Type**: DATE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: resident_congregate_setting
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Does the patient reside in a congregate care setting?
+
+---
+
+**Name**: symptomatic_for_disease
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient symptomatic?
+
+---
+
+**Name**: sending_application
+
+**Type**: HD
+
+**HL7 Field**: MSH-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: reporting_facility_name
+
+**Type**: TEXT
+
+**HL7 Field**: MSH-4-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's name
+
+---
+
+**Name**: reporting_facility_clia
+
+**Type**: ID_CLIA
+
+**HL7 Field**: MSH-4-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
+
+---
+
+**Name**: receiving_application
+
+**Type**: HD
+
+**HL7 Field**: MSH-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
+---
+
+**Name**: receiving_facility
+
+**Type**: HD
+
+**HL7 Field**: MSH-6
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
+
+---
+
+**Name**: message_id
+
+**Type**: ID
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+unique id to track the usage of the message
+
+---
+
+**Name**: processing_mode_code
+
+**Type**: CODE
+
+**HL7 Field**: MSH-11-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+D|Debugging
+P|Production
+T|Training
+
+**Documentation**:
+
+P, D, or T for Production, Debugging, or Training
+
+---
+
+**Name**: message_profile_id
+
+**Type**: EI
+
+**HL7 Field**: MSH-21
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The message profile identifer
+
+---
+
+**Name**: ordered_test_code
+
+**Type**: TABLE
+
+**HL7 Field**: OBR-4-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Ordered LOINC Code
+
+---
+
+**Name**: ordered_test_name
+
+**Type**: TABLE
+
+**HL7 Field**: OBR-4-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Ordered LOINC Long Name
+
+---
+
+**Name**: ordered_test_system_abbr
+
+**Type**: TEXT
+
+**HL7 Field**: OBR-4-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: date_result_released
+
+**Type**: DATETIME
+
+**HL7 Field**: OBR-22
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: result_format
+
+**Type**: TEXT
+
+**HL7 Field**: OBX-2
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: test_performed_code
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+The LOINC code of the test performed. This is a standardized coded value describing the test
+
+---
+
+**Name**: test_performed_name
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-3-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Performed LOINC Long Name
+
+**Documentation**:
+
+The LOINC description of the test performed as related to the LOINC code.
+
+---
+
+**Name**: test_performed_system_abbr
+
+**Type**: TEXT
+
+**HL7 Field**: OBX-3-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: test_result
+
+**Type**: CODE
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+
+**Documentation**:
+
+The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+
+---
+
+**Name**: abnormal_flag
+
+**Type**: CODE
+
+**HL7 Field**: OBX-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+A|Abnormal (applies to non-numeric results)
+>|Above absolute high-off instrument scale
+H|Above high normal
+HH|Above upper panic limits
+AC|Anti-complementary substances present
+<|Below absolute low-off instrument scale
+L|Below low normal
+LL|Below lower panic limits
+B|Better--use when direction not relevant
+TOX|Cytotoxic substance present
+DET|Detected
+IND|Indeterminate
+I|Intermediate. Indicates for microbiology susceptibilities only.
+MS|Moderately susceptible. Indicates for microbiology susceptibilities only.
+NEG|Negative
+null|No range defined, or normal ranges don't apply
+NR|Non-reactive
+N|Normal (applies to non-numeric results)
+ND|Not Detected
+POS|Positive
+QCF|Quality Control Failure
+RR|Reactive
+R|Resistant. Indicates for microbiology susceptibilities only.
+D|Significant change down
+U|Significant change up
+S|Susceptible. Indicates for microbiology susceptibilities only.
+AA|Very abnormal (applies to non-numeric units, analogous to panic limits for numeric units)
+VS|Very susceptible. Indicates for microbiology susceptibilities only.
+WR|Weakly reactive
+W|Worse--use when direction not relevant
+
+**Documentation**:
+
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
+
+---
+
+**Name**: test_result_status
+
+**Type**: CODE
+
+**HL7 Fields**: OBX-11-1, OBR-25-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+A|Some, but not all, results available
+C|Corrected, final
+F|Final results
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+X|No results available; Order canceled
+Y|No order on record for this test
+Z|No record of this patient
+
+---
+
+**Name**: device_id
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-17-1
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Documentation**:
+
+Device_id is a generated value for the OBX-17 field. It is based on the device model and the LIVD table.
+
+---
+
+**Name**: device_id_type
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-17-3
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Documentation**:
+
+Device_id_type is a generated value for the OBX-17 field. It is based on the device model and the LIVD table.
+
+---
+
+**Name**: equipment_model_id
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-18-1
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Equipment UID
+
+---
+
+**Name**: equipment_model_id_type
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-18-3
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Equipment UID Type
+
+---
+
+**Name**: test_result_date
+
+**Type**: DATETIME
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_name
+
+**Type**: TEXT
+
+**HL7 Field**: OBX-23-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: testing_lab_id_assigner
+
+**Type**: HD
+
+**HL7 Field**: OBX-23-6
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_clia
+
+**Type**: ID_CLIA
+
+**HL7 Field**: OBX-23-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
+
+---
+
+**Name**: testing_lab_street
+
+**Type**: STREET
+
+**HL7 Field**: OBX-24-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_street2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: OBX-24-2
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_city
+
+**Type**: CITY
+
+**HL7 Field**: OBX-24-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_state
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+---
+
+**Name**: testing_lab_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_county_code
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-24-9
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: placer_order_id
+
+**Type**: ID
+
+**HL7 Fields**: ORC-2-1, OBR-2-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: filler_order_id
+
+**Type**: ID
+
+**HL7 Field**: ORC-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: ordering_provider_id
+
+**Type**: ID_NPI
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ordering provider’s National Provider Identifier
+
+---
+
+**Name**: ordering_provider_first_name
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: ordering_provider_id_authority
+
+**Type**: HD
+
+**HL7 Fields**: ORC-12-9, OBR-16-9
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
+
+---
+
+**Name**: ordering_provider_id_authority_type
+
+**Type**: TEXT
+
+**HL7 Fields**: ORC-12-13, OBR-16-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
+
+---
+
+**Name**: ordering_provider_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: order_test_date
+
+**Type**: DATE
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: ordering_facility_name
+
+**Type**: TEXT
+
+**HL7 Field**: ORC-21-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_street
+
+**Type**: STREET
+
+**HL7 Field**: ORC-22-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The address of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_street2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: ORC-22-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The secondary address of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_city
+
+**Type**: CITY
+
+**HL7 Field**: ORC-22-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_state
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: ORC-22-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_facility_county_code
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-22-9
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: ordering_facility_email
+
+**Type**: EMAIL
+
+**HL7 Field**: ORC-23-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: ordering_facility_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Field**: ORC-23
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The phone number of the facility which the test was ordered from
+
+---
+
+**Name**: ordering_provider_street
+
+**Type**: STREET
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: ordering_provider_street2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: ordering_provider_city
+
+**Type**: CITY
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: ordering_provider_state
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: ordering_provider_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: ordering_provider_county_code
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-24-9
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: patient_id
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_id_assigner
+
+**Type**: HD
+
+**HL7 Field**: PID-3-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_last_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The patient's last name
+
+---
+
+**Name**: patient_first_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: patient_middle_initial
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_middle_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_suffix
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_name_type_code
+
+**Type**: TEXT
+
+**HL7 Field**: PID-5-7
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_dob
+
+**Type**: DATE
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: patient_gender
+
+**Type**: CODE
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patient_race
+
+**Type**: CODE
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: patient_street
+
+**Type**: STREET
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: patient_street2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: patient_city
+
+**Type**: CITY
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patient_state
+
+**Type**: TABLE
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The patient's state
+
+---
+
+**Name**: patient_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: patient_county_code
+
+**Type**: TABLE
+
+**HL7 Field**: PID-11-9
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: FIPS
+
+---
+
+**Name**: patient_email
+
+**Type**: EMAIL
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: patient_ethnicity
+
+**Type**: CODE
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+
+**Documentation**:
+
+The patient's ethnicity. There is a valueset defined based on the values in PID-22, but downstream consumers are free to define their own values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patient_died
+
+**Type**: CODE
+
+**HL7 Field**: PID-30-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+---
+
+**Name**: testing_lab_specimen_id
+
+**Type**: ID
+
+**HL7 Field**: SPM-2-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The specimen-id from the testing lab
+
+---
+
+**Name**: specimen_type
+
+**Type**: CODE
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: specimen_source_site_code
+
+**Type**: CODE
+
+**HL7 Field**: SPM-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+119297000|Blood specimen (specimen)
+71836000|Nasopharyngeal structure (body structure)
+45206002|Nasal structure (body structure)
+
+---
+
+**Name**: specimen_collection_date_time
+
+**Type**: DATETIME
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The date which the specimen was collected. The default format is yyyyMMddHHmmsszz
+
+
+---
+
+**Name**: testing_lab_specimen_received_datetime
+
+**Type**: DATETIME
+
+**HL7 Field**: SPM-18-1
+
+**Cardinality**: [0..1]
+
+---

--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -198,7 +198,7 @@ pointer/link to the unique id of a previously submitted result.  Usually blank. 
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -218,7 +218,7 @@ pointer/link to the unique id of a previously submitted result.  Usually blank. 
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -278,6 +278,8 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -286,7 +288,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -571,6 +573,8 @@ P, D, or T for Production, Debugging, or Training
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95418-0
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -592,6 +596,8 @@ Is the patient employed in health care?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
 
 **Cardinality**: [0..1]
 
@@ -615,6 +621,8 @@ Does the patient reside in a congregate care setting?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -636,6 +644,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -898,7 +908,7 @@ The phone number of the facility which the test was ordered from
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -912,6 +922,8 @@ The ordering provider’s National Provider Identifier
 
 **Type**: PERSON_NAME
 
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
 **Cardinality**: [0..1]
 
 **Documentation**:
@@ -924,7 +936,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -1012,7 +1024,7 @@ The zip code of the provider
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1042,6 +1054,10 @@ The phone number of the provider
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1051,5 +1067,9 @@ The phone number of the provider
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---

--- a/prime-router/docs/schema_documentation/standard-standard-covid-19.md
+++ b/prime-router/docs/schema_documentation/standard-standard-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -482,7 +490,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -496,7 +504,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -510,9 +518,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -520,15 +532,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -542,7 +560,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -552,7 +570,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1539,7 +1557,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1549,7 +1567,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1559,7 +1577,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1684,7 +1702,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1696,6 +1714,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1705,6 +1727,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1722,7 +1748,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1822,11 +1848,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2007,7 +2039,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2146,6 +2178,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2216,6 +2252,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2237,6 +2275,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2260,6 +2300,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2281,6 +2323,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2304,6 +2348,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2326,6 +2372,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2335,6 +2383,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2369,6 +2419,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2390,6 +2442,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2511,7 +2565,7 @@ UNK|Unknown
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -12,6 +12,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_CLIA
@@ -21,6 +25,10 @@
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -42,7 +50,7 @@ The name of the facility which the test was ordered from
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -178,7 +186,7 @@ The zip code of the provider
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -366,6 +374,8 @@ The patient's ethnicity. There is a valueset defined based on the values in PID-
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -471,6 +481,8 @@ The patient's state
 **Type**: DATE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
 
 **Cardinality**: [0..1]
 
@@ -649,7 +661,7 @@ The specimen source, such as Blood or Serum
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -711,7 +723,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -719,7 +731,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/tx-tx-covid-19.md
+++ b/prime-router/docs/schema_documentation/tx-tx-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -482,7 +490,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -496,7 +504,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -510,9 +518,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -520,15 +532,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -542,7 +560,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -552,7 +570,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1539,7 +1557,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1549,7 +1567,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1559,7 +1577,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1684,7 +1702,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1696,6 +1714,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1705,6 +1727,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1722,7 +1748,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1822,11 +1848,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2007,7 +2039,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2146,6 +2178,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2216,6 +2252,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2237,6 +2275,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2260,6 +2300,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2281,6 +2323,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2304,6 +2348,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2326,6 +2372,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2335,6 +2383,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2369,6 +2419,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2390,6 +2442,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2511,7 +2565,7 @@ UNK|Unknown
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/vt-vt-covid-19.md
+++ b/prime-router/docs/schema_documentation/vt-vt-covid-19.md
@@ -22,6 +22,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The receiving application for the message (specified by the receiver)
+
 ---
 
 **Name**: receiving_facility
@@ -31,6 +35,10 @@
 **HL7 Field**: MSH-6
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The receiving facility for the message (specified by the receiver)
 
 ---
 
@@ -482,7 +490,7 @@ The city of the provider
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-3
+**HL7 Fields**: ORC-12-3, OBR-16-3
 
 **Cardinality**: [0..1]
 
@@ -496,7 +504,7 @@ The first name of the provider who ordered the test
 
 **Type**: ID_NPI
 
-**HL7 Field**: ORC-12-1
+**HL7 Fields**: ORC-12-1, OBR-16-1
 
 **Cardinality**: [0..1]
 
@@ -510,9 +518,13 @@ The ordering provider’s National Provider Identifier
 
 **Type**: HD
 
-**HL7 Field**: ORC-12-9
+**HL7 Fields**: ORC-12-9, OBR-16-9
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually the OID for CMS
 
 ---
 
@@ -520,15 +532,21 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-12-13
+**HL7 Fields**: ORC-12-13, OBR-16-13
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+Usually NPI
 
 ---
 
 **Name**: ordering_provider_last_name
 
 **Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
 
 **Cardinality**: [0..1]
 
@@ -542,7 +560,7 @@ The last name of provider who ordered the test
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 
@@ -552,7 +570,7 @@ The last name of provider who ordered the test
 
 **Type**: TELEPHONE
 
-**HL7 Field**: ORC-14
+**HL7 Fields**: ORC-14, OBR-17
 
 **Cardinality**: [0..1]
 
@@ -1539,7 +1557,7 @@ The patient's zip code
 
 **Type**: ID
 
-**HL7 Field**: ORC-2-1
+**HL7 Fields**: ORC-2-1, OBR-2-1
 
 **Cardinality**: [0..1]
 
@@ -1549,7 +1567,7 @@ The patient's zip code
 
 **Type**: TEXT
 
-**HL7 Field**: ORC-2-2
+**HL7 Fields**: ORC-2-2, ORC-4-2, OBR-2-2
 
 **Cardinality**: [0..1]
 
@@ -1559,7 +1577,7 @@ The patient's zip code
 
 **Type**: ID_CLIA
 
-**HL7 Field**: ORC-2-3
+**HL7 Fields**: ORC-2-3, ORC-4-3, OBR-2-3
 
 **Cardinality**: [0..1]
 
@@ -1684,7 +1702,7 @@ W|Worse--use when direction not relevant
 
 **Documentation**:
 
-This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
 ---
 
@@ -1696,6 +1714,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The reporting facility's name
+
 ---
 
 **Name**: reporting_facility_clia
@@ -1705,6 +1727,10 @@ This field contains a table lookup indicating the normalcy status of the result.
 **HL7 Field**: MSH-4-2
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
 
 ---
 
@@ -1722,7 +1748,7 @@ This field contains a table lookup indicating the normalcy status of the result.
 
 **Type**: DATETIME
 
-**HL7 Field**: SPM-17-1
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
 
 **Cardinality**: [0..1]
 
@@ -1822,11 +1848,17 @@ WOOD|Swab, Wooden Shaft
 
 **Type**: EI
 
+**HL7 Fields**: SPM-2, OBR-3-1
+
 **Cardinality**: [0..1]
 
 
 **Reference URL**:
 [https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
 
 ---
 
@@ -2007,7 +2039,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **Type**: CODE
 
-**HL7 Field**: OBX-11-1
+**HL7 Fields**: OBX-11-1, OBR-25-1
 
 **Cardinality**: [0..1]
 
@@ -2146,6 +2178,10 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen-id from the testing lab
+
 ---
 
 **Name**: testing_lab_specimen_received_datetime
@@ -2216,6 +2252,8 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 82810-3
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2237,6 +2275,8 @@ Is the patient pregnant?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
 
 **Cardinality**: [0..1]
 
@@ -2260,6 +2300,8 @@ Is the patient employed in health care?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95417-2
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2281,6 +2323,8 @@ Is this the patient's first test for this condition?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
 
 **Cardinality**: [0..1]
 
@@ -2304,6 +2348,8 @@ Is the patient hospitalized?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95420-6
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2326,6 +2372,8 @@ Is the patient in the ICU?
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 65222-2
+
 **Cardinality**: [0..1]
 
 ---
@@ -2335,6 +2383,8 @@ Is the patient in the ICU?
 **Type**: NUMBER
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
 
 **Cardinality**: [0..1]
 
@@ -2369,6 +2419,8 @@ Always filled when `patient_age` is filled
 
 **HL7 Field**: AOE
 
+**LOINC Code**: 95421-4
+
 **Cardinality**: [0..1]
 
 **Value Sets**
@@ -2390,6 +2442,8 @@ Does the patient reside in a congregate care setting?
 **Type**: CODE
 
 **HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
 
 **Cardinality**: [0..1]
 
@@ -2511,7 +2565,7 @@ UNK|Unknown
 
 **Type**: PERSON_NAME
 
-**HL7 Field**: ORC-12-4
+**HL7 Fields**: ORC-12-4, OBR-16-4
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -18,7 +18,7 @@ elements:
     hhsGuidanceField:
     hl7Field: OBX-8
     mapper: obx8(test_result)
-    documentation: This field contains a table lookup indicating the normalcy status of the result.  A = abnormal; N = normal
+    documentation: This field is generated based on the normalcy status of the result. A = abnormal; N = normal
 
   - name: comment
     type: TEXT
@@ -364,6 +364,7 @@ elements:
     mapper: ifPresent(ordering_provider_id, CMS^2.16.840.1.113883.3.249^ISO)
     hl7Field: ORC-12-9
     hl7OutputFields: [ORC-12-9, OBR-16-9]
+    documentation: Usually the OID for CMS
 
   - name: ordering_provider_id_authority_type
     type: TEXT
@@ -372,6 +373,7 @@ elements:
     mapper: ifPresent(ordering_provider_id, NPI)
     hl7Field: ORC-12-13
     hl7OutputFields: [ORC-12-13, OBR-16-13]
+    documentation: Usually NPI
 
   - name: ordering_provider_last_name
     type: PERSON_NAME
@@ -747,10 +749,12 @@ elements:
   - name: receiving_application
     type: HD
     hl7Field: MSH-5
+    documentation: The receiving application for the message (specified by the receiver)
 
   - name: receiving_facility
     type: HD
     hl7Field: MSH-6
+    documentation: The receiving facility for the message (specified by the receiver)
 
   - name: reference_range
     type: TEXT
@@ -764,12 +768,14 @@ elements:
     natFlatFileField: Reporting_facility_name
     hhsGuidanceField:
     hl7Field: MSH-4-1
+    documentation: The reporting facility's name
 
   - name: reporting_facility_clia
     type: ID_CLIA
     natFlatFileField: Reporting_facility_id
     hhsGuidanceField:
     hl7Field: MSH-4-2
+    documentation: The reporting facility's CLIA
 
   - name: resident_congregate_setting
     type: CODE
@@ -820,11 +826,13 @@ elements:
     hl7Field: SPM-14
     referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.8/Fields/SPM.14
 
+  # replaced by testing_lab_specimen_id?
   - name: specimen_id
     type: EI
     hl7OutputFields: [SPM-2, OBR-3-1]
     mapper: use(message_id)
     referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2
+    documentation: A unique code for this specimen
 
   - name: specimen_role
     type: CODE
@@ -1027,6 +1035,7 @@ elements:
     natFlatFileField: Testing_lab_specimen_id
     hhsGuidanceField:
     hl7Field: SPM-2-1
+    documentation: The specimen-id from the testing lab
 
   - name: testing_lab_specimen_received_datetime
     type: DATETIME

--- a/prime-router/src/main/kotlin/DocumentationFactory.kt
+++ b/prime-router/src/main/kotlin/DocumentationFactory.kt
@@ -23,7 +23,11 @@ object DocumentationFactory {
         appendLabelAndData(sb, "Name", displayName)
         appendLabelAndData(sb, "Type", element.type?.name)
         appendLabelAndData(sb, "Format", csvField?.format)
-        appendLabelAndData(sb, "HL7 Field", element.hl7Field)
+        if (element.hl7OutputFields != null)
+            appendLabelAndData(sb, "HL7 Fields", element.hl7OutputFields.joinToString(", "))
+        else if (element.hl7Field != null)
+            appendLabelAndData(sb, "HL7 Field", element.hl7Field)
+        if (element.hl7Field == "AOE") appendLabelAndData(sb, "LOINC Code", element.hl7AOEQuestion)
         appendLabelAndData(
             sb, "Cardinality",
             element.cardinality?.toFormatted() ?: Element.Cardinality.ZERO_OR_ONE.toFormatted()

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -20,6 +20,7 @@ import gov.cdc.prime.router.FileSettings
 import gov.cdc.prime.router.FileSource
 import gov.cdc.prime.router.Metadata
 import gov.cdc.prime.router.Report
+import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.SettingsProvider
 import gov.cdc.prime.router.Translator
 import gov.cdc.prime.router.serializers.CsvSerializer
@@ -152,6 +153,7 @@ class ProcessData : CliktCommand(
     ).flag()
     private val receivingOrganization by option(
         "--output-receiving-org",
+        metavar = "<org name>",
         help = "Output using the APHL file format"
     )
 
@@ -467,6 +469,9 @@ class GenerateDocs : CliktCommand(
     private val includeTimestamps by
     option("--include-timestamps", help = "include creation time in file names")
         .flag(default = false)
+    private val outputHl7Elements by option(
+        "--mapped-hl7-elements"
+    ).flag(default = false)
     private val outputFileName by option(
         "--output",
         metavar = "<path>",
@@ -494,7 +499,7 @@ class GenerateDocs : CliktCommand(
             }
         } else {
             val schemaName = inputSchema?.toLowerCase() ?: ""
-            val schema = metadata.findSchema(schemaName)
+            var schema = metadata.findSchema(schemaName)
             if (schema == null) {
                 echo("$schemaName not found. Did you mean one of these?")
                 listSchemas(metadata)
@@ -502,6 +507,9 @@ class GenerateDocs : CliktCommand(
             }
             // start generating documentation
             echo("Generating documentation for $schemaName")
+            if (outputHl7Elements) {
+                schema = buildMappedHl7Schema(schema)
+            }
             DocumentationFactory.writeDocumentationForSchema(schema, outputDir, outputFileName, includeTimestamps)
         }
     }
@@ -509,6 +517,52 @@ class GenerateDocs : CliktCommand(
     override fun run() {
         val metadata = Metadata(Metadata.defaultMetadataDirectory)
         generateSchemaDocumentation(metadata)
+    }
+
+    /**
+     * Build a schema that contains all hl7 elements that would result from translation of the input schema
+     * This includes not only the elements from the input schema, but also mapped and default elements. Filter
+     * these elements to only those that have HL7 fields. In other words, this schema represents the
+     * output data dictionary for the input schema. The schema is sorted by HL7 segment.
+     */
+    private fun buildMappedHl7Schema(fromSchema: Schema): Schema {
+        val metadata = Metadata(Metadata.defaultMetadataDirectory)
+        val fileSettings = FileSettings(FileSettings.defaultSettingsDirectory)
+        val translator = Translator(metadata, fileSettings)
+        val mappedDefaults = mapOf(
+            "receiving_application" to "AZ",
+            "receiving_facility" to "AZDOH",
+            "message_profile_id" to "AZELR"
+        )
+        val toSchema = metadata.findSchema("covid-19") ?: error("covid-19 schema not defined")
+        val mapping = translator.buildMapping(toSchema, fromSchema, mappedDefaults)
+        val set = mutableSetOf<String>()
+        set.addAll(mapping.useDirectly.keys)
+        set.addAll(mapping.useDefault.keys)
+        set.addAll(mapping.useValueSet.keys)
+        set.addAll(mapping.useMapper.keys)
+        val reg = Regex("([A-Z]*)-?(\\d+)?-?(\\d+)?")
+        val hl7Elements = set.toList().mapNotNull {
+            val element = toSchema.findElement(it) ?: error("invalid element: $it")
+            if (element.hl7Field != null || element.hl7AOEQuestion != null) element else null
+        }.sortedBy {
+            if (it.hl7Field != null) {
+                val matches = reg.find(it.hl7Field) ?: return@sortedBy ""
+                val groupValues = matches.groupValues
+                val segment = groupValues[1]
+                val field = if (groupValues[2].isNotBlank()) 'A'.plus(groupValues[2].toInt()) else ""
+                val subField = if (groupValues[3].isNotBlank()) 'A'.plus(groupValues[3].toInt()) else ""
+                "$segment$field$subField${it.name}"
+            } else {
+                ""
+            }
+        }
+        return Schema(
+            fromSchema.baseName,
+            "covid-19",
+            hl7Elements,
+            description = "HL7 data elements resulting from ${fromSchema.baseName}"
+        )
     }
 }
 


### PR DESCRIPTION
This PR adds a documentation option to create a data dictionary for simple report. This data dictionary lists all HL7 elements that SimpleReport will generate. See prime-router/docs/schema_documentation/pdi-covid-19.md for an example output. 

## Changes
-  `--mapped-hl7-elements` flag for generating documents
- builds a special schema when this flag is set

## Checklist
- [x] Tested locally?
- [ ] Added new dependencies?
- [ ] Updated the docs?
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 

#577 

