### PR TITLE
Fixes errors from quick test for MT CSV schema

### DIFF
--- a/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
@@ -573,6 +573,8 @@ The patient's phone number with area code
 
 **Name**: Patient_role
 
+**Type**: TEXT
+
 **Cardinality**: [0..1]
 
 ---
@@ -801,6 +803,8 @@ An example of the ID is 03D2159846
 ---
 
 **Name**: Organization_name
+
+**Type**: TEXT
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/MT/mt-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/MT/mt-covid-19-csv.schema
@@ -157,6 +157,7 @@ elements:
       - name: Patient_email
 
   - name: patient_role
+    type: TEXT
     csvFields:
       - name: Patient_role
 
@@ -217,6 +218,8 @@ elements:
       - name: Testing_lab_county
 
   - name: organization_name
+    type: TEXT
+    default: ''
     csvFields:
       - name: Organization_name
 


### PR DESCRIPTION
This PR fixes two errors in serialization found during running quick test for MT 

## Changes
- Adds data type to `organization_name` and `patient_role`
- Updates docs

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

