### PR TITLE
Jim/timing fix

### DIFF
--- a/prime-router/examples/weekly-report/reports-ingested.sql
+++ b/prime-router/examples/weekly-report/reports-ingested.sql
@@ -1,0 +1,12 @@
+\echo List of all reports sent to SR  in the last week
+select report_id, item_count, sending_org, sending_org_client, RF.created_at,
+       RF.schema_name
+from report_file RF
+join action A on A.action_id = RF.action_id
+where 
+  A.action_name = 'receive'
+  and RF.sending_org is not null
+  and RF.created_at > now() - interval '7 days'
+order by receiving_org, receiving_org_svc, RF.created_at
+;
+

--- a/prime-router/examples/weekly-report/weekly-report.sql
+++ b/prime-router/examples/weekly-report/weekly-report.sql
@@ -1,0 +1,69 @@
+-- Note: these queries find all reports in the last 168 hours from the time the queries are run.
+-- For a query that instead finds all reports in the previous day, UTC time, replace this part of each query:
+--   and RF.created_at > now() - interval '7 days'
+-- with:
+--   and RF.created_at::date = 'yesterday'::date
+
+\echo These reports only look at the outbound side of the Hub
+\echo
+\echo List of all downloads that occurred in the last week
+select item_count, receiving_org, receiving_org_svc, date_trunc('second',RF.created_at) CREATED,
+       A.action_name, RF.downloaded_by, RF.body_format
+from report_file RF
+join action A on A.action_id = RF.action_id
+where 
+  A.action_name = 'download'
+  and RF.created_at > now() - interval '7 days'
+order by receiving_org, receiving_org_svc, RF.created_at
+;
+
+\echo ALL Reports supposed to go out, from the last week
+select report_id, item_count, receiving_org, receiving_org_svc, date_trunc('second',RF.created_at) CREATED,
+       A.action_name, RF.next_action, RF.body_format
+from report_file RF
+join action A on A.action_id = RF.action_id
+where 
+  (A.action_name = 'batch' or RF.next_action = 'send')
+  and RF.created_at > now() - interval '7 days'
+order by receiving_org, receiving_org_svc, RF.created_at
+;
+
+\echo Of the last weeks reports ready to be sent, here are those that actually got sent or downloaded
+\echo Careful: there will be repeats, eg, for multiple downloads of the same report
+select PARENT.report_id, PARENT.item_count, PARENT.receiving_org, PARENT.receiving_org_svc,
+       date_trunc('second', PARENT.created_at) CREATED,
+       date_trunc('second', CHILD.created_at) SENT, CHILD.downloaded_by, PARENT.body_format
+from report_file PARENT
+join report_lineage RL on PARENT.report_id = RL.parent_report_id
+join report_file CHILD on CHILD.report_id = RL.child_report_id
+where PARENT.report_id in 
+(
+  -- this nested query is just the list of all reports supposed to go out in last week
+  select report_id
+  from report_file RF
+  join action A on A.action_id = RF.action_id
+  where 
+    (A.action_name = 'batch' or RF.next_action = 'send')
+    and RF.created_at > now() - interval '7 days'
+)
+order by receiving_org, receiving_org_svc, PARENT.created_at
+;
+
+\echo Of the last weeks reports ready to be sent, here are those that were NEVER sent or downloaded
+select report_id, item_count, receiving_org, receiving_org_svc, date_trunc('second',RF.created_at) CREATED, RF.body_format
+from report_file RF
+where 
+RF.report_id in 
+(
+  -- this nested query is just the list of all reports supposed to go out in last week
+  select report_id
+  from report_file RF2
+  join action A on A.action_id = RF2.action_id
+  where 
+    (A.action_name = 'batch' or RF2.next_action = 'send')
+    and RF2.created_at > now() - interval '7 days'
+)
+-- will this be crazy slow?
+and RF.report_id not in (select parent_report_id from report_lineage)
+order by receiving_org, receiving_org_svc, RF.created_at
+;

