### PR TITLE
Remove SecretService System mock

### DIFF
--- a/prime-router/src/main/kotlin/secrets/EnvVarSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/EnvVarSecretService.kt
@@ -2,6 +2,10 @@ package gov.cdc.prime.router.secrets
 
 internal object EnvVarSecretService : SecretService() {
     override fun fetchSecretFromStore(secretName: String): String? {
+        return fetchEnvironmentVariable(secretName)
+    }
+
+    internal fun fetchEnvironmentVariable(secretName: String): String? {
         return System.getenv(secretName)
     }
 }

--- a/prime-router/src/test/kotlin/secrets/SecretServiceTests.kt
+++ b/prime-router/src/test/kotlin/secrets/SecretServiceTests.kt
@@ -1,7 +1,7 @@
 package gov.cdc.prime.router.secrets
 
 import io.mockk.every
-import io.mockk.mockkStatic
+import io.mockk.spyk
 import org.junit.jupiter.api.Test
 import java.lang.IllegalArgumentException
 import kotlin.test.assertEquals
@@ -9,13 +9,14 @@ import kotlin.test.fail
 
 internal class SecretServiceTests : SecretManagement {
 
+    private val mockSecretService = spyk(EnvVarSecretService)
+
     override val secretService: SecretService
-        get() = EnvVarSecretService
+        get() = mockSecretService
 
     @Test
     fun `test fetch from envVar`() {
-        mockkStatic(System::class)
-        every { System.getenv("SECRET_SERVICE_TEST") } returns "value_expected"
+        every { mockSecretService.fetchEnvironmentVariable("SECRET_SERVICE_TEST") } returns "value_expected"
         assertEquals("value_expected", secretService.fetchSecret("SECRET_SERVICE_TEST"))
     }
 


### PR DESCRIPTION
This is a refactor of the `SecretServiceTest` to not mock `System`, which caused issues / warnings for some developers.