### PR TITLE
Sync'd the organization files and added transports for VT and NM and GU

### DIFF
--- a/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
@@ -1,0 +1,1101 @@
+
+### Schema:         mt/mt-covid-19-csv
+#### Description:   MT COVID-19 flat file
+
+---
+
+**Name**: Result_ID
+
+**Type**: ID
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+unique id to track the usage of the message
+
+---
+
+**Name**: Corrected_result_ID
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+pointer/link to the unique id of a previously submitted result.  Usually blank. Or, if an item modifies/corrects a prior item, this field holds the message_id of the prior item.
+
+---
+
+**Name**: Placer_order_ID
+
+**Type**: ID
+
+**HL7 Fields**: ORC-2-1, OBR-2-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Filler_order_ID
+
+**Type**: ID
+
+**HL7 Fields**: ORC-3-1, SPM-2-2, OBR-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_last_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The patient's last name
+
+---
+
+**Name**: Patient_first_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: Patient_middle_name
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_suffix
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_ID
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_Id_type
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Ordered_test_code
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+The LOINC code of the test performed. This is a standardized coded value describing the test
+
+---
+
+**Name**: Ordered_test_name
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-3-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Performed LOINC Long Name
+
+**Documentation**:
+
+The LOINC description of the test performed as related to the LOINC code.
+
+---
+
+**Name**: Specimen_source_site_code
+
+**Type**: CODE
+
+**Format**: $code
+
+**HL7 Field**: SPM-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+119297000|Blood specimen (specimen)
+71836000|Nasopharyngeal structure (body structure)
+45206002|Nasal structure (body structure)
+
+---
+
+**Name**: Specimen_type_code
+
+**Type**: CODE
+
+**Format**: $code
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: Device_ID
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Model
+
+---
+
+**Name**: Instrument_ID
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Test_result_status
+
+**Type**: CODE
+
+**HL7 Fields**: OBX-11-1, OBR-25-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+A|Some, but not all, results available
+C|Corrected, final
+F|Final results
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+X|No results available; Order canceled
+Y|No order on record for this test
+Z|No record of this patient
+
+---
+
+**Name**: Test_result_code
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+
+---
+
+**Name**: Illness_onset_date
+
+**Type**: DATE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 65222-2
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Specimen_collection_date_time
+
+**Type**: DATETIME
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The date which the specimen was collected. The default format is yyyyMMddHHmmsszz
+
+
+---
+
+**Name**: Order_test_date
+
+**Type**: DATE
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Test_date
+
+**Type**: DATETIME
+
+**Format**: yyyyMMdd
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Date_result_released
+
+**Type**: DATETIME
+
+**Format**: yyyyMMdd
+
+**HL7 Field**: OBR-22
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_race
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: Patient_DOB
+
+**Type**: DATE
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: Patient_gender
+
+**Type**: CODE
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: Patient_ethnicity
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+
+**Documentation**:
+
+The patient's ethnicity. There is a valueset defined based on the values in PID-22, but downstream
+consumers are free to define their own values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: Patient_street
+
+**Type**: STREET
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: Patient_street_2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: Patient_city
+
+**Type**: CITY
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: Patient_state
+
+**Type**: TABLE
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The patient's state
+
+---
+
+**Name**: Patient_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: Patient_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: Patient_county
+
+**Type**: TABLE_OR_BLANK
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: Patient_email
+
+**Type**: EMAIL
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient_role
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Processing_mode_code
+
+**Type**: CODE
+
+**HL7 Field**: MSH-11-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+D|Debugging
+P|Production
+T|Training
+
+**Documentation**:
+
+P, D, or T for Production, Debugging, or Training
+
+---
+
+**Name**: Employed_in_healthcare
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient employed in health care?
+
+---
+
+**Name**: Resident_congregate_setting
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Does the patient reside in a congregate care setting?
+
+---
+
+**Name**: First_test
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is this the patient's first test for this condition?
+
+---
+
+**Name**: Symptomatic_for_disease
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient symptomatic?
+
+---
+
+**Name**: Testing_lab_name
+
+**Type**: TEXT
+
+**HL7 Field**: OBX-23-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: Testing_lab_CLIA
+
+**Type**: ID_CLIA
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
+
+---
+
+**Name**: Testing_lab_street
+
+**Type**: STREET
+
+**HL7 Field**: OBX-24-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Testing_lab_street_2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: OBX-24-2
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Testing_lab_city
+
+**Type**: CITY
+
+**HL7 Field**: OBX-24-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Testing_lab_state
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+---
+
+**Name**: Testing_lab_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Testing_lab_phone_number
+
+**Type**: TELEPHONE
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Testing_lab_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: Organization_name
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Ordering_facility_name
+
+**Type**: TEXT
+
+**HL7 Field**: ORC-21-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_street
+
+**Type**: STREET
+
+**HL7 Field**: ORC-22-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The address of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_street_2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: ORC-22-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The secondary address of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_city
+
+**Type**: CITY
+
+**HL7 Field**: ORC-22-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_state
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: ORC-22-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Field**: ORC-23
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The phone number of the facility which the test was ordered from
+
+---
+
+**Name**: Ordering_facility_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: Ordering_facility_email
+
+**Type**: EMAIL
+
+**HL7 Field**: ORC-23-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Ordering_provider_ID
+
+**Type**: ID_NPI
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ordering provider’s National Provider Identifier
+
+---
+
+**Name**: Ordering_provider_last_name
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: Ordering_provider_first_name
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: Ordering_provider_street
+
+**Type**: STREET
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: Ordering_provider_street_2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: Ordering_provider_city
+
+**Type**: CITY
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: Ordering_provider_state
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: Ordering_provider_zip_code
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: Ordering_provider_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: Ordering_provider_county
+
+**Type**: TABLE
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: reporting_facility_name
+
+**Type**: TEXT
+
+**HL7 Field**: MSH-4-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's name
+
+---
+
+**Name**: reporting_facility_clia
+
+**Type**: ID_CLIA
+
+**HL7 Fields**: MSH-4-2, SPM-2-1-3, SPM-2-2-3, PID-3-4-2, PID-3-6-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
+
+---