--- a/prime-router/examples/weekly-report/wip.sql
+++ b/prime-router/examples/weekly-report/wip.sql
@@ -1,0 +1,10 @@
+\echo Find WIP - Work in Progress.
+\echo In practice, that means jobs queued for 'batch'
+\echo
+\echo From the TASK table:
+select report_id, next_action, next_action_at,
+       schema_name, receiver_name,
+       item_count, body_format, created_at, retry_token
+from task
+where next_action_at > now()
+order by next_action_at;

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -626,6 +626,25 @@
           format: HL7
         transport:
           type: "NULL"
+      - name: SFTP_LEGACY
+        organizationName: ignore
+        topic: covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, IG)", "matches(ordering_facility_county, SFTP_LEGACY)" ]
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
+        translation:
+          useBatchHeaders: true
+          type: HL7
+          schemaName: tx/tx-covid-19
+          receivingApplicationName: NEDSS
+          receivingFacilityName: SFTP_LEGACY
+        transport:
+          type: SFTP_LEGACY
+          host: sftp
+          port: 22
+          filePath: ./upload
       - name: SFTP_FAIL    # If you put "FAIL" in the receiver name, then the happy-path tests in TestReportStream will ignore them.
         organizationName: ignore
         topic: covid-19

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -561,7 +561,7 @@
           initialTime: 00:00
         translation:
           type: CUSTOM
-          schemaName: tx/tx-covid-19
+          schemaName: fl/fl-covid-19
           format: HL7
         transport:
           type: SFTP

--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -36,9 +36,9 @@
       deidentify: false
       timing:
         operation: MERGE
-        numberPerDay: 1   # Once a day at 2pm EST
-        initialTime: 12:00
-        timeZone: ARIZONA
+        numberPerDay: 1
+        initialTime: 09:15
+        timeZone: EASTERN
       translation:
         type: CUSTOM
         schemaName: az/az-covid-19
@@ -66,9 +66,9 @@
         messageProfileId: AZELRIG^ADHS^2.16.840.1.113883.9.31^ISO
       timing:
         operation: MERGE
-        numberPerDay: 1   # Once a day at 2pm EST
-        initialTime: 12:00
-        timeZone: ARIZONA
+        numberPerDay: 1
+        initialTime: 09:15
+        timeZone: EASTERN
       transport:
         type: SFTP
         host: hssftp.azdhs.gov
@@ -88,9 +88,9 @@
         format: CSV
       timing:
         operation: MERGE
-        numberPerDay: 1   # Once a day at 2pm EST
-        initialTime: 12:00
-        timeZone: ARIZONA
+        numberPerDay: 1
+        initialTime: 09:15
+        timeZone: EASTERN
       transport:
         type: SFTP
         host: hssftp.azdhs.gov
@@ -115,9 +115,9 @@
         format: CSV
       timing:
         operation: MERGE
-        numberPerDay: 1 # Once a day  NOTE:  In production, they want deliveries once a day at 8am MST.
-        initialTime: 08:00
-        timeZone: ARIZONA
+        numberPerDay: 1   # Customer has asked for 8am AZ time. This is close, but allows a deploy window.
+        initialTime: 09:15
+        timeZone: EASTERN
 
 - name: fl-phd
   description: Florida Department of Health
@@ -139,8 +139,8 @@
         receivingFacilityOID: 2.16.840.1.114222.1.3645
       timing:
         operation: MERGE
-        numberPerDay: 12          # Twelve times a day starting at 02.00
-        initialTime: 02:00
+        numberPerDay: 12
+        initialTime: 01:15
         timeZone: EASTERN
       transport:
         type: SFTP
@@ -170,8 +170,8 @@
       timing:
         operation: MERGE
         numberPerDay: 12
-        initialTime: 02:00
-        timeZone: CENTRAL
+        initialTime: 01:15
+        timeZone: EASTERN
       transport:
         type: SFTP
         host: mft.nd.gov
