### PR TITLE
Fixes schema issue for OH

### DIFF
--- a/prime-router/docs/schema_documentation/oh-oh-covid-19.md
+++ b/prime-router/docs/schema_documentation/oh-oh-covid-19.md
@@ -42,9 +42,19 @@ The receiving facility for the message (specified by the receiver)
 
 ---
 
-**Name**: report_facility
+**Name**: reporting_facility
+
+**Type**: HD
+
+**HL7 Field**: MSH-4
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility for the message, as specified by the receiver. This is typically used if PRIME is the
+aggregator
+
 
 ---
 

--- a/prime-router/metadata/schemas/OH/oh-covid-19.schema
+++ b/prime-router/metadata/schemas/OH/oh-covid-19.schema
@@ -12,7 +12,7 @@ elements:
   - name: receiving_facility
     default: OHDOH^2.16.840.1.114222.4.1.3674^ISO
 
-  - name: report_facility
+  - name: reporting_facility
     default: CDC PRIME^36DSMP9999^CLIA
 
   - name: comment


### PR DESCRIPTION
This PR fixes problem with schema misnaming in OH schema. `report_facility` should be `reporting_facility`. 

## Changes
- Fixes problem with misnaming in OH schema

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