--- a/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
+++ b/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
@@ -1,6 +1,6 @@
 
-### Schema:         tcp/tcp-covid-19
-#### Description:   A COVID-19 schema for TCP working through A6
+### Schema:         tpca/tpca-covid-19
+#### Description:   A COVID-19 schema for TPCA working through A6
 
 ---
 

--- a/prime-router/metadata/schemas/MT/mt-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/MT/mt-covid-19-csv.schema
@@ -1,0 +1,305 @@
+---
+name: mt-covid-19-csv
+description: MT COVID-19 flat file
+topic: covid-19
+trackingElement: message_id
+basedOn: covid-19
+elements:
+  - name: message_id
+    csvFields:
+      - name: Result_ID
+
+  - name: previous_message_id
+    csvFields:
+      - name: Corrected_result_ID
+
+  - name: placer_order_id
+    csvFields:
+      - name: Placer_order_ID
+
+  - name: filler_order_id
+    csvFields:
+      - name: Filler_order_ID
+
+  - name: patient_last_name
+    csvFields:
+      - name: Patient_last_name
+
+  - name: patient_first_name
+    csvFields:
+      - name: Patient_first_name
+
+  - name: patient_middle_name
+    csvFields:
+      - name: Patient_middle_name
+
+  - name: patient_suffix
+    csvFields:
+      - name: Patient_suffix
+
+  - name: patient_id
+    csvFields:
+      - name: Patient_ID
+
+  - name: patient_id_type
+    csvFields:
+      - name: Patient_Id_type
+
+  - name: test_performed_code
+    csvFields:
+      - name: Ordered_test_code
+
+  - name: test_performed_name
+    csvFields:
+      - name: Ordered_test_name
+
+  - name: specimen_source_site_code
+    csvFields:
+      - name: Specimen_source_site_code
+        format: $code
+      - name: Specimen_source_site
+        format: $display
+
+  - name: specimen_type
+    csvFields:
+      - name: Specimen_type_code
+        format: $code
+      - name: Specimen_type
+        format: $display
+
+  - name: equipment_model_name
+    csvFields:
+      - name: Device_ID
+
+  - name: equipment_instance_id
+    csvFields:
+      - name: Instrument_ID
+
+  - name: test_result_status
+    csvFields:
+      - name: Test_result_status
+
+  - name: test_result
+    csvFields:
+      - name: Test_result_code
+        format: $display
+
+  - name: illness_onset_date
+    csvFields:
+      - name: Illness_onset_date
+
+  - name: specimen_collection_date_time
+    csvFields:
+      - name: Specimen_collection_date_time
+
+  - name: order_test_date
+    csvFields:
+      - name: Order_test_date
+
+  - name: test_result_date
+    csvFields:
+      - name: Test_date
+        format: yyyyMMdd
+
+  - name: date_result_released
+    csvFields:
+      - name: Date_result_released
+        format: yyyyMMdd
+
+  - name: patient_race
+    csvFields:
+      - name: Patient_race
+        format: $display
+
+  - name: patient_dob
+    csvFields:
+      - name: Patient_DOB
+
+  - name: patient_gender
+    csvFields:
+      - name: Patient_gender
+
+  - name: patient_ethnicity
+    csvFields:
+      - name: Patient_ethnicity
+        format: $display
+
+  - name: patient_street
+    csvFields:
+      - name: Patient_street
+
+  - name: patient_street2
+    csvFields:
+      - name: Patient_street_2
+
+  - name: patient_city
+    csvFields:
+      - name: Patient_city
+
+  - name: patient_state
+    csvFields:
+      - name: Patient_state
+
+  - name: patient_zip_code
+    csvFields:
+      - name: Patient_zip_code
+
+  - name: patient_phone_number
+    csvFields:
+      - name: Patient_phone_number
+
+  - name: patient_county
+    csvFields:
+      - name: Patient_county
+
+  - name: patient_email
+    csvFields:
+      - name: Patient_email
+
+  - name: patient_role
+    csvFields:
+      - name: Patient_role
+
+  - name: processing_mode_code
+    csvFields:
+      - name: Processing_mode_code
+
+  - name: employed_in_healthcare
+    csvFields:
+      - name: Employed_in_healthcare
+
+  - name: resident_congregate_setting
+    csvFields:
+      - name: Resident_congregate_setting
+
+  - name: first_test
+    csvFields:
+      - name: First_test
+
+  - name: symptomatic_for_disease
+    csvFields:
+      - name: Symptomatic_for_disease
+
+  - name: testing_lab_name
+    csvFields:
+      - name: Testing_lab_name
+
+  - name: testing_lab_clia
+    csvFields:
+      - name: Testing_lab_CLIA
+
+  - name: testing_lab_street
+    csvFields:
+      - name: Testing_lab_street
+
+  - name: testing_lab_street2
+    csvFields:
+      - name: Testing_lab_street_2
+
+  - name: testing_lab_city
+    csvFields:
+      - name: Testing_lab_city
+
+  - name: testing_lab_state
+    csvFields:
+      - name: Testing_lab_state
+
+  - name: testing_lab_zip_code
+    csvFields:
+      - name: Testing_lab_zip_code
+
+  - name: testing_lab_phone_number
+    csvFields:
+      - name: Testing_lab_phone_number
+
+  - name: testing_lab_county
+    csvFields:
+      - name: Testing_lab_county
+
+  - name: organization_name
+    csvFields:
+      - name: Organization_name
+
+  - name: ordering_facility_name
+    csvFields:
+      - name: Ordering_facility_name
+
+  - name: ordering_facility_street
+    csvFields:
+      - name: Ordering_facility_street
+
+  - name: ordering_facility_street2
+    csvFields:
+      - name: Ordering_facility_street_2
+
+  - name: ordering_facility_city
+    csvFields:
+      - name: Ordering_facility_city
+
+  - name: ordering_facility_state
+    csvFields:
+      - name: Ordering_facility_state
+
+  - name: ordering_facility_zip_code
+    csvFields:
+      - name: Ordering_facility_zip_code
+
+  - name: ordering_facility_phone_number
+    csvFields:
+      - name: Ordering_facility_phone_number
+
+  - name: ordering_facility_county
+    csvFields:
+      - name: Ordering_facility_county
+
+  - name: ordering_facility_email
+    csvFields:
+      - name: Ordering_facility_email
+
+  - name: ordering_provider_id
+    csvFields:
+      - name: Ordering_provider_ID
+
+  - name: ordering_provider_last_name
+    csvFields:
+      - name: Ordering_provider_last_name
+
+  - name: ordering_provider_first_name
+    csvFields:
+      - name: Ordering_provider_first_name
+
+  - name: ordering_provider_street
+    csvFields:
+      - name: Ordering_provider_street
+
+  - name: ordering_provider_street2
+    csvFields:
+      - name: Ordering_provider_street_2
+
+  - name: ordering_provider_city
+    csvFields:
+      - name: Ordering_provider_city
+
+  - name: ordering_provider_state
+    csvFields:
+      - name: Ordering_provider_state
+
+  - name: ordering_provider_zip_code
+    csvFields:
+      - name: Ordering_provider_zip_code
+
+  - name: ordering_provider_phone_number
+    csvFields:
+      - name: Ordering_provider_phone_number
+
+  - name: ordering_provider_county
+    csvFields:
+      - name: Ordering_provider_county
+
+  - name: reporting_facility_name
+    mapper: use(testing_lab_name)
+
+  - name: reporting_facility_clia
+    mapper: use(testing_lab_clia)
+
+