@@ -199,8 +199,8 @@
       timing:
         operation: MERGE
         numberPerDay: 12
-        initialTime: 02:00
-        timeZone: CENTRAL
+        initialTime: 01:15
+        timeZone: EASTERN
       transport:
         type: SFTP
         host: 204.58.124.41
@@ -236,8 +236,8 @@
         filePath: CDC-ELR/ProdFiles
       timing:
         operation: MERGE
-        numberPerDay: 12   # Twelve times a day starting at 02.00
-        initialTime: 02:00
+        numberPerDay: 12
+        initialTime: 01:15
         timeZone: EASTERN
 
 - name: nm-doh
@@ -260,9 +260,9 @@
         receivingFacilityOID: 2.16.840.1.113883.3.5364
       timing:
         operation: MERGE
-        numberPerDay: 12   # Twelve times a day starting at 02.00
-        initialTime: 02:00
-        timeZone: MOUNTAIN
+        numberPerDay: 12
+        initialTime: 01:15
+        timeZone: EASTERN
 
 - name: mt-doh
   description: Montana Department of Health
@@ -280,9 +280,9 @@
         useBatchHeaders: true
       timing:
         operation: MERGE
-        numberPerDay: 12   # Twelve times a day starting at 02.00
-        initialTime: 02:00
-        timeZone: MOUNTAIN
+        numberPerDay: 12
+        initialTime: 01:15
+        timeZone: EASTERN
 
 - name: tx-doh
   description: Texas Department of Health
@@ -302,9 +302,9 @@
         receivingFacilityName: TX-ELR
       timing:
         operation: MERGE
-        numberPerDay: 12   #  Twelve times a day starting at 02.00
-        initialTime: 12:00
-        timeZone: CENTRAL
+        numberPerDay: 12
+        initialTime: 01:15
+        timeZone: EASTERN
       transport:
         type: SFTP
         host: sftp-edts.hhs.texas.gov

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -547,6 +547,25 @@
         format: HL7
       transport:
         type: "NULL"
+    - name: SFTP_LEGACY
+      organizationName: ignore
+      topic: covid-19
+      jurisdictionalFilter: [ "matches(ordering_facility_state, IG)", "matches(ordering_facility_county, SFTP_LEGACY)" ]
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+      translation:
+        useBatchHeaders: true
+        type: HL7
+        schemaName: tx/tx-covid-19
+        receivingApplicationName: NEDSS
+        receivingFacilityName: SFTP_LEGACY
+      transport:
+        type: SFTP_LEGACY
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
     - name: SFTP_FAIL    # If you put "FAIL" in the receiver name, then the happy-path tests in TestReportStream will ignore them.
       organizationName: ignore
       topic: covid-19

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -491,7 +491,7 @@
         initialTime: 00:00
       translation:
         type: CUSTOM
-        schemaName: tx/tx-covid-19
+        schemaName: fl/fl-covid-19
         format: HL7
       transport:
         type: SFTP

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -515,7 +515,7 @@
         host: 10.0.2.4
         port: 22
         filePath: ./upload
-    - name: REDOX
+    - name: REDOX     # NOTE:  No Redox transport available in Staging at this time.
       organizationName: ignore
       topic: covid-19
       jurisdictionalFilter: [ "matches(ordering_facility_state, IG)", "matches(ordering_facility_county, REDOX)" ]
@@ -533,10 +533,6 @@
           redox_destination_name: "CDC Montgomery County PDH Destination (s) TEST ONLY"
           redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
           redox_source_name: "Prime Data Hub (Staging)"
-      transport:
-        type: REDOX      # Will fail.
-        apiKey: some_key
-        baseUrl: some_url
     - name: HL7_NULL
       organizationName: ignore
       topic: covid-19

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -332,7 +332,7 @@
           initialTime: 00:00
         translation:
           type: CUSTOM
-          schemaName: tx/tx-covid-19
+          schemaName: fl/fl-covid-19
           format: HL7
         transport:
           type: SFTP

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -392,6 +392,25 @@
           format: HL7
         transport:
           type: "NULL"
