### PR TITLE
Added case insensitive search and tests for Lookup Tables

### DIFF
--- a/prime-router/src/main/kotlin/LookupTable.kt
+++ b/prime-router/src/main/kotlin/LookupTable.kt
@@ -54,21 +54,30 @@ class LookupTable(
         }
     }
 
-    fun filter(filterColumn: String, filterValue: String, selectColumn: String): List<String> {
+    fun filter(
+        filterColumn: String,
+        filterValue: String,
+        selectColumn: String,
+        ignoreCase: Boolean = true
+    ): List<String> {
         val filterColumnNumber = headerIndex[filterColumn.toLowerCase()] ?: return emptyList()
         val selectColumnNumber = headerIndex[selectColumn.toLowerCase()] ?: return emptyList()
         return table
-            .filter { row -> row[filterColumnNumber] == filterValue }
+            .filter { row -> row[filterColumnNumber].equals(filterValue, ignoreCase) }
             .map { row -> row[selectColumnNumber] }
     }
 
-    fun filter(selectColumn: String, filters: Map<String, String>): List<String> {
+    fun filter(
+        selectColumn: String,
+        filters: Map<String, String>,
+        ignoreCase: Boolean = true
+    ): List<String> {
         val selectColumnNumber = headerIndex[selectColumn.toLowerCase()] ?: return emptyList()
         return table
             .filter { row ->
                 filters.all { (k, v) ->
                     val filterColumnNumber = headerIndex[k.toLowerCase()] ?: error("$k doesn't exist lookup table")
-                    row[filterColumnNumber] == v
+                    row[filterColumnNumber].equals(v, ignoreCase)
                 }
             }
             .map { row -> row[selectColumnNumber] }

--- a/prime-router/src/main/kotlin/LookupTable.kt
+++ b/prime-router/src/main/kotlin/LookupTable.kt
@@ -56,6 +56,17 @@ class LookupTable(
         return table[rowNumber][colNumber]
     }
 
+    /**
+     * Performs a search of the table by looking through a set of column for values
+     * and returning the result for the specified row and column.
+     *
+     * By default the search is case-insensitive, though you can pass in the flag
+     * to make it respect case.
+     * @param indexValues The values to look for in the index column
+     * @param lookupColumn The column to pull your value from based on the index
+     * @param ignoreCase Whether or not to perform a case insensitive search
+     * @return The value you're looking for in the table base on the index look up value
+     */
     fun lookupValues(
         indexValues: List<Pair<String, String>>,
         lookupColumn: String,
@@ -86,6 +97,9 @@ class LookupTable(
         }
     }
 
+    /**
+     * Takes the contents of the table and filters down the rows to match the filter value provided
+     */
     fun filter(
         filterColumn: String,
         filterValue: String,
@@ -99,6 +113,10 @@ class LookupTable(
             .map { row -> row[selectColumnNumber] }
     }
 
+    /**
+     * Takes the contents of the table and filters down the rows where all the filters match.
+     * This performs an implicit AND because all of the filters must match
+     */
     fun filter(
         selectColumn: String,
         filters: Map<String, String>,
@@ -115,6 +133,10 @@ class LookupTable(
             .map { row -> row[selectColumnNumber] }
     }
 
+    /**
+     * Given a list of column names, walks through each column name and maps out each value to
+     * its row in the column to speed lookup for another value in the same row but in a different column.
+     */
     @Synchronized
     private fun getIndex(columnNames: List<String>, ignoreCase: Boolean = true): Map<String, Int> {
         val indexName = columnNames.joinToString(indexDelimiter)

--- a/prime-router/src/test/kotlin/LookupTableTests.kt
+++ b/prime-router/src/test/kotlin/LookupTableTests.kt
@@ -8,52 +8,36 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LookupTableTests {
-    @Test
-    fun `test read table`() {
-        val csv = """
+    private val table: LookupTable
+    private val csv = """
             a,b
             1,2
             3,4
             5,6
-        """.trimIndent()
-        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
+    """.trimIndent()
+
+    init {
+        table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
+    }
+
+    @Test
+    fun `test read table`() {
         assertEquals(3, table.rowCount)
     }
 
     @Test
     fun `test lookup`() {
-        val csv = """
-            a,b
-            1,2
-            3,4
-            5,6
-        """.trimIndent()
-        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
         assertTrue(table.hasColumn("a"))
         assertEquals("4", table.lookupValue("a", "3", "b"))
     }
 
     @Test
     fun `test lookup second column`() {
-        val csv = """
-            a,b
-            1,2
-            3,4
-            5,6
-        """.trimIndent()
-        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
         assertEquals("3", table.lookupValue("b", "4", "a"))
     }
 
     @Test
     fun `test bad lookup`() {
-        val csv = """
-            a,b
-            1,2
-            3,4
-            5,6
-        """.trimIndent()
-        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
         assertFalse(table.hasColumn("c"))
         assertNull(table.lookupValue("a", "3", "c"))
     }
@@ -70,5 +54,39 @@ class LookupTableTests {
         assertEquals("B", table.lookupValues(listOf("a" to "3", "b" to "4"), "c"))
         assertEquals("A", table.lookupValues(listOf("a" to "1", "b" to "2"), "c"))
         assertNull(table.lookupValues(listOf("a" to "1", "b" to "6"), "c"))
+    }
+
+    @Test
+    fun `test table filter`() {
+        val listOfValues = table.filter("a", "1", "b")
+        assertFalse(listOfValues.isEmpty())
+        assertEquals("2", listOfValues[0])
+    }
+
+    @Test
+    fun `test table filter ignoreCase`() {
+        val csv = """
+            a,b,c
+            1,2,A
+            3,4,B
+            5,6,C
+        """.trimIndent()
+        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
+        val listOfValues = table.filter("c", "A", "A")
+        assertFalse(listOfValues.isEmpty())
+        assertEquals("1", listOfValues[0])
+    }
+
+    @Test
+    fun `test table filter but don't ignoreCase`() {
+        val csv = """
+            a,b,c
+            1,2,A
+            3,4,B
+            5,6,C
+        """.trimIndent()
+        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
+        val listOfValues = table.filter("c", "a", "A", false)
+        assertTrue(listOfValues.isEmpty())
     }
 }

--- a/prime-router/src/test/kotlin/LookupTableTests.kt
+++ b/prime-router/src/test/kotlin/LookupTableTests.kt
@@ -89,4 +89,17 @@ class LookupTableTests {
         val listOfValues = table.filter("c", "a", "A", false)
         assertTrue(listOfValues.isEmpty())
     }
+
+    @Test
+    fun `test table lookup but don't ignoreCase`() {
+        val csv = """
+            a,b,c
+            1,2,A
+            3,4,B
+            5,6,C
+        """.trimIndent()
+        val table = LookupTable.read(ByteArrayInputStream(csv.toByteArray()))
+        val value = table.lookupValue("c", "c", "a", false)
+        assertTrue(value.isNullOrEmpty())
+    }
 }


### PR DESCRIPTION
This PR adds an `ignoreCase` flag to `filter`, `lookupValue`, and `lookupValues` that is defaulted to `true`. In most cases, we don't really care about the case of the data passed in, and given the fact that the data can come in in different case than we expect, we should not fail a lookup because someone sends us something that does not explicitly match our tables.

### Real world example
In the `LIVD` table we have device names that we match on to them map their result codes to the LOINC values that organizations need. Specifically, a lab in Ohio was sending `ID Now` as the device name, but our LIVD table looks for `ID NOW` which caused the lookup to fail and pass through empty string for OBX-3.

## Changes
- Adds `ignoreCase` to `filter`
- Adds `ignoreCase` to `lookupValue`
- Adds `ignoreCase` to `lookupValues`
- Adds `ignoreCase` to `createIndex`
- Adds unit tests to check above logic

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


## Fixes
*List GitHub issues this PR fixes*
- #723 

