### PR TITLE
Fixed bug when Redox failures mix with credential lookup failures

### DIFF
--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -93,7 +93,7 @@ class RedoxTransport() : ITransport, SecretManagement {
                 "  ${t.localizedMessage}.  "
             context.logger.log(Level.WARNING, resultMsg, t)
             if (successCount == 0) {
-                nextRetryItems = RetryToken.allItems as MutableList<String>
+                nextRetryItems = (retryItems ?: RetryToken.allItems) as MutableList<String>
                 // If even one redox message got through, we'll call that 'send' rather than send_error
                 actionHistory.setActionType(TaskAction.send_error)
             }

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -106,7 +106,7 @@ class RedoxTransport() : ITransport, SecretManagement {
             }
             resultMsg = resultMsg + "$statusStr: $successCount of $attemptedCount items successfully sent to $sendUrl"
             actionHistory.trackActionResult(resultMsg)
-            context.logger.log(Level.INFO, resultMsg)
+            context.logger.info(resultMsg)
             if (successCount > 0) {
                 // only create a child report in the history, if something actually worked.
                 actionHistory.trackSentReport(receiver, sentReportId, null, sendUrl, resultMsg, successCount)
@@ -121,8 +121,7 @@ class RedoxTransport() : ITransport, SecretManagement {
             }
         }
         if (nextRetryItems.isNotEmpty()) {
-            context.logger.log(
-                Level.INFO,
+            context.logger.info(
                 "The retry item list for ${header.reportFile.reportId} is: " +
                     nextRetryItems.joinToString(",")
             )
@@ -156,7 +155,7 @@ class RedoxTransport() : ITransport, SecretManagement {
         return Pair(redox.apiKey, secret)
     }
 
-    private fun fetchToken(
+    fun fetchToken(
         redox: RedoxTransportType,
         key: String,
         secret: String,
@@ -189,7 +188,7 @@ class RedoxTransport() : ITransport, SecretManagement {
         }
     }
 
-    private fun sendItem(
+    fun sendItem(
         sendUrl: String,
         token: String,
         message: String,

--- a/prime-router/src/test/kotlin/transport/RedoxTransportTests.kt
+++ b/prime-router/src/test/kotlin/transport/RedoxTransportTests.kt
@@ -1,0 +1,212 @@
+package gov.cdc.prime.router.transport
+
+import com.microsoft.azure.functions.ExecutionContext
+import gov.cdc.prime.router.FileSettings
+import gov.cdc.prime.router.Metadata
+import gov.cdc.prime.router.RedoxTransportType
+import gov.cdc.prime.router.azure.ActionHistory
+import gov.cdc.prime.router.azure.WorkflowEngine
+import gov.cdc.prime.router.azure.db.enums.TaskAction
+import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
+import gov.cdc.prime.router.azure.db.tables.pojos.Task
+import gov.cdc.prime.router.secrets.SecretService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.spyk
+import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import java.util.logging.Logger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RedoxTransportTests {
+    val context = mockkClass(ExecutionContext::class)
+    val metadata = Metadata(Metadata.defaultMetadataDirectory)
+    val settings = FileSettings(FileSettings.defaultSettingsDirectory, "-local")
+    val logger = mockkClass(Logger::class)
+    val reportId = UUID.randomUUID()
+    val redox = spyk<RedoxTransport>()
+    val actionHistory = ActionHistory(TaskAction.send, context)
+    val secretService = mockk<SecretService>()
+    val transportType = RedoxTransportType("", "baseURL")
+    val task = Task(
+        reportId,
+        TaskAction.send,
+        null,
+        null,
+        "az-phd.elr-test",
+        4,
+        "",
+        "",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    )
+    private val reportFile = ReportFile(
+        reportId,
+        null,
+        TaskAction.send,
+        null,
+        null,
+        null,
+        "az-phd",
+        "elr-test",
+        null, null, null, null, null, null, null, null,
+        4, // pretend we have 4 items to send.
+        null, null, null
+    )
+
+    fun setupLogger() {
+        every { context.logger }.returns(logger)
+        every { logger.log(any(), any(), any<Throwable>()) }.returns(Unit)
+        every { logger.info(any<String>()) }.returns(Unit)
+    }
+
+    fun makeHeader(): WorkflowEngine.Header {
+        val content = "Redox Message 0\nRedox Message 1\nRedox Message 2\nRedox Message 3"
+        return WorkflowEngine.Header(
+            task, reportFile,
+            null,
+            settings.findOrganization("az-phd"),
+            settings.findReceiver("az-phd.elr-test"),
+            metadata.findSchema("covid-19"),
+            content = content.toByteArray(),
+        )
+    }
+
+    @BeforeEach
+    fun reset() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `test send happy path`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.returns("dont_tell!")
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns("token")
+        every { redox.sendItem(any(), any(), any(), any()) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
+        // The Test
+        val retryItems = redox.send(transportType, header, UUID.randomUUID(), null, context, actionHistory)
+
+        assertNull(retryItems)
+    }
+
+    @Test
+    fun `test send success on retry`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.returns("dont_tell!")
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns("token")
+        every { redox.sendItem(any(), any(), any(), any()) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
+        val retryItemsIn = listOf("0", "1", "2")
+        // The Test
+        val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
+
+        assertNull(retryItemsOut)
+    }
+
+    @Test
+    fun `test all sendItem calls fail`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.returns("dont_tell!")
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns("token")
+        every { redox.sendItem(any(), any(), any(), any()) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.FAILURE, 1234))
+        val retryItemsIn = null
+        // The Test
+        val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
+
+        assertNotNull(retryItemsOut)
+        assertEquals(4, retryItemsOut.size)
+        assertEquals("0", retryItemsOut[0])
+        assertEquals("1", retryItemsOut[1])
+        assertEquals("2", retryItemsOut[2])
+        assertEquals("3", retryItemsOut[3])
+    }
+    @Test
+    fun `test fetchSecret failure`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.throws(Exception("x"))
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns("token")
+        every { redox.sendItem(any(), any(), any(), any()) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
+
+        // fetchSecret fails, not on a retry situation.
+        val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), null, context, actionHistory)
+        assertNotNull(retryItemsOut)
+        assertEquals(1, retryItemsOut.size)
+        assertTrue(RetryToken.isAllItems(retryItemsOut))
+
+        // Now what if fetchSecret fails in a retry situation
+        val retryItemsIn = listOf("0", "3")
+        val retryItemsOut2 = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
+        assertNotNull(retryItemsOut2)
+        assertEquals(2, retryItemsOut2.size)
+        assertEquals("0", retryItemsOut2[0])
+        assertEquals("3", retryItemsOut2[1])
+    }
+
+    @Test
+    fun `test fetchToken fails`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.returns("dont_tell!")
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns(null) // failure
+        every { redox.sendItem(any(), any(), any(), any()) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
+
+        // fetchToken fails, not on a retry situation.
+        val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), null, context, actionHistory)
+        assertNotNull(retryItemsOut)
+        assertEquals(1, retryItemsOut.size)
+        assertTrue(RetryToken.isAllItems(retryItemsOut))
+
+        // Now what if fetchToken fails in a retry situation
+        val retryItemsIn = listOf("1", "2")
+        val retryItemsOut2 = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
+        assertNotNull(retryItemsOut2)
+        assertEquals(2, retryItemsOut2.size)
+        assertEquals("1", retryItemsOut2[0])
+        assertEquals("2", retryItemsOut2[1])
+    }
+
+    @Test
+    fun `test partial sendItem failure`() {
+        val header = makeHeader()
+        setupLogger()
+        every { redox.secretService }.returns(secretService)
+        every { secretService.fetchSecret(any()) }.returns("dont_tell!")
+        every { redox.fetchToken(any(), any(), any(), any()) }.returns("my token")
+        // Item 1 fails, all others succeed
+        every { redox.sendItem(any(), any(), any(), eq("$reportId-1")) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.FAILURE, 1234))
+        every { redox.sendItem(any(), any(), any(), neq("$reportId-1")) }
+            .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
+
+        // This is a retry after a retry.
+        val retryItemsIn = listOf("1", "2", "3")
+        val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
+        assertNotNull(retryItemsOut)
+        assertEquals(1, retryItemsOut.size)
+        assertEquals("1", retryItemsOut[0])
+    }
+}


### PR DESCRIPTION
This PR fixes a bug wherein a failure during a Vault credential lookup, during a retry of a previously partially successful Redox send, causes the subsequent retry to rerun everything, instead of just the retry items from the previously partially successful Redox send.

I actually think this is easier to understand by looking at the code changes, and not at that sentence.

I also added a printout of the RetryToken to the logging, as currently the RetryToken gets wiped out in the database, and I'm not putting it in the History tables at this time.

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [X] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*none known.

## Fixes
- see above.



