### PR TITLE
Revert Service Plan Name

### DIFF
--- a/operations/app/src/modules/app_service_plan/main.tf
+++ b/operations/app/src/modules/app_service_plan/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 resource "azurerm_app_service_plan" "service_plan" {
-  name = "${var.resource_prefix}-appserviceplan"
+  name = "${var.resource_prefix}-serviceplan"
   location = var.location
   resource_group_name = var.resource_group
   kind = "Linux"


### PR DESCRIPTION
Renaming an app service plan requires the destruction and re-provisioning of it.  I am reverting this so that it can be avoided in the environments where it is not necessary.