### PR TITLE
Support for PPK authentication via SFTP

### DIFF
--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -118,8 +118,8 @@ class CheckFunction : Logging {
         val host = sftpTransportType.host
         val port = sftpTransportType.port
         val path = sftpTransportType.filePath
-        val (user, pass) = SftpTransport.lookupCredentials(receiver.fullName)
-        val sshClient = SftpTransport.connect(host, port, user, pass)
+        val credential = SftpTransport.lookupCredentials(receiver.fullName)
+        val sshClient = SftpTransport.connect(host, port, credential)
         responseBody.add("${receiver.fullName}: Able to Connect to sftp site.  Now trying an `ls`...")
         val lsList: List<String> = SftpTransport.ls(sshClient, path)
         // Log what we found from ls, but don't return it.

--- a/prime-router/src/main/kotlin/cli/CredentialsCli.kt
+++ b/prime-router/src/main/kotlin/cli/CredentialsCli.kt
@@ -49,7 +49,7 @@ class CredentialsCli : CredentialManagement, CliktCommand(
     override fun run() {
         val credential = when (val it = type) {
             is UserPassCredentialOptions -> UserPassCredential(it.user, it.pass)
-            is UserPpkCredentialOptions -> UserPpkCredential(it.user, it.file.readText(Charsets.UTF_8))
+            is UserPpkCredentialOptions -> UserPpkCredential(it.user, it.file.readText(Charsets.UTF_8), it.filePass)
             else -> error("--type option is unknown")
         }
 
@@ -71,14 +71,13 @@ class CredentialsCli : CredentialManagement, CliktCommand(
 
 sealed class CredentialConfig(name: String) : OptionGroup(name)
 
-sealed class UserTypeCredentialOptions(name: String) : CredentialConfig(name)
-
 class UserPassCredentialOptions : CredentialConfig("Options for credential type 'UserPass'") {
-    val user by option().prompt(default = "")
-    val pass by option().prompt(default = "", requireConfirmation = true)
+    val user by option(help = "SFTP username").prompt(default = "")
+    val pass by option(help = "SFTP password").prompt(default = "", requireConfirmation = true)
 }
 
 class UserPpkCredentialOptions : CredentialConfig("Options for credential type 'UserPpk'") {
-    val user by option("--ppk-user").prompt(default = "")
-    val file by option("--ppk-file").file(mustExist = true).required()
+    val user by option("--ppk-user", help = "Username to authenticate alongside the PPK").prompt(default = "")
+    val file by option("--ppk-file", help = "Path to the PPK file").file(mustExist = true).required()
+    val filePass by option("--ppk-file-pass", help = "Password to decrypt the PPK (optional)").prompt(default = "")
 }

--- a/prime-router/src/main/kotlin/credentials/Credential.kt
+++ b/prime-router/src/main/kotlin/credentials/Credential.kt
@@ -8,7 +8,8 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 // All credential classes must exist in this file to inherit from a sealed class
 // https://kotlinlang.org/docs/reference/sealed-classes.html
 
-data class UserPassCredential(val user: String, val pass: String) : Credential()
+data class UserPassCredential(val user: String, val pass: String) : Credential(), SftpCredential
+data class UserPpkCredential(val user: String, val key: String) : Credential(), SftpCredential
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -16,7 +17,8 @@ data class UserPassCredential(val user: String, val pass: String) : Credential()
     property = "@type"
 )
 @JsonSubTypes(
-    JsonSubTypes.Type(value = UserPassCredential::class, name = "UserPass")
+    JsonSubTypes.Type(value = UserPassCredential::class, name = "UserPass"),
+    JsonSubTypes.Type(value = UserPpkCredential::class, name = "UserPpk")
 )
 sealed class Credential {
 
@@ -31,3 +33,5 @@ sealed class Credential {
         }
     }
 }
+
+interface SftpCredential

--- a/prime-router/src/main/kotlin/credentials/Credential.kt
+++ b/prime-router/src/main/kotlin/credentials/Credential.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 // https://kotlinlang.org/docs/reference/sealed-classes.html
 
 data class UserPassCredential(val user: String, val pass: String) : Credential(), SftpCredential
-data class UserPpkCredential(val user: String, val key: String) : Credential(), SftpCredential
+data class UserPpkCredential(val user: String, val key: String, val keyPass: String) : Credential(), SftpCredential
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -96,7 +96,11 @@ class SftpTransport : ITransport {
                 sshClient.connect(host, port.toInt())
                 when (credential) {
                     is UserPassCredential -> sshClient.authPassword(credential.user, credential.pass)
-                    is UserPpkCredential -> PuTTYKeyFile().init(StringReader(credential.key))
+                    is UserPpkCredential -> {
+                        val key = PuTTYKeyFile()
+                        key.init(StringReader(credential.key))
+                        sshClient.authPublickey(credential.user, key)
+                    }
                     else -> error("Unknown SftpCredential ${credential::class.simpleName}")
                 }
                 return sshClient

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -10,13 +10,17 @@ import gov.cdc.prime.router.azure.WorkflowEngine
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.credentials.CredentialHelper
 import gov.cdc.prime.router.credentials.CredentialRequestReason
+import gov.cdc.prime.router.credentials.SftpCredential
 import gov.cdc.prime.router.credentials.UserPassCredential
+import gov.cdc.prime.router.credentials.UserPpkCredential
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.sftp.StatefulSFTPClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
+import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
 import net.schmizz.sshj.xfer.InMemorySourceFile
 import net.schmizz.sshj.xfer.LocalSourceFile
 import java.io.InputStream
+import java.io.StringReader
 import java.util.logging.Level
 
 class SftpTransport : ITransport {
@@ -35,10 +39,10 @@ class SftpTransport : ITransport {
             if (header.content == null)
                 error("No content to sftp for report ${header.reportFile.reportId}")
             val receiver = header.receiver ?: error("No receiver defined for report ${header.reportFile.reportId}")
-            val (user, pass) = lookupCredentials(receiver.fullName)
+            val credential = lookupCredentials(receiver.fullName)
             // Dev note:  db table requires body_url to be unique, but not external_name
             val fileName = Report.formExternalFilename(header)
-            val sshClient = connect(host, port, user, pass)
+            val sshClient = connect(host, port, credential)
             context.logger.log(Level.INFO, "Successfully connected to $sftpTransportType, ready to upload $fileName")
             uploadFile(sshClient, sftpTransportType.filePath, fileName, header.content)
             val msg = "Success: sftp upload of $fileName to $sftpTransportType"
@@ -67,33 +71,34 @@ class SftpTransport : ITransport {
     }
 
     companion object {
-        fun lookupCredentials(receiverFullName: String): Pair<String, String> {
+        fun lookupCredentials(receiverFullName: String): SftpCredential {
             val credentialLabel = receiverFullName
                 .replace(".", "--")
                 .replace("_", "-")
                 .toUpperCase()
 
-            // Assumes credential will be cast as UserPassCredential, if not return null, and thus the error case
-            val credential = CredentialHelper.getCredentialService().fetchCredential(
+            // Assumes credential will be cast as SftpCredential, if not return null, and thus the error case
+            return CredentialHelper.getCredentialService().fetchCredential(
                 credentialLabel, "SftpTransport", CredentialRequestReason.SFTP_UPLOAD
-            ) as? UserPassCredential?
+            ) as? SftpCredential?
                 ?: error("Unable to find SFTP credentials for $receiverFullName connectionId($credentialLabel)")
-
-            return Pair(credential.user, credential.pass)
         }
 
         fun connect(
             host: String,
             port: String,
-            user: String,
-            pass: String,
+            credential: SftpCredential,
         ): SSHClient {
             // create our client
             val sshClient = SSHClient()
             try {
                 sshClient.addHostKeyVerifier(PromiscuousVerifier())
                 sshClient.connect(host, port.toInt())
-                sshClient.authPassword(user, pass)
+                when (credential) {
+                    is UserPassCredential -> sshClient.authPassword(credential.user, credential.pass)
+                    is UserPpkCredential -> PuTTYKeyFile().init(StringReader(credential.key))
+                    else -> error("Unknown SftpCredential ${credential::class.simpleName}")
+                }
                 return sshClient
             } catch (t: Throwable) {
                 sshClient.disconnect()


### PR DESCRIPTION
This PR adds PPK authentication to the SftpTransport.

Since Key Vault supports secrets as large as 25,000 bytes, PPK files are within that limit and can be stored as Azure secrets. In my testing, a PPK file stored in our JSON container averaged 2,800 bytes.

## Changes
- Refactors the SftpTransport to handle multiple authentication options
- Adds the ability to create UserPpk types via the CLI

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

