### PR TITLE
Add retry policy for Azure Key Vault

### DIFF
--- a/prime-router/src/main/kotlin/credentials/AzureCredentialService.kt
+++ b/prime-router/src/main/kotlin/credentials/AzureCredentialService.kt
@@ -1,9 +1,12 @@
 package gov.cdc.prime.router.credentials
 
 import com.azure.core.credential.TokenCredential
+import com.azure.core.http.policy.ExponentialBackoff
+import com.azure.core.http.policy.RetryPolicy
 import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.security.keyvault.secrets.SecretClient
 import com.azure.security.keyvault.secrets.SecretClientBuilder
+import java.time.Duration
 
 internal object AzureCredentialService : CredentialService() {
 
@@ -17,6 +20,7 @@ internal object AzureCredentialService : CredentialService() {
         return secretClientBuilder
             .vaultUrl("https://$KEY_VAULT_NAME.vault.azure.net")
             .credential(credential)
+            .retryPolicy(RetryPolicy(ExponentialBackoff(3, Duration.ofMillis(250L), Duration.ofSeconds(2))))
             .buildClient()
     }
 

--- a/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
@@ -1,9 +1,12 @@
 package gov.cdc.prime.router.secrets
 
 import com.azure.core.credential.TokenCredential
+import com.azure.core.http.policy.ExponentialBackoff
+import com.azure.core.http.policy.RetryPolicy
 import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.security.keyvault.secrets.SecretClient
 import com.azure.security.keyvault.secrets.SecretClientBuilder
+import java.time.Duration
 
 internal object AzureSecretService : SecretService() {
     private val KEY_VAULT_NAME: String by lazy { System.getenv("SECRET_KEY_VAULT_NAME") ?: "" }
@@ -16,6 +19,7 @@ internal object AzureSecretService : SecretService() {
         return secretClientBuilder
             .vaultUrl("https://$KEY_VAULT_NAME.vault.azure.net")
             .credential(credential)
+            .retryPolicy(RetryPolicy(ExponentialBackoff(3, Duration.ofMillis(250L), Duration.ofSeconds(2))))
             .buildClient()
     }
 

--- a/prime-router/src/test/kotlin/credentials/AzureCredentialServiceTests.kt
+++ b/prime-router/src/test/kotlin/credentials/AzureCredentialServiceTests.kt
@@ -37,6 +37,7 @@ internal class AzureCredentialServiceTests {
         val secretClientBuilder = mockkClass(SecretClientBuilder::class)
         every { secretClientBuilder.vaultUrl(any()) } returns secretClientBuilder
         every { secretClientBuilder.credential(any()) } returns secretClientBuilder
+        every { secretClientBuilder.retryPolicy(any()) } returns secretClientBuilder
         every { secretClientBuilder.buildClient() } returns secretClient
 
         val mockAzureCredential = mockkClass(TokenCredential::class)

--- a/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
+++ b/prime-router/src/test/kotlin/secrets/AzureSecretServiceTests.kt
@@ -35,6 +35,7 @@ internal class AzureSecretServiceTests {
         val secretClientBuilder = mockkClass(SecretClientBuilder::class)
         every { secretClientBuilder.vaultUrl(any()) } returns secretClientBuilder
         every { secretClientBuilder.credential(any()) } returns secretClientBuilder
+        every { secretClientBuilder.retryPolicy(any()) } returns secretClientBuilder
         every { secretClientBuilder.buildClient() } returns secretClient
 
         val mockAzureCredential = mockkClass(TokenCredential::class)


### PR DESCRIPTION
This PR add a retry policy specifically to the Azure Key Vault access.

## Changes
- Uses Azure's own build in retry policy, with exponential backoff, to retry fetching secrets
- 

## Checklist
- [x] Tested locally?
- [] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

