### PR TITLE
Fixes bug in mapper

### DIFF
--- a/prime-router/src/main/kotlin/Mappers.kt
+++ b/prime-router/src/main/kotlin/Mappers.kt
@@ -413,9 +413,7 @@ class SplitMapper : Mapper {
         }
         val splitElements = value.split(delimiter)
         val index = args[1].toInt()
-        if (index > splitElements.count()) error("Index $index exceeds count of split values in $value")
-
-        return splitElements[index].trim()
+        return splitElements.getOrNull(index)?.trim()
     }
 }
 
@@ -432,9 +430,7 @@ class SplitByCommaMapper : Mapper {
         val delimiter = ","
         val splitElements = value.split(delimiter)
         val index = args[1].toInt()
-        if (index > splitElements.count()) error("Index $index exceeds count of split values in $value")
-
-        return splitElements[index].trim()
+        return splitElements.getOrNull(index)?.trim()
     }
 }
 

--- a/prime-router/src/test/kotlin/MapperTests.kt
+++ b/prime-router/src/test/kotlin/MapperTests.kt
@@ -301,8 +301,20 @@ class MapperTests {
     }
 
     @Test
-    fun `test split by comma mapper`() {
+    fun `test split mapper with error condition`() {
         val mapper = SplitMapper()
+        val args = listOf("patient_name", "1")
+        val element = Element("patient_first_name")
+        val values = listOf(
+            ElementAndValue(Element("patient_name"), "ThereAreNoSpacesHere")
+        )
+        val actual = mapper.apply(element, args, values)
+        assertNull(actual, "Expected null. Actual $actual")
+    }
+
+    @Test
+    fun `test split by comma mapper`() {
+        val mapper = SplitByCommaMapper()
         val args = listOf("patient_name", "2")
         val element = Element("patient_first_name")
         val values = listOf(
@@ -311,6 +323,18 @@ class MapperTests {
         val expected = "Mona"
         val actual = mapper.apply(element, args, values)
         assertEquals(expected, actual, "Expected $expected. Actual $actual")
+    }
+
+    @Test
+    fun `test split by comma mapper error condition`() {
+        val mapper = SplitByCommaMapper()
+        val args = listOf("patient_name", "2")
+        val element = Element("patient_first_name")
+        val values = listOf(
+            ElementAndValue(Element("patient_name"), "I have no commas")
+        )
+        val actual = mapper.apply(element, args, values)
+        assertNull(actual, "Expected null. Actual $actual")
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a bug in the split mappers so they never fail with an error but just return null.

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added a test?
- [ ] Did you check for sensitive data, and remove any?
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes 
- #issues in GitHub

## To Be Done
- Stuff still to done

