### PR TITLE
check all sftp

### DIFF
--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -14,21 +14,21 @@ import gov.cdc.prime.router.transport.SftpTransport
 import org.apache.logging.log4j.kotlin.Logging
 
 /*
- * HealthCheck API
+ * Check API
  */
 
-class HealthCheckFunction : Logging {
+class CheckFunction : Logging {
 
-    @FunctionName("healthcheck")
-    fun healthcheck(
+    @FunctionName("check")
+    fun run(
         @HttpTrigger(
-            name = "healthcheck",
+            name = "check",
             methods = [HttpMethod.GET],
             authLevel = AuthorizationLevel.FUNCTION,
         ) request: HttpRequestMessage<String?>,
         context: ExecutionContext,
     ): HttpResponseMessage {
-        logger.info("Entering healthcheck")
+        logger.info("Entering check api")
         val responseBody = mutableListOf<String>()
         var httpStatus = HttpStatus.OK
         try {
@@ -68,7 +68,7 @@ class HealthCheckFunction : Logging {
                 // Like Gen 18:31, if even one good sftp is found, that saves the overall run.
                 overallPass = true
             }
-            responseBody.add("\n")
+            responseBody.add("") // This will add a newline when the strings are returned.
         }
         return overallPass
     }

--- a/prime-router/src/main/kotlin/azure/HealthCheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/HealthCheckFunction.kt
@@ -4,9 +4,11 @@ import com.microsoft.azure.functions.ExecutionContext
 import com.microsoft.azure.functions.HttpMethod
 import com.microsoft.azure.functions.HttpRequestMessage
 import com.microsoft.azure.functions.HttpResponseMessage
+import com.microsoft.azure.functions.HttpStatus
 import com.microsoft.azure.functions.annotation.AuthorizationLevel
 import com.microsoft.azure.functions.annotation.FunctionName
 import com.microsoft.azure.functions.annotation.HttpTrigger
+import gov.cdc.prime.router.Receiver
 import gov.cdc.prime.router.SFTPTransportType
 import gov.cdc.prime.router.transport.SftpTransport
 import org.apache.logging.log4j.kotlin.Logging
@@ -18,7 +20,7 @@ import org.apache.logging.log4j.kotlin.Logging
 class HealthCheckFunction : Logging {
 
     @FunctionName("healthcheck")
-    fun run(
+    fun healthcheck(
         @HttpTrigger(
             name = "healthcheck",
             methods = [HttpMethod.GET],
@@ -28,6 +30,7 @@ class HealthCheckFunction : Logging {
     ): HttpResponseMessage {
         logger.info("Entering healthcheck")
         val responseBody = mutableListOf<String>()
+        var httpStatus = HttpStatus.OK
         try {
             if (request.queryParameters.size != 1) {
                 return HttpUtilities.badRequestResponse(request, "Must send exactly one option")
@@ -35,41 +38,87 @@ class HealthCheckFunction : Logging {
             val receiverFullName = request.queryParameters["sftpcheck"]
                 ?: return HttpUtilities.badRequestResponse(request, "Missing option sftpcheck")
             val settings = WorkflowEngine.settings
-            val receiver = settings.findReceiver(receiverFullName)
-                ?: return HttpUtilities.badRequestResponse(request, "Unable to find receiver $receiverFullName")
-            responseBody.add("Found ${receiver.fullName} as a valid receiver")
-            if (receiver.transport == null) {
-                return HttpUtilities.badRequestResponse(request, "$receiverFullName has no transport defined")
-            }
-            when (receiver.transport) {
-                is SFTPTransportType -> {
-                    testSftp(receiver.transport, receiverFullName, responseBody)
+            if (receiverFullName == "all") {
+                if (!testAllTransports(settings.receivers, responseBody)) {
+                    httpStatus = HttpStatus.INTERNAL_SERVER_ERROR // everything bombed.
                 }
-                // todo add other types of transports as needed.
-                else ->
-                    return HttpUtilities.badRequestResponse(
-                        request,
-                        "Test of ${receiver.transport.type} type not implemented."
-                    )
+            } else {
+                val receiver = settings.findReceiver(receiverFullName)
+                    ?: return HttpUtilities.badRequestResponse(request, "Unable to find receiver $receiverFullName")
+                responseBody.add("$receiverFullName: is a valid receiver")
+                if (receiver.transport == null) {
+                    return HttpUtilities.badRequestResponse(request, "$receiverFullName: no transport defined")
+                }
+                httpStatus = if (testTransport(receiver, responseBody)) HttpStatus.OK else HttpStatus.BAD_REQUEST
             }
         } catch (t: Throwable) {
             responseBody.add(t.localizedMessage)
+            httpStatus = HttpStatus.BAD_REQUEST
         }
-        return HttpUtilities.okResponse(request, responseBody.joinToString("\n") + "\n")
+        return HttpUtilities.httpResponse(request, responseBody.joinToString("\n") + "\n", httpStatus)
     }
 
-    fun testSftp(sftpTransportType: SFTPTransportType, receiverFullName: String, responseBody: MutableList<String>) {
+    /**
+     * Return true if even one sftp worked; return false if all failed.
+     */
+    private fun testAllTransports(receivers: Collection<Receiver>, responseBody: MutableList<String>): Boolean {
+        var overallPass = false
+        receivers.forEach { receiver ->
+            if (testTransport(receiver, responseBody)) {
+                // Like Gen 18:31, if even one good sftp is found, that saves the overall run.
+                overallPass = true
+            }
+            responseBody.add("\n")
+        }
+        return overallPass
+    }
+
+    /**
+     * Returns true on success, false on fail.
+     */
+    fun testTransport(receiver: Receiver, responseBody: MutableList<String>): Boolean {
+        if (receiver.transport == null) {
+            responseBody.add("**** ${receiver.fullName}:  no transport defined.")
+            return false
+        }
+        try {
+            return when (receiver.transport) {
+                is SFTPTransportType -> {
+                    testSftp(receiver.transport, receiver, responseBody)
+                    responseBody.add("**** ${receiver.fullName}: OK")
+                    true
+                }
+                // todo add other types of transports as needed.
+                else -> {
+                    responseBody.add(
+                        "**** ${receiver.fullName}: No test implemented for transport type " +
+                            "${receiver.transport?.type ?: "null"}"
+                    )
+                    false
+                }
+            }
+        } catch (t: Throwable) {
+            responseBody.add("${receiver.fullName}: ${t.localizedMessage}")
+            responseBody.add("**** ${receiver.fullName}: FAILED")
+            return false
+        }
+    }
+
+    /**
+     * Any normal return is success.  Any exception thrown is failure.
+     */
+    fun testSftp(sftpTransportType: SFTPTransportType, receiver: Receiver, responseBody: MutableList<String>) {
         val host = sftpTransportType.host
         val port = sftpTransportType.port
         val path = sftpTransportType.filePath
-        val (user, pass) = SftpTransport.lookupCredentials(receiverFullName)
+        val (user, pass) = SftpTransport.lookupCredentials(receiver.fullName)
         val sshClient = SftpTransport.connect(host, port, user, pass)
-        responseBody.add("Able to Connect to sftp site.  Now trying an `ls`.")
+        responseBody.add("${receiver.fullName}: Able to Connect to sftp site.  Now trying an `ls`...")
         val lsList: List<String> = SftpTransport.ls(sshClient, path)
         // Log what we found from ls, but don't return it.
         logger.info("What we got back from ls (first few lines): ")
         lsList.filterIndexed { index, _ -> index <= 5 }.forEach { logger.info(it) }
-        val msg = "Success: ls returned ${lsList.size} rows of info from $sftpTransportType"
+        val msg = "${receiver.fullName}: Success: ls returned ${lsList.size} rows of info from $sftpTransportType"
         logger.info(msg)
         responseBody.add(msg)
     }

--- a/prime-router/src/main/kotlin/azure/HttpUtilities.kt
+++ b/prime-router/src/main/kotlin/azure/HttpUtilities.kt
@@ -46,11 +46,11 @@ class HttpUtilities {
 
         /**
          * This alllows the validator to figure out specific failure, and pass it in here.
-         * Can be used for any failed response code.
+         * Can be used for any response code.
          & todo other generic failure response methods here could be removed, and replaced with this
          *      generic method, instead of having to create a new method for every HttpStatus code.
          */
-        fun notOKResponse(
+        fun httpResponse(
             request: HttpRequestMessage<String?>,
             responseBody: String,
             httpStatus: HttpStatus,

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -78,7 +78,7 @@ class ReportFunction {
                     HttpUtilities.okResponse(request, createResponseBody(validatedRequest))
                 }
                 validatedRequest.report == null -> {
-                    HttpUtilities.notOKResponse(
+                    HttpUtilities.httpResponse(
                         request,
                         createResponseBody(validatedRequest),
                         validatedRequest.httpStatus


### PR DESCRIPTION
This PR implements some cleanup to the sftpcheck.

## Changes
- Renamed `api/check` instead of `api/healthcheck`
- New option:  `api/check?sftpcheck=all` will check all Transports.   Right now only sftp checks are implemented, however.    This will also tell you if the transport definition is missing.



## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [X] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- no known issues.