+      - name: SFTP_LEGACY
+        organizationName: ignore
+        topic: covid-19
+        jurisdictionalFilter: [ "matches(ordering_facility_state, IG)", "matches(ordering_facility_county, SFTP_LEGACY)" ]
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
+        translation:
+          useBatchHeaders: true
+          type: HL7
+          schemaName: tx/tx-covid-19
+          receivingApplicationName: NEDSS
+          receivingFacilityName: SFTP_LEGACY
+        transport:
+          type: SFTP_LEGACY
+          host: sftp
+          port: 22
+          filePath: ./upload
       - name: SFTP_FAIL    # If you put "FAIL" in the receiver name, then the happy-path tests in TestReportStream will ignore them.
         organizationName: ignore
         topic: covid-19

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -85,7 +85,7 @@ Examples:
         toobig("Submit ${REPORT_MAX_ITEMS + 1} lines, which should be an error.  Slower ;)", TestStatus.SLOW),
         dbconnections("Test weird issue wherein many 'sends' cause db connection failures", TestStatus.FAILS),
         strac("Submit data in the strac schema format, wait, confirm via database queries", TestStatus.FAILS),
-        badsftp("Test ReportStream's response to sftp connection failures", TestStatus.DRAFT),
+        badsftp("Test ReportStream's response to sftp connection failures. Tests RETRY too!", TestStatus.DRAFT),
     }
 
     private val list by option(
@@ -399,6 +399,7 @@ Examples:
         val reportId = ReportId.fromString(tree["id"].textValue())
         echo("Id of submitted report: $reportId")
         waitABit(30, environment)
+        echo("For this test, failure during send, is a 'pass'.   Need to fix this.")
         examineLineageResults(reportId, listOf(sftpFailReceiver), fakeItemCount)
     }
 

--- a/prime-router/src/main/kotlin/transport/SftpLegacyTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpLegacyTransport.kt
@@ -16,7 +16,6 @@ import gov.cdc.prime.router.credentials.CredentialRequestReason
 import gov.cdc.prime.router.credentials.UserPassCredential
 import org.apache.logging.log4j.kotlin.KotlinLogger
 import java.io.ByteArrayInputStream
-import java.io.IOException
 import java.util.logging.Level
 
 class SftpLegacyTransport : ITransport {
@@ -55,17 +54,16 @@ class SftpLegacyTransport : ITransport {
             )
             actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
             null
-        } catch (ioException: IOException) {
+        } catch (t: Throwable) {
             val msg =
                 "FAILED Sftp Legacy upload of inputReportId ${header.reportFile.reportId} to " +
-                    "$sftpTransportType (orgService = ${header.receiver?.fullName ?: "null"})"
-            context.logger.log(
-                Level.WARNING, msg, ioException
-            )
+                    "$sftpTransportType (orgService = ${header.receiver?.fullName ?: "null"})" +
+                    ", Exception: ${t.localizedMessage}"
+            context.logger.log(Level.WARNING, msg, t)
             actionHistory.setActionType(TaskAction.send_error)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems
-        } // let other exceptions bubble out
+        }
     }
 
     companion object {

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -63,7 +63,7 @@ class SftpTransport : ITransport {
             actionHistory.setActionType(TaskAction.send_error)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems
-        } // let non-IO exceptions be caught by the caller
+        }
     }
 
     companion object {


### PR DESCRIPTION
This PR ... 

## Changes
- Tweaked organizations-prod.yml timings to make it more likely there will be times when our "WIP" queue is empty.
- Removed broken redox transport from organizations-test.yml
- Added SFTP_LEGACY test to './prime test' smoke test. 
- Tweaked SftpLegacyTransport code to retry on all exceptions, so its parallel to how SftpTransport now works.

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [X] Added tests?
- [X] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- None known

## Fixes

- This does not fix, but helps mitigate the problem of deploying schema changes when we have WIP.
