### PR TITLE
Use Key Vault for client secret management

### DIFF
--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -86,6 +86,10 @@ resource "azurerm_function_app" "function_app" {
     "TX_DOH__ELR__USER" = "@Microsoft.KeyVault(VaultName=${var.resource_prefix}-appconfig;SecretName=functionapp-tx-phd-user)"
     "TX_DOH__ELR__PASS" = "@Microsoft.KeyVault(VaultName=${var.resource_prefix}-appconfig;SecretName=functionapp-tx-phd-pass)"
 
+    # Manage client secrets via a KeyVault
+    "CREDENTIAL_STORAGE_METHOD": "AZURE"
+    "CREDENTIAL_KEY_VAULT_NAME": "${var.resource_prefix}-clientconfig"
+
     "WEBSITE_VNET_ROUTE_ALL" = 1
 
     "DOCKER_REGISTRY_SERVER_URL" = var.login_server


### PR DESCRIPTION
This PR sets the environment variables required for the function app to use the Key Vault.

This must be deployed before #392 so the environment variables are in place. The Key Vault will not be used until the application code is deployed.

A follow on PR will be submit after this rolls out successfully to remove the old environment variables.