### PR TITLE
Adds logic to map the zip code to the county for routing

### DIFF
--- a/prime-router/docs/schema_documentation/tcp-tcp-covid-19.md
+++ b/prime-router/docs/schema_documentation/tcp-tcp-covid-19.md
@@ -189,11 +189,15 @@ The patient's state
 
 **Name**: Zip
 
-**Type**: POSTAL_CODE
+**Type**: TABLE
 
 **HL7 Field**: PID-11-5
 
 **Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: zipcode
 
 **Documentation**:
 
@@ -540,6 +544,30 @@ Is the patient pregnant?
 
 ---
 
+**Name**: sending_application
+
+**Type**: HD
+
+**HL7 Field**: MSH-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: message_profile_id
+
+**Type**: EI
+
+**HL7 Field**: MSH-21
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The message profile identifer
+
+---
+
 **Name**: patient_first_name
 
 **Type**: PERSON_NAME
@@ -579,5 +607,126 @@ The patient's last name
 **Documentation**:
 
 The first name of the provider who ordered the test
+
+---
+
+**Name**: ordering_provider_last_name
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: testing_lab_name
+
+**Type**: TEXT
+
+**HL7 Field**: OBX-23-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: testing_lab_city
+
+**Type**: CITY
+
+**HL7 Field**: OBX-24-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_street
+
+**Type**: STREET
+
+**HL7 Field**: OBX-24-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_state
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+---
+
+**Name**: testing_lab_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: testing_lab_phone_number
+
+**Type**: TELEPHONE
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testing_lab_clia
+
+**Type**: ID_CLIA
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
+
+---
+
+**Name**: patient_county
+
+**Type**: TABLE
+
+**Cardinality**: [1..1]
+
+**Table**: zip-code-data
+
+**Table Column**: county
 
 ---

--- a/prime-router/metadata/schemas/TCP/tcp-covid-19.schema
+++ b/prime-router/metadata/schemas/TCP/tcp-covid-19.schema
@@ -70,6 +70,9 @@ elements:
     csvFields: [{ name: State }]
 
   - name: patient_zip_code
+    type: TABLE
+    table: zip-code-data
+    tableColumn: zipcode
     csvFields: [{ name: Zip }]
 
   - name: patient_phone_number_raw
@@ -145,6 +148,10 @@ elements:
 
   - name: equipment_model_name
 
+  - name: sending_application
+
+  - name: message_profile_id
+
   - name: patient_first_name
     mapper: split(patient_name, 0)
 
@@ -153,3 +160,37 @@ elements:
 
   - name: ordering_provider_first_name
     mapper: split(ordering_provider, 0)
+
+  - name: ordering_provider_last_name
+    mapper: split(ordering_provider, 1)
+
+  - name: testing_lab_name
+    default: TPCA Lab and Diagnostic Imaging Center
+
+  - name: testing_lab_city
+    default: Talahassee
+
+  - name: testing_lab_street
+    default: 1803 Miccosukee Commons Drive
+
+  - name: testing_lab_state
+    default: FL
+
+  - name: testing_lab_zip_code
+    default: 32308
+
+  - name: testing_lab_county
+    default: Leon
+
+  - name: testing_lab_phone_number
+    default: 8509426624
+
+  - name: testing_lab_clia
+    default: 10D0270039
+
+  - name: patient_county
+    type: TABLE
+    table: zip-code-data
+    tableColumn: county
+    mapper: lookup(patient_zip_code)
+    #csvFields: [{ name: Patient_county }] # <- uncomment this to see it show up in csv file

--- a/prime-router/metadata/tables/zip-code-data.csv
+++ b/prime-router/metadata/tables/zip-code-data.csv
@@ -4367,7 +4367,9 @@ state_fips,state,state_abbr,zipcode,county,city
 12,Florida,FL,32301,Leon,Tallahassee
 12,Florida,FL,32303,Leon,Tallahassee
 12,Florida,FL,32304,Leon,Tallahassee
+12,Florida,FL,32305,Leon,Tallahassee
 12,Florida,FL,32308,Leon,Tallahassee
+12,Florida,FL,32309,Leon,Tallahassee
 12,Florida,FL,32310,Leon,Tallahassee
 12,Florida,FL,32311,Leon,Tallahassee
 12,Florida,FL,32312,Leon,Tallahassee


### PR DESCRIPTION
This PR updates the TPC schema to include more default fields that make the HL7 look fuller and includes a mapper for the county for patients.

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