--- a/prime-router/metadata/schemas/TPCA/tpca-covid-19.schema
+++ b/prime-router/metadata/schemas/TPCA/tpca-covid-19.schema
@@ -1,6 +1,6 @@
 ---
-name: tcp-covid-19
-description: A COVID-19 schema for TCP working through A6
+name: tpca-covid-19
+description: A COVID-19 schema for TPCA working through A6
 trackingElement: specimen_id
 topic: covid-19
 basedOn: covid-19

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -349,6 +349,25 @@
           numberPerDay: 1440 # Every minute
           initialTime: 00:00
           timeZone: MOUNTAIN
+      - name: elr-csv
+        organizationName: mt-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(patient_state, MT)
+        translation:
+          type: CUSTOM
+          format: CSV
+          schemaName: mt/mt-covid-19-csv
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: MOUNTAIN
 
   - name: tx-doh
     description: Texas Department of Health

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -22,14 +22,14 @@
         schemaName: strac/strac-covid-19
         format: CSV
 
-  - name: tcp
-    description: TCP Receiver organization via A6
+  - name: tpca
+    description: TPCA Receiver organization via A6
     jurisdiction: FEDERAL
     senders:
       - name: default
-        organizationName: tcp
+        organizationName: tpca
         topic: covid-19
-        schemaName: tcp/tcp-covid-19
+        schemaName: tpca/tpca-covid-19
         format: CSV
 
   - name: az-phd
