### PR TITLE
Add PostgreSQL Replica within Peered Virtual Network

### DIFF
--- a/operations/app/src/modules/database/variables.tf
+++ b/operations/app/src/modules/database/variables.tf
@@ -33,6 +33,11 @@ variable "private_subnet_id" {
     description = "Private Subnet ID"
 }
 
+variable "private2_subnet_id" {
+    type = string
+    description = "Private2 Subnet ID"
+}
+
 variable "app_config_key_vault_id" {
     type = string
     description = "Key Vault used for database user/pass"

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -90,8 +90,8 @@ resource "azurerm_subnet_network_security_group_association" "private_private" {
   network_security_group_id = azurerm_network_security_group.nsg_private.id
 }
 
-resource "azurerm_virtual_network" "vnet_peer_1" {
-  name = "${var.resource_prefix}-vnet-peer-001"
+resource "azurerm_virtual_network" "virtual_network_2" {
+  name = "${var.resource_prefix}-vnet-peer"
   location = "westus"
   resource_group_name = var.resource_group
   address_space = ["10.1.0.0/16"]
@@ -105,11 +105,11 @@ resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.vnet_peer_1.name
-  address_prefixes = ["10.1.23.0/24"]
+  address_prefixes = ["10.1.3.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }
 
-resource "azurerm_virtual_network_peering" "peer_1" {
+resource "azurerm_virtual_network_peering" "virtual_network_peer" {
   name = "${var.resource_prefix}-peering-001"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.virtual_network.name

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -94,7 +94,7 @@ resource "azurerm_virtual_network" "virtual_network_2" {
   name = "${var.resource_prefix}-vnet2"
   location = "westus"
   resource_group_name = var.resource_group
-  address_space = ["10.0.23.0/16"]
+  address_space = ["10.1.0.0/16"]
 
   tags = {
     environment = var.environment
@@ -105,7 +105,7 @@ resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.virtual_network_2.name
-  address_prefixes = ["10.0.23.0/24"]
+  address_prefixes = ["10.1.23.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }
 

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -104,7 +104,7 @@ resource "azurerm_virtual_network" "virtual_network_2" {
 resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
-  virtual_network_name = azurerm_virtual_network.vnet_peer_1.name
+  virtual_network_name = azurerm_virtual_network.virutal_network_2.name
   address_prefixes = ["10.1.3.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }
@@ -113,7 +113,7 @@ resource "azurerm_virtual_network_peering" "virtual_network_peer" {
   name = "${var.resource_prefix}-peering-001"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.virtual_network.name
-  remote_virtual_network_id = azurerm_virtual_network.vnet_peer_1.id
+  remote_virtual_network_id = azurerm_virtual_network.virtual_network_2.id
 }
 
 output "public_subnet_id" {

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -94,7 +94,7 @@ resource "azurerm_virtual_network" "virtual_network_2" {
   name = "${var.resource_prefix}-vnet2"
   location = "westus"
   resource_group_name = var.resource_group
-  address_space = ["11.0.0.0/16"]
+  address_space = ["10.0.23.0/16"]
 
   tags = {
     environment = var.environment
@@ -105,7 +105,7 @@ resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.virtual_network_2.name
-  address_prefixes = ["11.0.3.0/24"]
+  address_prefixes = ["10.0.23.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }
 

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -90,6 +90,32 @@ resource "azurerm_subnet_network_security_group_association" "private_private" {
   network_security_group_id = azurerm_network_security_group.nsg_private.id
 }
 
+resource "azurerm_virtual_network" "virtual_network_2" {
+  name = "${var.resource_prefix}-vnet2"
+  location = "westus"
+  resource_group_name = var.resource_group
+  address_space = ["11.0.0.0/16"]
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+resource "azurerm_subnet" "private2" {
+  name = "private"
+  resource_group_name = var.resource_group
+  virtual_network_name = azurerm_virtual_network.virtual_network_2.name
+  address_prefixes = ["11.0.3.0/24"]
+  service_endpoints = ["Microsoft.Sql"]
+}
+
+resource "azurerm_virtual_network_peering" "vnet_vnet2" {
+  name = "${var.resource_prefix}-peer-vnet-vnet2"
+  resource_group_name = var.resource_group
+  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  remote_virtual_network_id = azurerm_virtual_network.virtual_network_2.id
+}
+
 output "public_subnet_id" {
   value = azurerm_subnet.public.id
 }
@@ -100,4 +126,8 @@ output "container_subnet_id" {
 
 output "private_subnet_id" {
   value = azurerm_subnet.private.id
+}
+
+output "private2_subnet_id" {
+  value = azurerm_subnet.private2.id
 }

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -90,8 +90,8 @@ resource "azurerm_subnet_network_security_group_association" "private_private" {
   network_security_group_id = azurerm_network_security_group.nsg_private.id
 }
 
-resource "azurerm_virtual_network" "virtual_network_2" {
-  name = "${var.resource_prefix}-vnet2"
+resource "azurerm_virtual_network" "vnet_peer_1" {
+  name = "${var.resource_prefix}-vnet-peer-001"
   location = "westus"
   resource_group_name = var.resource_group
   address_space = ["10.1.0.0/16"]
@@ -104,16 +104,16 @@ resource "azurerm_virtual_network" "virtual_network_2" {
 resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
-  virtual_network_name = azurerm_virtual_network.virtual_network_2.name
+  virtual_network_name = azurerm_virtual_network.vnet_peer_1.name
   address_prefixes = ["10.1.23.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }
 
-resource "azurerm_virtual_network_peering" "vnet_vnet2" {
-  name = "${var.resource_prefix}-peer-vnet-vnet2"
+resource "azurerm_virtual_network_peering" "peer_1" {
+  name = "${var.resource_prefix}-peering-001"
   resource_group_name = var.resource_group
   virtual_network_name = azurerm_virtual_network.virtual_network.name
-  remote_virtual_network_id = azurerm_virtual_network.virtual_network_2.id
+  remote_virtual_network_id = azurerm_virtual_network.vnet_peer_1.id
 }
 
 output "public_subnet_id" {

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -104,7 +104,7 @@ resource "azurerm_virtual_network" "virtual_network_2" {
 resource "azurerm_subnet" "private2" {
   name = "private"
   resource_group_name = var.resource_group
-  virtual_network_name = azurerm_virtual_network.virutal_network_2.name
+  virtual_network_name = azurerm_virtual_network.virtual_network_2.name
   address_prefixes = ["10.1.3.0/24"]
   service_endpoints = ["Microsoft.Sql"]
 }

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -75,6 +75,7 @@ module "database" {
     location = local.location
     public_subnet_id = module.network.public_subnet_id
     private_subnet_id = module.network.private_subnet_id
+    private2_subnet_id = module.network.private2_subnet_id
     eventhub_namespace_name = module.event_hub.eventhub_namespace_name
     eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
     app_config_key_vault_id = module.key_vault.app_config_key_vault_id


### PR DESCRIPTION
This PR adds a read replica for our master PostgreSQL server.  This will allow us to 1) alleviate burden on the master server for heavy read workloads, and 2) fail-over and promote the read replica to the master server upon a disaster scenario with minimal downtime.

The replica server is provisioned within the West US region, which is a pair to the East US region.  Additionally, it is provisioned within a second virtual network that is peered to the virtual network that resides within the East US region.  During testing, the communication between the master and replica worked just fine with public traffic disabled to the replica and no peered virtual network provisioned, so it may not be needed.  However, I opted to keep it as part of this PR as it will make for a much quicker response time if a disaster should occur (ie. the new VNet will not need to be provisioned to allow application traffic to access the server in the second region).