### PR TITLE
Database Connection / Queue Tuning

### DIFF
--- a/prime-router/host.json
+++ b/prime-router/host.json
@@ -3,5 +3,10 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"
+  },
+  "extensions": {
+    "queues": {
+      "batchSize": 8
+    }
   }
 }

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -499,6 +499,9 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             config.addDataSourceProperty("cachePrepStmts", "true")
             config.addDataSourceProperty("prepStmtCacheSize", "250")
             config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048")
+            config.addDataSourceProperty("maximumPoolSize", "20") // Default is 10
+            config.addDataSourceProperty("connectionTimeout", "60000") // Default is 30000 (30 seconds)
+
             // See this info why these are a good value
             //  https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
             config.minimumIdle = 2


### PR DESCRIPTION
This PR addresses some of the timeout issues we've been seeing with SFTP connections.

## Changes
- Increases available database connections from 10 to 20.
- Increases the connection timeout from 30 seconds to 60 seconds.
- Decreases the amount of queue items fetched from 16 to 8 (which will cap total number of items processing simultaneous to 8 + 4 = 12 which is  < the 20 available DB connections)

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