@@ -187,12 +187,12 @@
       - name: elr
         organizationName: fl-phd
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, FL)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, FL)
         deidentify: false
         translation:
           type: HL7
           useBatchHeaders: true
-          schemaName: fl/fl-covid-19
           receivingApplicationName: FDOH-ELR
           receivingApplicationOID: 2.16.840.1.114222.4.3.3.8.1.3
           receivingFacilityName: FDOH
@@ -221,7 +221,6 @@
         deidentify: false
         translation:
           type: HL7
-          schemaName: nd/nd-covid-19
           useBatchHeaders: true
           receivingApplicationName: Maven
           receivingApplicationOID: 2.16.840.1.114222.4.3.4.34.1.1
@@ -250,7 +249,6 @@
           - matches(ordering_facility_state, LA)
         translation:
           type: HL7
-          schemaName: la/la-covid-19
           useBatchHeaders: true
           receivingOrganization: laoph
           receivingApplicationName: LA-ELR
@@ -308,10 +306,10 @@
       - name: elr
         organizationName: nm-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, NM)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, NM)
         translation:
           type: HL7
-          schemaName: nm/nm-covid-19
           useBatchHeaders: true
           receivingApplicationName: NMDOH
           receivingApplicationOID: 2.16.840.1.113883.3.5364
@@ -340,7 +338,6 @@
           - matches(patient_state, MT)
         translation:
           type: HL7
-          schemaName: mt/mt-covid-19
           useBatchHeaders: true
         transport:
           type: SFTP
@@ -365,12 +362,11 @@
           - matches(ordering_facility_state, TX)
         translation:
           type: HL7
-          schemaName: tx/tx-covid-19
           useBatchHeaders: true
           receivingApplicationName: NEDSS
           receivingFacilityName: TX-ELR
         transport:
-          type: SFTP
+          type: SFTP_LEGACY
           host: sftp
           port: 22
           filePath: ./upload
@@ -392,12 +388,11 @@
           - matches(ordering_facility_state, GU)
         translation:
           type: HL7
-          schemaName: gu/gu-covid-19
           useBatchHeaders: true
           receivingApplicationName: GUDOH
           receivingFacilityName: GUDOH
         transport:
