### PR TITLE
Improve local docker-compose settings

### DIFF
--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -85,9 +85,13 @@ services:
 
   settings:
     build: settings/.
-    command: "--wait=8 prime_dev organizations-local.yml"
+    command: "--wait=8 prime_dev /settings/organizations-local.yml"
     depends_on:
       - prime_dev
+    volumes:
+      - type: bind
+        source: ./settings
+        target: /settings
 
   # Secrets management
   vault:


### PR DESCRIPTION
This PR removes the requirement that changes to `organizations-local.yml` be `mvn package` before running `docker-compose up` 

## Changes
- `organizations-local.yml` is now bound to the container instead placed into the container. 
- 

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 
- #issues in GitHub

## To Be Done
- Stuff still to done

