### PR TITLE
Secret Management Service

### DIFF
--- a/prime-router/src/main/kotlin/azure/DownloadFunction.kt
+++ b/prime-router/src/main/kotlin/azure/DownloadFunction.kt
@@ -15,6 +15,7 @@ import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
+import gov.cdc.prime.router.secrets.SecretManagement
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 import org.thymeleaf.templateresolver.StringTemplateResolver
@@ -27,7 +28,7 @@ import java.util.Calendar
 import java.util.UUID
 import java.util.logging.Level
 
-class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()) {
+class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()) : SecretManagement {
     val DAYS_TO_SHOW = 7L
     val LOGIN_PAGE = "./assets/csv-download-site/login__inline.html"
     val DOWNLOAD_PAGE = "./assets/csv-download-site/index__inline.html"
@@ -76,7 +77,7 @@ class DownloadFunction(private val workflowEngine: WorkflowEngine = WorkflowEngi
 
         val attr = mapOf(
             "OKTA_baseUrl" to System.getenv("OKTA_baseUrl"),
-            "OKTA_clientId" to System.getenv("OKTA_clientId"),
+            "OKTA_clientId" to secretService.fetchSecret("OKTA_clientId"),
             "OKTA_redirect" to System.getenv("OKTA_redirect")
         )
 

--- a/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
@@ -1,0 +1,28 @@
+package gov.cdc.prime.router.secrets
+
+import com.azure.core.credential.TokenCredential
+import com.azure.identity.DefaultAzureCredentialBuilder
+import com.azure.security.keyvault.secrets.SecretClient
+import com.azure.security.keyvault.secrets.SecretClientBuilder
+
+internal object AzureSecretService : SecretService()  {
+    private val KEY_VAULT_NAME: String by lazy { System.getenv("SECRET_KEY_VAULT_NAME") ?: "" }
+    private val secretClient by lazy { initSecretClient() }
+
+    internal fun initSecretClient(
+        secretClientBuilder: SecretClientBuilder = SecretClientBuilder(),
+        credential: TokenCredential = DefaultAzureCredentialBuilder().build()
+    ): SecretClient {
+        return secretClientBuilder
+            .vaultUrl("https://$KEY_VAULT_NAME.vault.azure.net")
+            .credential(credential)
+            .buildClient()
+    }
+
+    override fun fetchSecretFromStore(secretName: String): String? {
+        val azureSafeSecretName = secretName.toLowerCase().replace("_", "-")
+        return secretClient.getSecret(azureSafeSecretName)?.let {
+            return it.value
+        }
+    }
+}

--- a/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
@@ -5,7 +5,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.security.keyvault.secrets.SecretClient
 import com.azure.security.keyvault.secrets.SecretClientBuilder
 
-internal object AzureSecretService : SecretService()  {
+internal object AzureSecretService : SecretService() {
     private val KEY_VAULT_NAME: String by lazy { System.getenv("SECRET_KEY_VAULT_NAME") ?: "" }
     private val secretClient by lazy { initSecretClient() }
 

--- a/prime-router/src/main/kotlin/secrets/EnvVarSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/EnvVarSecretService.kt
@@ -1,0 +1,7 @@
+package gov.cdc.prime.router.secrets
+
+internal object EnvVarSecretService : SecretService() {
+    override fun fetchSecretFromStore(secretName: String): String? {
+        return System.getenv(secretName)
+    }
+}

--- a/prime-router/src/main/kotlin/secrets/SecretManagement.kt
+++ b/prime-router/src/main/kotlin/secrets/SecretManagement.kt
@@ -1,0 +1,24 @@
+package gov.cdc.prime.router.secrets
+
+// Option to access credential service by static class
+class SecretHelper() {
+    companion object {
+        fun getSecretService(): SecretService {
+            return secretServiceForStorageMethod()
+        }
+    }
+}
+
+// Option to access credential service by interface
+interface SecretManagement {
+    @Suppress("unused")
+    val secretService: SecretService
+        get() = secretServiceForStorageMethod()
+}
+
+internal fun secretServiceForStorageMethod(): SecretService {
+    return when (System.getenv("SECRET_STORAGE_METHOD")) {
+        "AZURE" -> AzureSecretService
+        else -> EnvVarSecretService
+    }
+}

--- a/prime-router/src/main/kotlin/secrets/SecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/SecretService.kt
@@ -1,0 +1,16 @@
+package gov.cdc.prime.router.secrets
+
+abstract class SecretService {
+    companion object {
+        private val URL_SAFE_KEY_PATTERN = Regex("^[a-zA-Z0-9-_]*$")
+    }
+
+    protected abstract fun fetchSecretFromStore(secretName: String): String?
+
+    fun fetchSecret(secretName: String): String? {
+        require(URL_SAFE_KEY_PATTERN.matches(secretName)) {
+            "secretName must match: ${URL_SAFE_KEY_PATTERN.pattern}"
+        }
+        return fetchSecretFromStore(secretName)
+    }
+}

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -12,9 +12,10 @@ import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.TransportType
 import gov.cdc.prime.router.azure.ActionHistory
 import gov.cdc.prime.router.azure.WorkflowEngine
+import gov.cdc.prime.router.secrets.SecretManagement
 import java.util.logging.Level
 
-class RedoxTransport() : ITransport {
+class RedoxTransport() : ITransport, SecretManagement {
     private val secretEnvName = "REDOX_SECRET"
     private val redoxTimeout = 1000
     private val redoxBaseUrl = "https://api.redoxengine.com"
@@ -111,7 +112,7 @@ class RedoxTransport() : ITransport {
 
     private fun getKeyAndSecret(redox: RedoxTransportType): Pair<String, String> {
         // Dev Note: The Redox API key doesn't change, while the secret can
-        val secret = System.getenv(secretEnvName) ?: ""
+        val secret = secretService.fetchSecret(secretEnvName) ?: ""
         if (secret.isBlank()) error("Unable to find $secretEnvName")
         return Pair(redox.apiKey, secret)
     }

--- a/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
+++ b/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
@@ -10,9 +10,9 @@ import io.mockk.mockkClass
 import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.AfterTest
 import kotlin.test.assertEquals
 
 internal class AzureSecretServiceTests {
@@ -42,7 +42,7 @@ internal class AzureSecretServiceTests {
         val retVal = secretService.initSecretClient(
             secretClientBuilder = secretClientBuilder, credential = mockAzureCredential
         )
-        verify { secretClientBuilder.vaultUrl("https://${KEY_VAULT_NAME}.vault.azure.net") }
+        verify { secretClientBuilder.vaultUrl("https://$KEY_VAULT_NAME.vault.azure.net") }
         verify { secretClientBuilder.credential(mockAzureCredential) }
 
         assertEquals(secretClient, retVal, "Expects mock secret client to be returned")

--- a/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
+++ b/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
@@ -1,0 +1,61 @@
+package gov.cdc.prime.router.secrets
+
+import com.azure.core.credential.TokenCredential
+import com.azure.security.keyvault.secrets.SecretClient
+import com.azure.security.keyvault.secrets.SecretClientBuilder
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.AfterTest
+import kotlin.test.assertEquals
+
+internal class AzureSecretServiceTests {
+    private val secretService = spyk(AzureSecretService, recordPrivateCalls = true)
+    private val secretClient = mockk<SecretClient>()
+
+    @BeforeTest
+    fun setUp() {
+        every { secretService getProperty "KEY_VAULT_NAME" } returns KEY_VAULT_NAME
+        every { secretService getProperty "secretClient" } returns secretClient
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(secretService)
+    }
+
+    @Test
+    fun `initializes a Key Vault using the correct URL`() {
+        val secretClientBuilder = mockkClass(SecretClientBuilder::class)
+        every { secretClientBuilder.vaultUrl(any()) } returns secretClientBuilder
+        every { secretClientBuilder.credential(any()) } returns secretClientBuilder
+        every { secretClientBuilder.buildClient() } returns secretClient
+
+        val mockAzureCredential = mockkClass(TokenCredential::class)
+
+        val retVal = secretService.initSecretClient(
+            secretClientBuilder = secretClientBuilder, credential = mockAzureCredential
+        )
+        verify { secretClientBuilder.vaultUrl("https://${KEY_VAULT_NAME}.vault.azure.net") }
+        verify { secretClientBuilder.credential(mockAzureCredential) }
+
+        assertEquals(secretClient, retVal, "Expects mock secret client to be returned")
+    }
+
+    @Test
+    fun `uses Key Vault to retrieve a secret`() {
+        every { secretClient.getSecret(any()) } returns KeyVaultSecret("functionapp-secret-name", "From Azure")
+        val secret = secretService.fetchSecret("SECRET_NAME")
+        assertEquals("From Azure", secret, "Expected secret not returned")
+    }
+
+    companion object {
+        private const val KEY_VAULT_NAME = "UNIT_TEST_KEY_VAULT"
+    }
+}

--- a/prime-router/src/test/kotlin/secrets/SecretServiceTests.kt
+++ b/prime-router/src/test/kotlin/secrets/SecretServiceTests.kt
@@ -1,0 +1,49 @@
+package gov.cdc.prime.router.secrets
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Test
+import java.lang.IllegalArgumentException
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+internal class SecretServiceTests : SecretManagement {
+
+    override val secretService: SecretService
+        get() = EnvVarSecretService
+
+    @Test
+    fun `test fetch from envVar`() {
+        mockkStatic(System::class)
+        every { System.getenv("SECRET_SERVICE_TEST") } returns "value_expected"
+        assertEquals("value_expected", secretService.fetchSecret("SECRET_SERVICE_TEST"))
+    }
+
+    @Test
+    fun `test fetchSecret handles valid secretNames`() {
+        VALID_SECRET_NAMES.forEach {
+            secretService.fetchSecret(it)
+        }
+    }
+
+    @Test
+    fun `test fetchSecret throws IllegalArgumentException with non-url safe secretNames`() {
+        INVALID_SECRET_NAMES.forEach {
+            try {
+                secretService.fetchSecret(it)
+                fail("IllegalArgumentException not thrown for $it")
+            } catch (e: IllegalArgumentException) {
+                assertEquals("secretName must match: ^[a-zA-Z0-9-_]*\$", e.message)
+            }
+        }
+    }
+
+    companion object {
+        private val VALID_SECRET_NAMES = listOf(
+            "valid1", "35wtfsdfe4t4wr4w4343", "with-dashes-in-name-", "with_UNDER-score"
+        )
+        private val INVALID_SECRET_NAMES = listOf(
+            "slashes/are/not/allowed", "no spaces", "?andotherthings"
+        )
+    }
+}


### PR DESCRIPTION
As part of the ongoing work to lock down our Azure environment to VPN only, we discovered that our Key Vault references do not work when our Key Vault is private only ([example Key Vault reference](https://github.com/CDCgov/prime-data-hub/blob/master/operations/app/src/modules/function_app/main.tf#L51)) ([Slack conversation thread](https://usds.slack.com/archives/C01HFHPNJEL/p1615916228012700)).

This PR adds a new SecretService, which supports fetching secrets via environment variables locally and in Azure Key Vault when the `SECRET_STORAGE_METHOD` environment variable equals `AZURE`.

## Changes
- Adds a SecretService, heavily based off the work I did on building a CredentialService for SFTP credentials in Azure Key Vault.
- Migrates two environment variables calls that use Key Vault to the SecretService. Unless we move all environment variables to Key Vault, these should be the only two to migrate for now.

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [x] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