-          type: SFTP_LEGACY
+          type: SFTP
           host: sftp
           port: 22
           filePath: ./upload
@@ -419,7 +414,6 @@
           - matches(ordering_facility_state, VT)
         translation:
           type: HL7
-          schemaName: vt/vt-covid-19
           useBatchHeaders: true
           receivingApplicationName: NBS
           receivingApplicationOID: 2.16.840.1.114222.4.1.185.1

--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -285,7 +285,21 @@
         useBatchHeaders: true
       timing:
         operation: MERGE
-        numberPerDay: 12
+        numberPerDay: 1         # change to once a day for download site
+        initialTime: 01:15
+        timeZone: EASTERN
+    - name: elr-csv
+      organizationName: mt-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(patient_state, MT)
+      translation:
+        type: CUSTOM
+        format: CSV
+        schemaName: mt/mt-covid-19-csv
+      timing:
+        operation: MERGE
+        numberPerDay: 1
         initialTime: 01:15
         timeZone: EASTERN
 

--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -258,6 +258,11 @@
         receivingApplicationOID: 2.16.840.1.113883.3.5364
         receivingFacilityName: NMDOH
         receivingFacilityOID: 2.16.840.1.113883.3.5364
+      transport:
+        type: SFTP
+        host: secure.lcfresearch.org
+        port: 22
+        filePath: ./
       timing:
         operation: MERGE
         numberPerDay: 12
@@ -309,7 +314,61 @@
         type: SFTP_LEGACY
         host: sftp-edts.hhs.texas.gov
         port: 22
+        filePath: ./USDS_IN
+
+- name: gu-doh
+  description: Guam Department of Health
+  jurisdiction: STATE
+  stateCode: GU
+  receivers:
+    - name: elr
+      organizationName: gu-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, GU)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: GUDOH
+        receivingFacilityName: GUDOH
+      transport:
+        type: SFTP
+        host: sftp-west.inductivehealth.com
+        port: 22
         filePath: ./
+      timing:
+        operation: MERGE
+        numberPerDay: 12 # every two hours
+        initialTime: 00:00
+        timeZone: EASTERN
+
+- name: vt-doh
+  description: Vermont Department of Health
+  jurisdiction: STATE
+  stateCode: VT
+  receivers:
+    - name: elr
+      organizationName: vt-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, VT)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: NBS
+        receivingApplicationOID: 2.16.840.1.114222.4.1.185.1
+        receivingFacilityName: VDH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.185
+      transport:
+        type: SFTP
+        host: gs-sftp.ahs.state.vt.us
+        port: 22
+        filePath: ./
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: EASTERN
 
 - name: pa-phd
   description: Pennsylvania Department of Health

--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -286,7 +286,7 @@
       timing:
         operation: MERGE
         numberPerDay: 1         # change to once a day for download site
-        initialTime: 01:15
+        initialTime: 09:15
         timeZone: EASTERN
     - name: elr-csv
       organizationName: mt-doh
@@ -300,7 +300,7 @@
       timing:
         operation: MERGE
         numberPerDay: 1
-        initialTime: 01:15
+        initialTime: 09:15
         timeZone: EASTERN
 
 - name: tx-doh
@@ -353,7 +353,7 @@
       timing:
         operation: MERGE
         numberPerDay: 12 # every two hours
-        initialTime: 00:00
+        initialTime: 01:15
         timeZone: EASTERN
 
 - name: vt-doh
@@ -380,8 +380,8 @@
         filePath: ./
       timing:
         operation: MERGE
-        numberPerDay: 1440 # Every minute
-        initialTime: 00:00
+        numberPerDay: 12 # Every two hours
+        initialTime: 01:15
         timeZone: EASTERN
 
 - name: pa-phd

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -314,6 +314,25 @@
         numberPerDay: 1440 # Every minute
         initialTime: 00:00
         timeZone: MOUNTAIN
+    - name: elr-csv
+      organizationName: mt-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(patient_state, MT)
+      translation:
+        type: CUSTOM
+        format: CSV
+        schemaName: mt/mt-covid-19-csv
+      transport:
+        type: SFTP
+        host: sftp
+        port: 22
+        filePath: ./upload
+      timing:
+        operation: MERGE
+        numberPerDay: 1440
+        initialTime: 00:00
+        timeZone: MOUNTAIN
 
 - name: tx-doh
   description: Texas Department of Health

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -22,14 +22,14 @@
       schemaName: strac/strac-covid-19
       format: CSV
 
