### PR TITLE
Fixed download file extension issue

### DIFF
--- a/prime-router/src/main/kotlin/azure/DownloadFunction.kt
+++ b/prime-router/src/main/kotlin/azure/DownloadFunction.kt
@@ -93,7 +93,7 @@ class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngi
         return reportFiles.sortedByDescending {
             it.createdAt
         }.map {
-            val svc = WorkflowEngine().settings.findReceiver(it.receivingOrg)
+            val svc = WorkflowEngine().settings.findReceiver(it.receivingOrg + "." + it.receivingOrgSvc)
             val orgDesc = authClaims.organization.description
             val receiver = if (svc !== null && svc.description.isNotBlank()) svc.description else orgDesc
             TestResult(
@@ -174,9 +174,14 @@ class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngi
                 response = responsePage(request, authClaims)
             else {
                 val filename = Report.formExternalFilename(header)
+                val mimeType = when (header.reportFile.bodyFormat) {
+                    "CSV" -> "text/csv"
+                    "HL7" -> "text/hl7"
+                    else -> "text/plain"
+                }
                 response = request
                     .createResponseBuilder(HttpStatus.OK)
-                    .header("Content-Type", "text/csv")
+                    .header("Content-Type", mimeType)
                     .header("Content-Disposition", "attachment; filename=$filename")
                     .body(header.content)
                     .build()

--- a/prime-router/src/main/kotlin/azure/DownloadFunction.kt
+++ b/prime-router/src/main/kotlin/azure/DownloadFunction.kt
@@ -174,9 +174,12 @@ class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngi
                 response = responsePage(request, authClaims)
             else {
                 val filename = Report.formExternalFilename(header)
+                // todo replace with Report.Format.toMimeType
                 val mimeType = when (header.reportFile.bodyFormat) {
-                    "CSV" -> "text/csv"
-                    "HL7" -> "text/hl7"
+                    Report.Format.CSV.name -> "text/csv"
+                    Report.Format.HL7.name -> "text/hl7"
+                    Report.Format.HL7_BATCH.name -> "text/hl7"
+                    Report.Format.INTERNAL.name -> "text/csv"
                     else -> "text/plain"
                 }
                 response = request


### PR DESCRIPTION
This PR fixes a bug wherein .hl7 files were given an .csv file extension on download.

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 
- Bug that file extensions for hl7 downloads were erroneous.

## To Be Done
- Confirm on various browsers.  I tested on Firefox and Safari
