### PR TITLE
Update TX AOE Questions to Default Those That Can Be Defaulted

### DIFF
--- a/prime-router/metadata/schemas/TX/tx-covid-19.schema
+++ b/prime-router/metadata/schemas/TX/tx-covid-19.schema
@@ -244,14 +244,19 @@ elements:
 
   # AOE questions
   - name: pregnant
+    default: 261665006
 
   - name: employed_in_healthcare
+    default: UNK
 
   - name: first_test
+    default: UNK
 
   - name: hospitalized
+    default: UNK
 
   - name: icu
+    default: UNK
 
   - name: illness_onset_date
 
@@ -260,6 +265,8 @@ elements:
   - name: patient_age_units
 
   - name: resident_congregate_setting
+    default: UNK
 
   - name: symptomatic_for_disease
+    default: UNK
 


### PR DESCRIPTION
This PR updates the TX schema to default the AOE questions that can be defaulted by a single value. The only two that cannot be defaulted are `patient_age` and `illness_onset_date`.  HHS guidance says to not default these.

## Changes
- Adds default value to the AOE questions

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes
- #662 

## To Be Done

