### PR TITLE
Jim/settings test

### DIFF
--- a/prime-router/settings/SETTINGS-TEST-ORG.yml
+++ b/prime-router/settings/SETTINGS-TEST-ORG.yml
@@ -1,0 +1,106 @@
+---
+- name: "SETTINGS-TEST-ORG"
+  description: "DESCRIPTION"
+  jurisdiction: "FEDERAL"
+  stateCode: null
+  countyName: null
+  senders:
+  - name: "SENDER"
+    organizationName: "SETTINGS-TEST-ORG"
+    format: "CSV"
+    topic: "covid-19"
+    schemaName: "strac/strac-covid-19"
+  receivers:
+  - name: "RECEIVER1"
+    organizationName: "SETTINGS-TEST-ORG"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "fl/fl-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: "RECEIVING_ORG"
+      useAphlNamingFormat: false
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, IG)"
+    - "matches(ordering_facility_county, CSV)"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: "DESCRIPTION"
+    transport: !<SFTP>
+      host: "sftp"
+      port: "22"
+      filePath: "./upload"
+      type: "SFTP"
+  - name: "RECEIVER2"
+    organizationName: "SETTINGS-TEST-ORG"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "pa/pa-covid-19-redox"
+      format: "REDOX"
+      defaults:
+        processing_mode_code: "T"
+        redox_source_name: "Prime Hub (Local)"
+        redox_destination_id: "62d62d52-3771-4151-aff4-4a3d420a8b7a"
+        redox_destination_name: "Prime Local Redox Destination"
+        redox_source_id: "d89d4057-930f-4c5b-bb39-8cddb326e928"
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      useAphlNamingFormat: false
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, IG)"
+    - "matches(ordering_facility_county, REDOX)"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: "X"
+    transport: !<REDOX>
+      apiKey: "some_key"
+      baseUrl: "http://redox:1080"
+      type: "REDOX"
+  - name: "RECEIVER3"
+    organizationName: "SETTINGS-TEST-ORG"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "NEDSS"
+      receivingApplicationOID: "RECEIVING_OID"
+      receivingFacilityName: "SFTP_LEGACY"
+      receivingFacilityOID: "RECEIVING_FACILITY_OID"
+      messageProfileId: "MESSAGE_PROFILE_ID"
+      reportingFacilityName: "FACILITY_NAME"
+      reportingFacilityId: "FACILITY_ID"
+      suppressQstForAoe: false
+      suppressHl7Fields: "true"
+      suppressAoe: false
+      nameFormat: "STANDARD"
+      receivingOrganization: "RECEIVING_ORG"
+      type: "HL7"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, IG)"
+    - "matches(ordering_facility_county, SFTP_LEGACY)"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 5
+      initialTime: "07:00"
+      timeZone: "MOUNTAIN"
+      maxReportCount: 100
+    description: "DESCRIPTION"
+    transport: !<SFTP>
+      host: "sftp"
+      port: "22"
+      filePath: "./upload"
+      type: "SFTP"

--- a/prime-router/settings/SETTINGS-TEST-ORG.yml
+++ b/prime-router/settings/SETTINGS-TEST-ORG.yml
@@ -24,7 +24,7 @@
       type: "CUSTOM"
     jurisdictionalFilter:
     - "matches(ordering_facility_state, IG)"
-    - "matches(ordering_facility_county, CSV)"
+    - "matches(ordering_facility_county, RECEIVER1)"
     deidentify: false
     timing:
       operation: "MERGE"
@@ -56,7 +56,7 @@
       type: "CUSTOM"
     jurisdictionalFilter:
     - "matches(ordering_facility_state, IG)"
-    - "matches(ordering_facility_county, REDOX)"
+    - "matches(ordering_facility_county, RECEIVER2)"
     deidentify: false
     timing:
       operation: "MERGE"
@@ -90,7 +90,7 @@
       type: "HL7"
     jurisdictionalFilter:
     - "matches(ordering_facility_state, IG)"
-    - "matches(ordering_facility_county, SFTP_LEGACY)"
+    - "matches(ordering_facility_county, RECEIVER3)"
     deidentify: false
     timing:
       operation: "MERGE"

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -337,7 +337,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             .where(
                 SETTING.IS_ACTIVE.isTrue,
                 SETTING.TYPE.eq(type)
-            )
+            ).orderBy(SETTING.SETTING_ID)
             .fetch()
             .into(Setting::class.java)
     }
@@ -351,7 +351,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                 SETTING.IS_ACTIVE.isTrue,
                 SETTING.TYPE.eq(type),
                 SETTING.ORGANIZATION_ID.eq(organizationId)
-            )
+            ).orderBy(SETTING.SETTING_ID)
             .fetch()
             .into(Setting::class.java)
     }


### PR DESCRIPTION
This PR adds a test .yml settings file containing an organization, one sender, three receivers, one fat hen, a couple of duck, three brown bears, four running hares, etc.

## Changes
- also tweaked the db query so they come out in the same order every time, so I can test with a simple 'diff'.

Here's the current manual test for settings:

$ ./prime multiple-settings set --input settings/SETTINGS-TEST-ORG.yml

Success. Setting SETTINGS-TEST-ORG at version 0
Success. Setting SETTINGS-TEST-ORG.SENDER at version 0
Success. Setting SETTINGS-TEST-ORG.RECEIVER1 at version 1
Success. Setting SETTINGS-TEST-ORG.RECEIVER2 at version 1
Success. Setting SETTINGS-TEST-ORG.RECEIVER3 at version 1

$ ./prime multiple-settings get --output actual.yml --filter SETTINGS-TEST-ORG
$ diff settings/SETTINGS-TEST-ORG.yml actual.yml 

If they files are identical, collect $200.

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [X] Added tests?
- [X ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
No issues known.

## Todo

- automate the above inside TestReportStream.
