### PR TITLE
Null Transport

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -405,10 +405,7 @@
           schemaName: tx/tx-covid-19
           format: HL7
         transport:
-          type: SFTP
-          host: sftp
-          port: 22
-          filePath: ./upload
+          type: NULL
       - name: HL7_BATCH
         organizationName: ignore
         topic: covid-19

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -405,10 +405,7 @@
         schemaName: tx/tx-covid-19
         format: HL7
       transport:
-        type: SFTP
-        host: 10.0.2.4
-        port: 22
-        filePath: ./upload
+        type: NULL
     - name: HL7_BATCH
       organizationName: ignore
       topic: covid-19

--- a/prime-router/src/main/kotlin/TransportType.kt
+++ b/prime-router/src/main/kotlin/TransportType.kt
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     JsonSubTypes.Type(SFTPTransportType::class, name = "SFTP"),
     JsonSubTypes.Type(EmailTransportType::class, name = "EMAIL"),
     JsonSubTypes.Type(RedoxTransportType::class, name = "REDOX"),
+    JsonSubTypes.Type(NullTransportType::class, name = "NULL"),
 )
 abstract class TransportType(val type: String)
 
@@ -37,3 +38,8 @@ data class RedoxTransportType
     val baseUrl: String?,
 ) :
     TransportType("REDOX")
+
+data class NullTransportType
+@JsonCreator constructor(
+    val dummy: String? = null,
+) : TransportType("NULL")

--- a/prime-router/src/main/kotlin/azure/BatchFunction.kt
+++ b/prime-router/src/main/kotlin/azure/BatchFunction.kt
@@ -71,7 +71,7 @@ class BatchFunction {
             }
             actionHistory.queueMessages() // Must be done after txn, to avoid race condition
         } catch (e: Exception) {
-            context.logger.log(Level.SEVERE, "Batch exception", e)
+            context.logger.log(Level.SEVERE, "Batch function exception for event: $message", e)
         }
     }
 }

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -89,7 +89,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
             }
             // For debugging and auditing purposes
         } catch (t: Throwable) {
-            context.logger.log(Level.SEVERE, "Send exception", t)
+            context.logger.log(Level.SEVERE, "Send function exception for event: $message", t)
         }
     }
 

--- a/prime-router/src/main/kotlin/transport/NullTransport.kt
+++ b/prime-router/src/main/kotlin/transport/NullTransport.kt
@@ -7,6 +7,9 @@ import gov.cdc.prime.router.TransportType
 import gov.cdc.prime.router.azure.ActionHistory
 import gov.cdc.prime.router.azure.WorkflowEngine
 
+/**
+ * The Null transport is intended for testing and benchmarking purposes.
+ */
 class NullTransport : ITransport {
     override fun send(
         transportType: TransportType,
@@ -16,7 +19,7 @@ class NullTransport : ITransport {
         context: ExecutionContext,
         actionHistory: ActionHistory
     ): RetryItems? {
-        if (header.content == null) error("No content to Null for report ${header.reportFile.reportId}")
+        if (header.content == null) error("No content for report ${header.reportFile.reportId}")
         val receiver = header.receiver ?: error("No receiver defined for report ${header.reportFile.reportId}")
         val fileName = Report.formExternalFilename(header)
         val msg = "Sending to Null Transport"

--- a/prime-router/src/main/kotlin/transport/NullTransport.kt
+++ b/prime-router/src/main/kotlin/transport/NullTransport.kt
@@ -1,0 +1,35 @@
+package gov.cdc.prime.router.transport
+
+import com.microsoft.azure.functions.ExecutionContext
+import gov.cdc.prime.router.Report
+import gov.cdc.prime.router.ReportId
+import gov.cdc.prime.router.TransportType
+import gov.cdc.prime.router.azure.ActionHistory
+import gov.cdc.prime.router.azure.WorkflowEngine
+
+class NullTransport : ITransport {
+    override fun send(
+        transportType: TransportType,
+        header: WorkflowEngine.Header,
+        sentReportId: ReportId,
+        retryItems: RetryItems?,
+        context: ExecutionContext,
+        actionHistory: ActionHistory
+    ): RetryItems? {
+        if (header.content == null) error("No content to Null for report ${header.reportFile.reportId}")
+        val receiver = header.receiver ?: error("No receiver defined for report ${header.reportFile.reportId}")
+        val fileName = Report.formExternalFilename(header)
+        val msg = "Sending to Null Transport"
+        actionHistory.trackActionResult(msg)
+        actionHistory.trackSentReport(
+            receiver,
+            sentReportId,
+            fileName,
+            transportType.toString(),
+            msg,
+            header.reportFile.itemCount
+        )
+        actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
+        return null
+    }
+}


### PR DESCRIPTION
This PR creates a NullTransport which doesn't send anything but creates ActionHistory. This transport is just intended for benchmarking purposes. 

## Changes
- NullTransport
- Switched IG.HL7 receiver to use the NullTransport to help narrow down a throughput bottleneck
- Added a better logging for the outer handler of the Send and Batch function

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 
- #issues in GitHub

## To Be Done
- Stuff still to done