-- name: tcp
-  description: TCP Receiver organization via A6
+- name: tpca
+  description: TPCA Receiver organization via A6
   jurisdiction: FEDERAL
   senders:
     - name: default
-      organizationName: tcp
+      organizationName: tpca
       topic: covid-19
-      schemaName: tcp/tcp-covid-19
+      schemaName: tpca/tpca-covid-19
       format: CSV
 
 - name: az-phd
@@ -159,12 +159,16 @@
     - name: elr
       organizationName: fl-phd
       topic: covid-19
-      jurisdictionalFilter: [ "matches(ordering_facility_state, FL)" ]
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, FL)
       deidentify: false
       translation:
         type: HL7
-        schemaName: fl/fl-covid-19
         useBatchHeaders: true
+        receivingApplicationName: FDOH-ELR
+        receivingApplicationOID: 2.16.840.1.114222.4.3.3.8.1.3
+        receivingFacilityName: FDOH
+        receivingFacilityOID: 2.16.840.1.114222.1.3645
       timing:
         operation: MERGE
         numberPerDay: 1440 # Every minute
@@ -187,7 +191,6 @@
       jurisdictionalFilter: [ "matches(ordering_facility_state, ND)" ]
       translation:
         type: HL7
-        schemaName: nd/nd-covid-19
         useBatchHeaders: true
         receivingApplicationName: Maven
         receivingApplicationOID: 2.16.840.1.114222.4.3.4.34.1.1
@@ -212,10 +215,10 @@
     - name: elr
       organizationName: la-doh
       topic: covid-19
-      jurisdictionalFilter: [ "matches(ordering_facility_state, LA)" ]
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, LA)
       translation:
         type: HL7
-        schemaName: la/la-covid-19
         useBatchHeaders: true
         receivingOrganization: LAOPH
         receivingApplicationName: LA-ELR
@@ -240,10 +243,10 @@
     - name: elr
       organizationName: oh-doh
       topic: covid-19
-      jurisdictionalFilter: [ "matches(ordering_facility_state, OH)" ]
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, OH)
       translation:
         type: HL7
-        schemaName: oh/oh-covid-19
         useBatchHeaders: true
         suppressQstForAoe: true
         receivingApplicationName: OHDOH
@@ -273,10 +276,10 @@
     - name: elr
       organizationName: nm-doh
       topic: covid-19
-      jurisdictionalFilter: [ "matches(ordering_facility_state, NM)" ]
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, NM)
       translation:
         type: HL7
-        schemaName: nm/nm-covid-19
         useBatchHeaders: true
         receivingApplicationName: NMDOH
         receivingApplicationOID: 2.16.840.1.113883.3.5364
@@ -301,10 +304,10 @@
     - name: elr
       organizationName: mt-doh
       topic: covid-19
-      jurisdictionalFilter: [ "matches(patient_state, MT)" ]
+      jurisdictionalFilter:
+        - matches(patient_state, MT)
       translation:
         type: HL7
-        schemaName: mt/mt-covid-19
         useBatchHeaders: true
       timing:
         operation: MERGE
@@ -320,10 +323,10 @@
     - name: elr
       organizationName: tx-doh
       topic: covid-19
-      jurisdictionalFilter: [ "matches(ordering_facility_state, TX)" ]
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, TX)
       translation:
         type: HL7
-        schemaName: tx/tx-covid-19
         useBatchHeaders: true
         receivingApplicationName: NEDSS
         receivingFacilityName: TX-ELR
@@ -337,6 +340,60 @@
         host: 10.0.2.4
         port: 22
         filePath: ./upload
+
+- name: gu-doh
+  description: Guam Department of Health
+  jurisdiction: STATE
+  stateCode: GU
+  receivers:
+    - name: elr
+      organizationName: gu-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, GU)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: GUDOH
+        receivingFacilityName: GUDOH
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
+      timing:
+        operation: MERGE
+        numberPerDay: 1440
+        initialTime: 00:00
+        timeZone: CHAMORRO
+
+- name: vt-doh
+  description: Vermont Department of Health
+  jurisdiction: STATE
+  stateCode: VT
+  receivers:
+    - name: elr
+      organizationName: vt-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, VT)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: NBS
+        receivingApplicationOID: 2.16.840.1.114222.4.1.185.1
+        receivingFacilityName: VDH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.185
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
+      timing:
+        operation: MERGE
+        numberPerDay: 1440
+        initialTime: 00:00
+        timeZone: EASTERN
 
 - name: co-phd
   description: Colorado Department of Health

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -228,6 +228,15 @@
         translation:
           type: HL7
           useBatchHeaders: true
