### PR TITLE
Add options for to assist backfill of results

### DIFF
--- a/prime-router/docs/openapi.yml
+++ b/prime-router/docs/openapi.yml
@@ -33,6 +33,7 @@ paths:
             enum:
               - ValidatePayload # Validate the payload, but do not process. return 200 on OK or 400 on fail
               - CheckConnections # Health check
+              - SendImmediately # Send the reports immediately, skip batching and timing
               - SkipSend # Validate and route but do not send reports. Data is kept in the hub.
               - SkipInvalidItems # Send valid ones
           example: ValidatePayload
@@ -47,6 +48,15 @@ paths:
             items:
               type: string
           example: processing_mode_code%3AD
+        - in: query
+          name: routeTo
+          description: A comma speparated list of receiver names. Limit the list of possible receivers to these receivers.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          example: fl-phd.elr,fl-phd.download
       requestBody:
         description: The public health information being routed
         required: true

--- a/prime-router/docs/releases/2021-03-15-release-notes.md
+++ b/prime-router/docs/releases/2021-03-15-release-notes.md
@@ -1,0 +1,18 @@
+#  Report Stream March 15, 2021*
+
+## General useful links:
+
+- All Schemas are documented here:  [Link to detailed schema dictionaries](../schema_documentation)
+- The Hub API is documented here: [Hub OpenApi Spec](../openapi.yml)
+- [Click here for all release notes](../releases)
+
+## For this release
+
+### New `/api/reports` options to support back filling of results
+
+Two changes to the `/api/reports` end-point to assist in sending reports to a particular receiver. This is type action will typically be done when a new receiver is defined after a results are received by the hub. 
+
+- `SendImmediately` value for the `option` query parameter to bypass any timing found on the receiver.
+- `routeTo` query parameter restricts the list of receivers which a report can be routed to. 
+  
+The `routeTo` parameter **does not** bypass the jurisdictional filters of the receiver, so results meant for one receiver still cannot be sent to another receiver.

--- a/prime-router/src/main/kotlin/Translator.kt
+++ b/prime-router/src/main/kotlin/Translator.kt
@@ -34,11 +34,13 @@ class Translator(private val metadata: Metadata, private val settings: SettingsP
      */
     fun filterAndTranslateByReceiver(
         input: Report,
-        defaultValues: DefaultValues = emptyMap()
+        defaultValues: DefaultValues = emptyMap(),
+        limitReceiversTo: List<String> = emptyList()
     ): List<Pair<Report, Receiver>> {
         if (input.isEmpty()) return emptyList()
         return settings.receivers.filter { receiver ->
-            receiver.topic == input.schema.topic
+            receiver.topic == input.schema.topic &&
+                (limitReceiversTo.isEmpty() || limitReceiversTo.contains(receiver.fullName))
         }.mapNotNull { receiver ->
             val mappedReport = translateByReceiver(input, receiver, defaultValues)
             if (mappedReport.itemCount == 0) return@mapNotNull null

--- a/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
@@ -12,7 +12,6 @@ import gov.cdc.prime.router.Metadata
 import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.Receiver
 import gov.cdc.prime.router.Report
-import gov.cdc.prime.router.ResultDetail
 import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.ItemLineage
@@ -58,9 +57,9 @@ class ActionHistoryTests {
         val one = Schema(name = "one", topic = "test", elements = listOf())
         val report1 = Report(one, listOf(), sources = listOf(ClientSource("myOrg", "myClient")))
         val incomingReport = ReportFunction.ValidatedRequest(
-            ReportFunction.Options.CheckConnections, mapOf(),
-            listOf<ResultDetail>(),
-            listOf<ResultDetail>(), report1, HttpStatus.OK
+            HttpStatus.OK,
+            options = ReportFunction.Options.CheckConnections,
+            report = report1,
         )
         val actionHistory1 = ActionHistory(TaskAction.receive)
         val blobInfo1 = BlobAccess.BlobInfo(Report.Format.CSV, "myUrl", byteArrayOf(0x11, 0x22))
@@ -80,9 +79,8 @@ class ActionHistoryTests {
 
         // must pass a valid report.   Here, its set to null.
         val incomingReport2 = ReportFunction.ValidatedRequest(
-            ReportFunction.Options.CheckConnections, mapOf(),
-            listOf<ResultDetail>(),
-            listOf<ResultDetail>(), null, HttpStatus.OK
+            HttpStatus.OK,
+            options = ReportFunction.Options.CheckConnections
         )
         assertFails { actionHistory1.trackExternalInputReport(incomingReport2, blobInfo1) }
     }
@@ -228,9 +226,8 @@ class ActionHistoryTests {
         val one = Schema(name = "schema1", topic = "topic1", elements = listOf())
         val report1 = Report(one, listOf(), sources = listOf(ClientSource("myOrg", "myClient")))
         val incomingReport = ReportFunction.ValidatedRequest(
-            ReportFunction.Options.None, mapOf(),
-            listOf<ResultDetail>(),
-            listOf<ResultDetail>(), report1, HttpStatus.OK
+            HttpStatus.OK,
+            report = report1,
         )
         val actionHistory1 = ActionHistory(TaskAction.receive)
         val blobInfo1 = BlobAccess.BlobInfo(Report.Format.CSV, "myUrl", byteArrayOf(0x11, 0x22))

--- a/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
+++ b/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
@@ -153,11 +153,7 @@ class WorkflowEngineTests {
         every { actionHistory.trackExternalInputReport(any(), any()) }.returns(Unit)
 
         val engine = makeEngine(metadata, settings)
-        val validatedRequest = ReportFunction.ValidatedRequest(
-            ReportFunction.Options.None,
-            emptyMap(),
-            emptyList(), emptyList(), report1, HttpStatus.OK
-        )
+        val validatedRequest = ReportFunction.ValidatedRequest(HttpStatus.OK, report = report1)
         engine.receiveReport(validatedRequest, actionHistory)
 
         verify(exactly = 1) {


### PR DESCRIPTION
Two changes to the `/api/reports` end-point to assist in sending reports to a particular receiver. This is type action will typically be done when a new receiver is defined after a results are received by the hub. 

- `SendImmediately` value for the `option` query parameter to bypass any timing found on the receiver.
- `routeTo` query parameter restricts the list of receivers which a report can be routed to. 
  
The `routeTo` parameter **does not** bypass the jurisdictional filters of the receiver, so results meant for one receiver still cannot be sent to another receiver.

## Changes
- As described above

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [x] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- Note that the jurisdictional filters are not bypassed by the `routeTo` function.

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

