### PR TITLE
Remove setting env vars manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
                    echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhprod
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=prod
-                   echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_PROD_CREDS }}
-                   echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_PROD_SECRET }}
                    echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_PROD_USER }}
                    echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_PROD_PWD }}
                else
@@ -34,8 +32,6 @@ jobs:
                    echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
                    echo >> $GITHUB_ENV PREFIX=pdhstaging
                    echo >> $GITHUB_ENV PRIME_ENVIRONMENT=test
-                   echo >> $GITHUB_ENV SFTP_CREDS=${{ secrets.SFTP_TEST_CREDS }}
-                   echo >> $GITHUB_ENV REDOX_SECRET=${{ secrets.REDOX_STAGING_SECRET }}
                    echo >> $GITHUB_ENV POSTGRES_USER=${{ secrets.POSTGRESQL_TEST_USER }}
                    echo >> $GITHUB_ENV POSTGRES_PASSWORD=${{ secrets.POSTGRESQL_TEST_PWD }}
                fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,17 +80,3 @@ jobs:
 
       - name: Restart Azure Functions App
         run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.PREFIX }}-functionapp
-
-      - name: Set SFTP Environment Variables
-        run: |
-              az functionapp config appsettings set \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name ${{ env.PREFIX }}-functionapp \
-              --settings PRIME_ENVIRONMENT=${{ env.PRIME_ENVIRONMENT }} ${{ env.SFTP_CREDS }}
-
-      - name: Set Redox Environment Variables
-        run: |
-              az functionapp config appsettings set \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name ${{ env.PREFIX }}-functionapp \
-              --settings REDOX_SECRET=${{ env.REDOX_SECRET }} 


### PR DESCRIPTION
Environment variables were manually being set using the Azure CLI via stored GitHub secrets.  This is no longer desired as the secrets are now in Azure Key Vault and their reference is derived by terraform.  Removing this code prevents secrets being reverted from Key Vault references to their original values stored in GitHub.  Once this PR is merged, these secrets will be purged from GitHub.