+      - name: elr-csv
+        organizationName: mt-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(patient_state, MT)
+        translation:
+          type: CUSTOM
+          format: CSV
+          schemaName: mt/mt-covid-19-csv
 
   - name: tx-doh
     description: Texas Department of Health

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -22,14 +22,14 @@
         schemaName: strac/strac-covid-19
         format: CSV
 
-  - name: tcp
-    description: TCP Receiver organization via A6
+  - name: tpca
+    description: TPCA Receiver organization via A6
     jurisdiction: FEDERAL
     senders:
       - name: default
-        organizationName: tcp
+        organizationName: tpca
         topic: covid-19
-        schemaName: tcp/tcp-covid-19
+        schemaName: tpca/tpca-covid-19
         format: CSV
 
   - name: az-phd
@@ -128,11 +128,16 @@
       - name: elr
         organizationName: fl-phd
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, FL)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, FL)
         deidentify: false
         translation:
           type: HL7
           useBatchHeaders: true
+          receivingApplicationName: FDOH-ELR
+          receivingApplicationOID: 2.16.840.1.114222.4.3.3.8.1.3
+          receivingFacilityName: FDOH
+          receivingFacilityOID: 2.16.840.1.114222.1.3645
 
   - name: nd-doh
     description: North Dakota Department of Health
@@ -142,7 +147,9 @@
       - name: elr
         organizationName: nd-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, ND)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, ND)
+        deidentify: false
         translation:
           type: HL7
           useBatchHeaders: true
@@ -150,11 +157,6 @@
           receivingApplicationOID: 2.16.840.1.114222.4.3.4.34.1.1
           receivingFacilityName: NDDOH
           receivingFacilityOID: 2.16.840.1.113883.3.89.109.100.1.3
-        transport:
-          type: SFTP
-          host: sftp
-          port: 22
-          filePath: ./upload
 
   - name: la-doh
     description: Louisiana Department of Health
@@ -164,7 +166,8 @@
       - name: elr
         organizationName: la-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, LA)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, LA)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -180,7 +183,8 @@
       - name: elr
         organizationName: oh-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, OH)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, OH)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -201,7 +205,8 @@
       - name: elr
         organizationName: nm-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, NM)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, NM)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -218,7 +223,8 @@
       - name: elr
         organizationName: mt-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(patient_state, MT)" ]
+        jurisdictionalFilter:
+          - matches(patient_state, MT)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -231,12 +237,47 @@
       - name: elr
         organizationName: tx-doh
         topic: covid-19
-        jurisdictionalFilter: [ "matches(ordering_facility_state, TX)" ]
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, TX)
         translation:
           type: HL7
           useBatchHeaders: true
           receivingApplicationName: NEDSS
           receivingFacilityName: TX-ELR
+
+  - name: gu-doh
+    description: Guam Department of Health
+    jurisdiction: STATE
+    stateCode: GU
+    receivers:
+      - name: elr
+        organizationName: gu-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, GU)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: GUDOH
+          receivingFacilityName: GUDOH
+
+  - name: vt-doh
+    description: Vermont Department of Health
+    jurisdiction: STATE
+    stateCode: VT
+    receivers:
+      - name: elr
+        organizationName: vt-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, VT)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: NBS
+          receivingApplicationOID: 2.16.840.1.114222.4.1.185.1
+          receivingFacilityName: VDH
+          receivingFacilityOID: 2.16.840.1.114222.4.1.185
 
   - name: pa-phd
     description: Pennsylvania Department of Health


### PR DESCRIPTION
This PR updates the organization files so they're matching across the different levels and updates VT, NM, and GU to have transport information in prod. This will require us to add their credential information into prod so we can test and verify the connections.

I also changed the name of TCP to match TPCA as it should be.

## Changes
- Changed the name of TCP to TPCA
- Added organizations for VT, NM, and GU to prod and included their transport info
- Updated the docs

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- Add the credential information for NM, GU, and VT into secrets storage on prod #712 

