### PR TITLE
Fixes the cast to a safe cast for the HL7Configuration object

### DIFF
--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -249,7 +249,7 @@ class Hl7Serializer(val metadata: Metadata) {
 
     internal fun createMessage(report: Report, row: Int, translatorConfig: TranslatorConfiguration? = null): String {
         val message = ORU_R01()
-        val hl7Config = translatorConfig as Hl7Configuration?
+        val hl7Config = translatorConfig as? Hl7Configuration?
         val processingId = if (hl7Config?.useTestProcessingMode == true) {
             "T"
         } else {


### PR DESCRIPTION
This PR fixes a bug in the unsafe cast of a translator config to the hl7 configuration. Corrected it to be safe.

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 
- Exception occurring in staging currently running batch operations

