### PR TITLE
Alerting

### DIFF
--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -35,6 +35,12 @@ resource "azurerm_monitor_action_group" "action_group" {
   resource_group_name = var.resource_group
   short_name = "ReportStream"
 
+  webhook_receiver {
+    name = "PagerDuty"
+    service_uri = data.azurerm_key_vault_secret.pagerduty_url.value
+    use_common_alert_schema = true
+  }
+
   dynamic "email_receiver" {
     for_each = local.devops
     content {
@@ -142,6 +148,11 @@ resource "azurerm_application_insights_web_test" "ping_test" {
     # This prevents terraform from seeing a tag change for each plan/apply
     "hidden-link:/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/${var.resource_group}/providers/microsoft.insights/components/${var.resource_prefix}-appinsights" = "Resource"
   }
+}
+
+data "azurerm_key_vault_secret" "pagerduty_url" {
+    key_vault_id = var.key_vault_id
+    name = "pagerduty-integration-url"
 }
 
 output "instrumentation_key" {

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -124,9 +124,9 @@ resource "azurerm_application_insights_web_test" "ping_test" {
   geo_locations = ["us-va-ash-azr"]
 
   configuration = <<XML
-    <WebTest>
+    <WebTest Name="" Id="" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="60" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
       <Items>
-        <Request Method="GET" Url="${local.ping_url}" ExpectedHttpStatusCode="200"/>
+        <Request Method="GET"  Version="1.1" Url="${local.ping_url}" ThinkTime="0" Timeout="60" ParseDependentRequests="False" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False"/>
       </Items>
     </WebTest>
     XML

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -3,18 +3,6 @@ terraform {
 }
 
 locals{
-  devops = {
-    "cglodosky" = "que3@cdc.gov"
-    "rhawes" = "qom6@cdc.gov"
-    "rheft" = "qwp3@cdc.gov"
-  }
-
-  developers = {
-    "jduff" = "qop5@cdc.gov"
-    "mreeves" = "qva8@cdc.gov"
-    "myoung" = "qtv1@cdc.gov"
-  }
-
   ping_url = (var.environment == "prod" ? "https://prime.cdc.gov" : "https://${var.environment}.prime.cdc.gov")
 }
 
@@ -39,24 +27,6 @@ resource "azurerm_monitor_action_group" "action_group" {
     name = "PagerDuty"
     service_uri = data.azurerm_key_vault_secret.pagerduty_url.value
     use_common_alert_schema = true
-  }
-
-  dynamic "email_receiver" {
-    for_each = local.devops
-    content {
-      name = "${email_receiver.key}_-EmailAction-"
-      email_address = email_receiver.value
-      use_common_alert_schema = true
-    }
-  }
-
-  dynamic "email_receiver" {
-    for_each = (var.environment == "prod" ? local.developers : {})
-    content {
-      name = "${email_receiver.key}_-EmailAction-"
-      email_address = email_receiver.value
-      use_common_alert_schema = true
-    }
   }
 
   tags = {

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -58,6 +58,10 @@ resource "azurerm_monitor_action_group" "action_group" {
       use_common_alert_schema = true
     }
   }
+
+  tags = {
+    "environment" = var.environment
+  }
 }
 
 # Severity 0 - Critical 
@@ -86,6 +90,10 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
   action {
     action_group_id = azurerm_monitor_action_group.action_group[0].id
   }
+
+  tags = {
+    "environment" = var.environment
+  }
 }
 
 resource "azurerm_monitor_metric_alert" "exception_alert" {
@@ -108,6 +116,10 @@ resource "azurerm_monitor_metric_alert" "exception_alert" {
   action {
     action_group_id = azurerm_monitor_action_group.action_group[0].id
   }
+
+  tags = {
+    "environment" = var.environment
+  }
 }
 
 resource "azurerm_application_insights_web_test" "ping_test" {
@@ -126,7 +138,7 @@ resource "azurerm_application_insights_web_test" "ping_test" {
   configuration = <<XML
     <WebTest Name="" Id="" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="60" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
       <Items>
-        <Request Method="GET"  Version="1.1" Url="${local.ping_url}" ThinkTime="0" Timeout="60" ParseDependentRequests="False" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False"/>
+        <Request Method="GET" Version="1.1" Url="${local.ping_url}" ThinkTime="0" Timeout="60" ParseDependentRequests="False" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" ReportingName="" IgnoreHttpStatusCode="False"/>
       </Items>
     </WebTest>
     XML

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -2,14 +2,139 @@ terraform {
     required_version = ">= 0.14"
 }
 
+locals{
+  devops = {
+    "cglodosky" = "que3@cdc.gov"
+    "rhawes" = "qom6@cdc.gov"
+    "rheft" = "qwp3@cdc.gov"
+  }
+
+  developers = {
+    "jduff" = "qop5@cdc.gov"
+    "mreeves" = "qva8@cdc.gov"
+    "myoung" = "qtv1@cdc.gov"
+  }
+
+  ping_url = (var.environment == "prod" ? "https://prime.cdc.gov" : "https://${var.environment}.prime.cdc.gov")
+}
+
 resource "azurerm_application_insights" "app_insights" {
-  name = var.name
+  name = "${var.resource_prefix}-appinsights"
   location = var.location
   resource_group_name = var.resource_group
   application_type = "web"
 
   tags = {
     environment = var.environment
+  }
+}
+
+resource "azurerm_monitor_action_group" "action_group" {
+  count = (var.environment != "dev" ? 1 : 0)
+  name = "${var.resource_prefix}-actiongroup"
+  resource_group_name = var.resource_group
+  short_name = "ReportStream"
+
+  sms_receiver {
+    name = "cglodosky_-SMSAction-"
+    country_code = "1"
+    phone_number = "7155704677"
+  }
+
+  dynamic "email_receiver" {
+    for_each = local.devops
+    content {
+      name = "${email_receiver.key}_-EmailAction-"
+      email_address = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "email_receiver" {
+    for_each = (var.environment == "prod" ? local.developers : {})
+    content {
+      name = "${email_receiver.key}_-EmailAction-"
+      email_address = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+}
+
+# Severity 0 - Critical 
+# Severity 1 - Error
+# Severity 2 - Warning
+# Severity 3 - Informational
+# Severity 4 - Verbose
+
+resource "azurerm_monitor_metric_alert" "severity0_alert" {
+  count = (var.environment != "dev" ? 1 : 0)
+  name = "Critical Alert"
+  resource_group_name = var.resource_group
+  scopes = [azurerm_application_insights.app_insights.id]
+  window_size = "PT1H"
+  frequency = "PT30M"
+  severity = 0
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name = "availabilityResults/availabilityPercentage"
+    aggregation = "Average"
+    operator = "LessThan"
+    threshold = 100
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group[0].id
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "severity1_alert" {
+  count = (var.environment != "dev" ? 1 : 0)
+  name = "Error Alert"
+  resource_group_name = var.resource_group
+  scopes = [azurerm_application_insights.app_insights.id]
+  window_size = "PT1H"
+  frequency = "PT30M"
+  severity = 1
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name = "exceptions/count"
+    aggregation = "Count"
+    operator = "GreaterThan"
+    threshold = 0
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group[0].id
+  }
+}
+
+resource "azurerm_application_insights_web_test" "ping_test" {
+  count = (var.environment != "dev" ? 1 : 0)
+  name = "${var.resource_prefix}-pingfunctions"
+  location = var.location
+  resource_group_name = var.resource_group
+  application_insights_id = azurerm_application_insights.app_insights.id
+  kind = "ping"
+  frequency = 300
+  timeout = 60
+  enabled = true
+  retry_enabled = true
+  geo_locations = ["us-va-ash-azr"]
+
+  configuration = <<XML
+    <WebTest>
+      <Items>
+        <Request Method="GET" Url="${local.ping_url}" ExpectedHttpStatusCode="200"/>
+      </Items>
+    </WebTest>
+    XML
+
+  tags = {
+    "environment" = var.environment
+    # This prevents terraform from seeing a tag change for each plan/apply
+    "hidden-link:/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/${var.resource_group}/providers/microsoft.insights/components/${var.resource_prefix}-appinsights" = "Resource"
   }
 }
 

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -66,9 +66,9 @@ resource "azurerm_monitor_action_group" "action_group" {
 # Severity 3 - Informational
 # Severity 4 - Verbose
 
-resource "azurerm_monitor_metric_alert" "severity0_alert" {
+resource "azurerm_monitor_metric_alert" "availability_alert" {
   count = (var.environment != "dev" ? 1 : 0)
-  name = "CRITICAL"
+  name = "Degraded Availability"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -88,9 +88,9 @@ resource "azurerm_monitor_metric_alert" "severity0_alert" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "severity1_alert" {
+resource "azurerm_monitor_metric_alert" "exception_alert" {
   count = (var.environment != "dev" ? 1 : 0)
-  name = "ERROR"
+  name = "Exception(s) Raised"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_monitor_action_group" "action_group" {
 
 resource "azurerm_monitor_metric_alert" "severity0_alert" {
   count = (var.environment != "dev" ? 1 : 0)
-  name = "Critical Alert"
+  name = "CRITICAL"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -90,7 +90,7 @@ resource "azurerm_monitor_metric_alert" "severity0_alert" {
 
 resource "azurerm_monitor_metric_alert" "severity1_alert" {
   count = (var.environment != "dev" ? 1 : 0)
-  name = "Error Alert"
+  name = "ERROR"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -35,12 +35,6 @@ resource "azurerm_monitor_action_group" "action_group" {
   resource_group_name = var.resource_group
   short_name = "ReportStream"
 
-  sms_receiver {
-    name = "cglodosky_-SMSAction-"
-    country_code = "1"
-    phone_number = "7155704677"
-  }
-
   dynamic "email_receiver" {
     for_each = local.devops
     content {

--- a/operations/app/src/modules/application_insights/variables.tf
+++ b/operations/app/src/modules/application_insights/variables.tf
@@ -17,3 +17,8 @@ variable "resource_prefix" {
     type = string
     description = "Resource Prefix"
 }
+
+variable "key_vault_id" {
+    type = string
+    description = "Application Key Vault ID"
+}

--- a/operations/app/src/modules/application_insights/variables.tf
+++ b/operations/app/src/modules/application_insights/variables.tf
@@ -13,7 +13,7 @@ variable "location" {
     description = "Function App Location"
 }
 
-variable "name" {
+variable "resource_prefix" {
     type = string
-    description = "App Service Name"
+    description = "Resource Prefix"
 }

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -139,6 +139,7 @@ module "application_insights" {
     resource_group = var.resource_group
     resource_prefix = var.resource_prefix
     location = local.location
+    key_vault_id = module.key_vault.application_key_vault_id
 }
 
 module "event_hub" {

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -137,7 +137,7 @@ module "application_insights" {
     source = "../application_insights"
     environment = var.environment
     resource_group = var.resource_group
-    name = "${var.resource_prefix}-appinsights"
+    resource_prefix = var.resource_prefix
     location = local.location
 }
 


### PR DESCRIPTION
This PR begins laying the groundwork for alerting via application insights.  There are currently two alert severity levels: Critical and Error.

- Error
  - Exception(s) Thrown
    - This occurs when > 0 exceptions are detected within a period of one hour.  Count is checked every thirty minutes and alert sent when appropriate.
- Critical
  - Degraded Availability
    - This occurs when < 100% of URL ping checks to the main Front Door URL (eg. https://prime.cdc.gov) respond with a 200 OK.  This may need to be adjusted to be more lenient before throwing an alert.

The first pass sets up an email group to be alerted based on the environment.  The next phase will be sending these alerts to PagerDuty so that the on-call person receives the alerts as opposed to keeping a separate list.