### PR TITLE
Updates path for SFTP in prod for LA and aligns test organization files

### DIFF
--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -205,7 +205,7 @@
         type: SFTP
         host: 204.58.124.41
         port: 22
-        filePath: ./HL7
+        filePath: ./
 
 - name: oh-doh
   description: Ohio Department of Health

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -163,7 +163,18 @@
       deidentify: false
       translation:
         type: HL7
+        schemaName: fl/fl-covid-19
         useBatchHeaders: true
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: nd-doh
   description: North Dakota Department of Health
@@ -176,11 +187,22 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, ND)" ]
       translation:
         type: HL7
+        schemaName: nd/nd-covid-19
         useBatchHeaders: true
         receivingApplicationName: Maven
         receivingApplicationOID: 2.16.840.1.114222.4.3.4.34.1.1
         receivingFacilityName: NDDOH
         receivingFacilityOID: 2.16.840.1.113883.3.89.109.100.1.3
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: la-doh
   description: Louisiana Department of Health
@@ -193,11 +215,22 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, LA)" ]
       translation:
         type: HL7
+        schemaName: la/la-covid-19
         useBatchHeaders: true
         receivingOrganization: LAOPH
         receivingApplicationName: LA-ELR
         receivingFacilityName: LADOH
         nameFormat: APHL
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: oh-doh
   description: Ohio Department of Health
@@ -210,6 +243,7 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, OH)" ]
       translation:
         type: HL7
+        schemaName: oh/oh-covid-19
         useBatchHeaders: true
         suppressQstForAoe: true
         receivingApplicationName: OHDOH
@@ -217,6 +251,16 @@
         receivingFacilityName: OHDOH
         receivingFacilityOID: 2.16.840.1.114222.4.1.3674
         nameFormat: OHIO
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: nm-doh
   description: New Mexico Department of Health
@@ -229,11 +273,22 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, NM)" ]
       translation:
         type: HL7
+        schemaName: nm/nm-covid-19
         useBatchHeaders: true
         receivingApplicationName: NMDOH
         receivingApplicationOID: 2.16.840.1.113883.3.5364
         receivingFacilityName: NMDOH
         receivingFacilityOID: 2.16.840.1.113883.3.5364
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: mt-doh
   description: Montana Department of Health
@@ -246,6 +301,7 @@
       jurisdictionalFilter: [ "matches(patient_state, MT)" ]
       translation:
         type: HL7
+        schemaName: mt/mt-covid-19
         useBatchHeaders: true
 
 - name: tx-doh
@@ -259,9 +315,20 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, TX)" ]
       translation:
         type: HL7
+        schemaName: tx/tx-covid-19
         useBatchHeaders: true
         receivingApplicationName: NEDSS
         receivingFacilityName: TX-ELR
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: ARIZONA
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
 
 - name: co-phd
   description: Colorado Department of Health


### PR DESCRIPTION
This PR updates the sftp path for LA in prod to have the checker pass. Also aligned the organizations-test file so everything is aligned.

## Changes
- Changes path for SFTP for LA in prod
- Updates `organizations-test.yml` to match other organization files

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

