### PR TITLE
api/report ingests no longer fail on downstream transform errors

### DIFF
--- a/prime-router/docs/schema_documentation/empty.md
+++ b/prime-router/docs/schema_documentation/empty.md
@@ -17,3 +17,33 @@
 unique id to track the usage of the message
 
 ---
+
+**Name**: Ordering_facility_county
+
+**Type**: TABLE
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: Ordering_facilty_state
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the facility which the test was ordered from
+
+---

--- a/prime-router/metadata/schemas/empty.schema
+++ b/prime-router/metadata/schemas/empty.schema
@@ -8,3 +8,11 @@ elements:
   - name: message_id
     cardinality: ONE
     csvFields: [{name: Message_ID}]
+
+  - name: ordering_facility_county
+    cardinality: ONE
+    csvFields: [{name: Ordering_facility_county}]
+
+  - name: ordering_facility_state
+    cardinality: ONE
+    csvFields: [{name: Ordering_facilty_state}]

--- a/prime-router/settings/prod/0001-ca-scc-phd.yml
+++ b/prime-router/settings/prod/0001-ca-scc-phd.yml
@@ -12,10 +12,10 @@
         deidentify: false
         translation:
           type: CUSTOM
-          schemaName: primedatainput/pdi-covid-19
+          schemaName: ca/ca-scc-covid-19
           format: CSV
         timing:
           operation: MERGE
           numberPerDay: 1 # daily
-          initialTime: 09:15 # A little after the 12am EASTERN reports from simple report
+          initialTime: 09:15 # A little after the 9am EASTERN reports from simple report
           timeZone: EASTERN

--- a/prime-router/src/main/kotlin/ResultDetail.kt
+++ b/prime-router/src/main/kotlin/ResultDetail.kt
@@ -10,7 +10,7 @@ data class ResultDetail(val scope: DetailScope, val id: String, val details: Str
      * @property REPORT scope for the detail
      * @property ITEM scope for the detail
      */
-    enum class DetailScope { PARAMETER, REPORT, ITEM }
+    enum class DetailScope { PARAMETER, REPORT, ITEM, TRANSLATION }
 
     override fun toString(): String {
         return "${scope.toString().toLowerCase()}${if (id.isBlank()) "" else " $id"}: $details"
@@ -27,6 +27,10 @@ data class ResultDetail(val scope: DetailScope, val id: String, val details: Str
 
         fun param(id: String, message: String): ResultDetail {
             return ResultDetail(DetailScope.PARAMETER, id, message)
+        }
+
+        fun translation(id: String, message: String): ResultDetail {
+            return ResultDetail(DetailScope.TRANSLATION, id, message)
         }
     }
 }

--- a/prime-router/src/main/kotlin/azure/HttpUtilities.kt
+++ b/prime-router/src/main/kotlin/azure/HttpUtilities.kt
@@ -14,7 +14,8 @@ import java.time.OffsetDateTime
 enum class ReportStreamEnv(val endPoint: String) {
     TEST("https://pdhtest-functionapp.azurewebsites.net/api/reports"),
     LOCAL("http://localhost:7071/api/reports"),
-    STAGING("https://pdhstaging-functionapp.azurewebsites.net/api/reports"),
+    STAGING("https://staging.prime.cdc.gov/api/reports"),
+//    STAGING("https://pdhstaging-functionapp.azurewebsites.net/api/reports"),
     PROD("not implemented"),
 }
 

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -44,8 +44,8 @@ class ReportFunction {
 
     data class ValidatedRequest(
         val httpStatus: HttpStatus,
-        val errors: List<ResultDetail> = emptyList(),
-        val warnings: List<ResultDetail> = emptyList(),
+        val errors: MutableList<ResultDetail> = mutableListOf<ResultDetail>(),
+        val warnings: MutableList<ResultDetail> = mutableListOf<ResultDetail>(),
         val options: Options = Options.None,
         val defaults: Map<String, String> = emptyMap(),
         val routeTo: List<String> = emptyList(),
@@ -245,7 +245,8 @@ class ReportFunction {
                 .filterAndTranslateByReceiver(
                     validatedRequest.report!!,
                     validatedRequest.defaults,
-                    validatedRequest.routeTo
+                    validatedRequest.routeTo,
+                    validatedRequest.warnings,
                 )
                 .forEach { (report, receiver) ->
                     sendToDestination(

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -36,6 +36,13 @@ import java.nio.file.Paths
 import java.time.OffsetDateTime
 import kotlin.system.exitProcess
 
+enum class TestStatus(val description: String) {
+    DRAFT("Experimental"), // Tests that are experimental
+    FAILS("Always fails"), // For tests that just always fail, and we haven't fixed the issue yet.
+    SLOW("Good test, but slow"), // For tests that are crazy slow
+    GOODSTUFF("Part of Smoke test"), // Only Smoke the Good Stuff.
+}
+
 class TestReportStream : CliktCommand(
     name = "test",
     help = """Run tests of the Router functions
@@ -60,36 +67,8 @@ Examples:
 
 """,
 ) {
-    lateinit var db: DatabaseAccess
 
-    enum class TestStatus(val description: String) {
-        DRAFT("Experimental"), // Tests that are experimental
-        FAILS("Always fails"), // For tests that just always fail, and we haven't fixed the issue yet.
-        SLOW("Good test, but slow"), // For tests that are crazy slow
-        GOODSTUFF("Part of Smoke test"), // Only Smoke the Good Stuff.
-    }
-
-    enum class AwesomeTest(
-        val description: String,
-        val status: TestStatus,
-    ) {
-        ping("CheckConnections: Is the reports endpoint alive and listening?", TestStatus.GOODSTUFF),
-        end2end("Create Fake data, submit, wait, confirm sent via database lineage data", TestStatus.GOODSTUFF),
-        merge("Submit multiple files, wait, confirm via db that merge occurred", TestStatus.GOODSTUFF),
-        hl7null("The NULL transport does db work, but no transport.  Uses HL7 format", TestStatus.GOODSTUFF),
-        toomanycols(
-            "Submit a file with more than $REPORT_MAX_ITEM_COLUMNS columns, which should error",
-            TestStatus.GOODSTUFF
-        ),
-        badcsv("Submit badly formatted csv files - should get errors", TestStatus.GOODSTUFF),
-        stracbasic("Basic strac test to REDOX only.", TestStatus.DRAFT),
-        strac("Submit data in strac schema, send to all formats and variety of schemas", TestStatus.GOODSTUFF),
-        garbage("Garbage in - Nice error message out", TestStatus.GOODSTUFF),
-        huge("Submit $REPORT_MAX_ITEMS line csv file, wait, confirm via db.  Slow.", TestStatus.SLOW),
-        toobig("Submit ${REPORT_MAX_ITEMS + 1} lines, which should be an error.  Slower ;)", TestStatus.SLOW),
-        dbconnections("Test weird issue wherein many 'sends' cause db connection failures", TestStatus.FAILS),
-        badsftp("Test ReportStream's response to sftp connection failures. Tests RETRY too!", TestStatus.DRAFT),
-    }
+    val defaultWorkingDir = "./target/csv_test_files"
 
     private val list by option(
         "--list",
@@ -100,7 +79,7 @@ Examples:
         "--run",
         metavar = "test1,test2",
         help = """Specify set of tests to run.   Default is to run all if not specified.
-            Allowed tests are: ${AwesomeTest.values().joinToString(",")}
+            Allowed tests are: ${coolTestList.joinToString(",")}
        """
     )
 
@@ -146,504 +125,87 @@ Examples:
     }
 
     override fun run() {
+        DatabaseAccess.isFlywayMigrationOK = false
+
         // Create directory if it does not exist
         val dirPath = Paths.get(dir)
         if (Files.notExists(dirPath)) Files.createDirectory(dirPath)
 
-        DatabaseAccess.isFlywayMigrationOK = false
         if (list) {
             echo("Available options to --run <test1,test2> are:")
-            doList(AwesomeTest.values().toList())
+            printTestList(coolTestList)
             exitProcess(0)
         }
         val environment = ReportStreamEnv.valueOf(env.toUpperCase())
+
         val tests = if (run != null) {
-            run.toString().split(",").mapNotNull {
-                try {
-                    AwesomeTest.valueOf(it)
-                } catch (e: IllegalArgumentException) {
-                    bad("Skipping unknown test: $it")
-                    null
-                }
+            run.toString().split(",").mapNotNull { test ->
+                coolTestList.find { it.name.equals(test, ignoreCase = true) }
             }
         } else {
             // No --run arg:  run the smoke tests.
-            AwesomeTest.values().filter { it.status == TestStatus.GOODSTUFF }.toList()
+            coolTestList.filter { it.status == TestStatus.GOODSTUFF }
         }
-        ugly("Running the following tests, POSTing to ${environment.endPoint}:")
-        doList(tests)
-        doTests(tests, environment)
+
+        CoolTest.ugly("Running the following tests, POSTing to ${environment.endPoint}:")
+        printTestList(tests)
+        runTests(tests, environment)
     }
 
-    private fun doList(tests: List<AwesomeTest>) {
+    private fun printTestList(tests: List<CoolTest>) {
         val formatTemplate = "%-20s%-20s\t%s"
         tests.forEach {
             echo(formatTemplate.format(it.name, it.status.description, it.description))
         }
     }
 
-    private fun doTests(tests: List<AwesomeTest>, environment: ReportStreamEnv) {
+    private fun runTests(tests: List<CoolTest>, environment: ReportStreamEnv) {
+        val failures = mutableListOf<CoolTest>()
         tests.forEach { test ->
-            when (test) {
-                AwesomeTest.ping -> doPingTest(environment)
-                AwesomeTest.end2end -> doEnd2EndTest(environment)
-                AwesomeTest.merge -> doMergeTest(environment)
-                AwesomeTest.hl7null -> doHL7NullTest(environment)
-                AwesomeTest.toomanycols -> doTooManyColsTest(environment)
-                AwesomeTest.badcsv -> doBadCsvTest(environment)
-                AwesomeTest.stracbasic -> doStracBasicTest(environment)
-                AwesomeTest.strac -> doStracTest(environment)
-                AwesomeTest.garbage -> doGarbageTest(environment)
-                AwesomeTest.huge -> doHugeTest(environment)
-                AwesomeTest.toobig -> doTooBigTest(environment)
-                AwesomeTest.dbconnections -> doDbConnectionsTest(environment)
-                AwesomeTest.badsftp -> doBadSftpTest(environment)
-                else -> bad("Test $test not implemented")
-            }
+            if (!test.run(environment, key, dir))
+                failures.add(test)
+        }
+        if (failures.isNotEmpty()) {
+            CoolTest.bad("*** Tests FAILED:  ${failures.map { it.name }.joinToString(",")} ***")
+        } else {
+            CoolTest.good("All tests passed")
         }
     }
 
-    // ping
-    private fun doPingTest(
-        environment: ReportStreamEnv
-    ) {
-        ugly("Starting ping Test: run CheckConnections of ${environment.endPoint}")
-        val (responseCode, json) = HttpUtilities.postReportBytes(
-            environment,
-            "x".toByteArray(),
-            orgName,
-            simpleReportSenderName,
-            key,
-            ReportFunction.Options.CheckConnections
+    companion object {
+        val coolTestList = listOf<CoolTest>(
+            Ping(),
+            End2End(),
+            Merge(),
+            Hl7Null(),
+            TooManyCols(),
+            BadCsv(),
+            StracBasic(),
+            Strac(),
+            Garbage(),
+            Huge(),
+            TooBig(),
+            DbConnections(),
+            BadSftp(),
         )
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_OK) {
-            echo("Ping/CheckConnections Test FAILED:  response code $responseCode")
-            exitProcess(-1) // other tests won't work.
-        }
-        try {
-            val tree = jacksonObjectMapper().readTree(json)
-            if (tree["errorCount"].intValue() != 0 || tree["warningCount"].intValue() != 0) {
-                bad("***Ping/CheckConnections Test FAILED***")
-            } else {
-                good("Test passed: Ping/CheckConnections")
-            }
-        } catch (e: NullPointerException) {
-            bad("***Ping/CheckConnections FAILED***: Unable to properly parse response json")
-        }
     }
+}
 
-    // end2end
-    private fun doGarbageTest(
-        environment: ReportStreamEnv
-    ) {
-        ugly("Starting ${AwesomeTest.garbage} Test: send ${emptySender.fullName} data to $allGoodCounties")
-        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            emptySender,
-            fakeItemCount,
-            receivingStates,
-            allGoodCounties,
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, emptySender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        try {
-            db = WorkflowEngine().db
-            db.transact { txn ->
-                // Hack:  this gets most recent stored action.  Might be wrong action, if system is very active
-                val action = actionQuery(txn) ?: error("***garbage test failed: No related db action found in db")
-                echo("garbage: ReportStream stored Action History = ${action.actionResult}")
-                if (action.actionResult.contains("Exception")) {
-                    good("garbage: Test passed.")
-                } else {
-                    bad("***garbage Test FAILED***: No Exception recorded in Action History")
-                }
-            }
-        } catch (t: Throwable) {
-            bad("***garbage Test FAILED***: Exception: $t")
-        }
-    }
+abstract class CoolTest {
+    abstract val name: String
+    abstract val description: String
+    abstract val status: TestStatus
 
-    // end2end
-    private fun doEnd2EndTest(
-        environment: ReportStreamEnv
-    ) {
-        ugly("Starting ${AwesomeTest.end2end} Test: send ${simpleRepSender.fullName} data to $allGoodCounties")
-        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            allGoodCounties,
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            bad("***end2end Test FAILED***:  response code $responseCode")
-            return
-        }
-        try {
-            val tree = jacksonObjectMapper().readTree(json)
-            val reportId = ReportId.fromString(tree["id"].textValue())
-            echo("Id of submitted report: $reportId")
-            waitABit(25, environment)
-            examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
-        } catch (e: NullPointerException) {
-            bad("***end2end Test FAILED***: Unable to properly parse response json")
-        }
-    }
+    abstract fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean
 
-    private fun doMergeTest(environment: ReportStreamEnv) {
-        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
-        val numResends = 5
-        ugly("Starting merge test:  Merge $numResends reports, each of which sends to $allGoodCounties")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            allGoodCounties,
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub over and over
-        val reportIds = (1..numResends).map {
-            val (responseCode, json) =
-                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-            echo("Response to POST: $responseCode")
-            if (responseCode != HttpURLConnection.HTTP_CREATED) {
-                bad("***Merge Test FAILED***:  response code $responseCode")
-                return
-            }
-            val tree = jacksonObjectMapper().readTree(json)
-            val reportId = ReportId.fromString(tree["id"].textValue())
-            echo("Id of submitted report: $reportId")
-            reportId
-        }
-        waitABit(40, environment)
-        examineMergeResults(reportIds[0], allGoodReceivers, fakeItemCount, numResends)
-    }
-
-    /**
-     * Test weirdness in Staging wherein we have strange HL7 'send' numbers
-     *
-     * This test, when it fails, exposes a database connection exception in Staging.
-     *
-     */
-    private fun doDbConnectionsTest(environment: ReportStreamEnv) {
-        val fakeItemCount = 40
-        ugly("Starting dbconnections Test: test of many threads attempting to sftp $fakeItemCount HL7s.")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            "HL7",
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.   Make numResends > 1 to create merges.
-        val numResends = 1
-        val reportIds = (1..numResends).map {
-            val (responseCode, json) =
-                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-            echo("Response to POST: $responseCode")
-            echo(json)
-            if (responseCode != HttpURLConnection.HTTP_CREATED) {
-                bad("***dbconnections Test FAILED***:  response code $responseCode")
-                return
-            }
-            val tree = jacksonObjectMapper().readTree(json)
-            val reportId = ReportId.fromString(tree["id"].textValue())
-            echo("Id of submitted report: $reportId")
-            reportId
-        }
-        waitABit(30, environment)
-        examineMergeResults(reportIds[0], listOf(hl7Receiver), fakeItemCount, numResends)
-    }
-
-    /**
-     * Test using the NULL transport.
-     */
-    private fun doHL7NullTest(environment: ReportStreamEnv) {
-        val fakeItemCount = 40
-        ugly("Starting hl7null Test: test of many threads all doing database interactions, but no sends. ")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            "HL7_NULL",
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.   Make numResends > 1 to create merges.
-        val numResends = 1
-        val reportIds = (1..numResends).map {
-            val (responseCode, json) =
-                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-            echo("Response to POST: $responseCode")
-            echo(json)
-            if (responseCode != HttpURLConnection.HTTP_CREATED) {
-                bad("***hl7null Test FAILED***:  response code $responseCode")
-                return
-            }
-            val tree = jacksonObjectMapper().readTree(json)
-            val reportId = ReportId.fromString(tree["id"].textValue())
-            echo("Id of submitted report: $reportId")
-            reportId
-        }
-        waitABit(30, environment)
-        examineMergeResults(reportIds[0], listOf(hl7NullReceiver), fakeItemCount, numResends)
-    }
-
-    /**
-     * Test using the a receiver with a broken sftp site.  Note:  there are two failure modes here:
-     * - if the sftp auth stuff is set up, then RS get repeated IOException, and multiple retries.
-     * - if its NOT set up, then RS fails without retries.
-     *
-     * Either way, the lineage results for the 'send' step should be zero.
-     */
-    private fun doBadSftpTest(environment: ReportStreamEnv) {
-        val fakeItemCount = 40
-        ugly("Starting badsftp Test: test that our code handles sftp connectivity problems")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            sftpFailReceiver.name,
-            dir,
-        )
-        echo("Created datafile $file")
-        val (responseCode, json) =
-            HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            bad("***badsftp Test FAILED***:  response code $responseCode")
-            return
-        }
-        val tree = jacksonObjectMapper().readTree(json)
-        val reportId = ReportId.fromString(tree["id"].textValue())
-        echo("Id of submitted report: $reportId")
-        waitABit(30, environment)
-        echo("For this test, failure during send, is a 'pass'.   Need to fix this.")
-        examineLineageResults(reportId, listOf(sftpFailReceiver), fakeItemCount)
-    }
-
-    private fun doHugeTest(environment: ReportStreamEnv) {
-        val fakeItemCount = 10000
-        ugly("Starting huge Test: Attempting to send a report with $fakeItemCount items. This is terrapin slow.")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            csvReceiver.name,
-            dir,
-            Report.Format.CSV
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            bad("***Huge Test FAILED***:  response code $responseCode")
-            return
-        }
-        val tree = jacksonObjectMapper().readTree(json)
-        val reportId = ReportId.fromString(tree["id"].textValue())
-        echo("Id of submitted report: $reportId")
-        waitABit(30, environment)
-        examineLineageResults(reportId, listOf(csvReceiver), fakeItemCount)
-    }
-
-    private fun doTooBigTest(environment: ReportStreamEnv) {
-        val fakeItemCount = REPORT_MAX_ITEMS + 1
-        ugly("Starting toobig test: Attempting to send a report with $fakeItemCount items. This is slllooooowww.")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            simpleRepSender,
-            fakeItemCount,
-            receivingStates,
-            csvReceiver.name,
-            dir,
-            Report.Format.CSV
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        try {
-            val tree = jacksonObjectMapper().readTree(json)
-            val firstError = ((tree["errors"] as ArrayNode)[0]) as ObjectNode
-            if (firstError["details"].textValue().contains("rows")) {
-                good("toobig Test passed.")
-            } else {
-                bad("***toobig Test Test FAILED***: Did not find the error")
-            }
-        } catch (e: Exception) {
-            bad("***toobig Test FAILED***: Unable to parse json response")
-        }
-    }
-
-    private fun doTooManyColsTest(
-        environment: ReportStreamEnv
-    ) {
-        ugly("Starting toomanycols Test: submitting a file with too many columns.")
-        val file = File("./src/test/csv_test_files/input/too-many-columns.csv")
-        if (!file.exists()) {
-            error("Unable to find file ${file.absolutePath} to do toomanycols test")
-        }
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        try {
-            val tree = jacksonObjectMapper().readTree(json)
-            val firstError = ((tree["errors"] as ArrayNode)[0]) as ObjectNode
-            if (firstError["details"].textValue().contains("columns")) {
-                good("toomanycols Test passed.")
-            } else {
-                bad("***toomanycols Test FAILED***:  did not find the error.")
-            }
-        } catch (e: Exception) {
-            bad("***toomanycols Test FAILED***: Unable to parse json response")
-        }
-    }
-
-    private fun doBadCsvTest(environment: ReportStreamEnv) {
-        val filenames = listOf("not-a-csv-file.csv", /* "column-headers-only.csv", */ "completely-empty-file.csv")
-        filenames.forEachIndexed { i, filename ->
-            ugly("Starting badcsv file Test $i: submitting $filename")
-            val file = File("./src/test/csv_test_files/input/$filename")
-            if (!file.exists()) {
-                error("Unable to find file ${file.absolutePath} to do badcsv test")
-            }
-            val (responseCode, json) = HttpUtilities.postReportFile(
-                environment,
-                file,
-                org.name,
-                simpleRepSender.name,
-                key
-            )
-            echo("Response to POST: $responseCode")
-            echo(json)
-            if (responseCode >= 400) {
-                good("badcsv Test $i of $filename passed: Failure HttpStatus code was returned.")
-            } else {
-                bad("***badcsv Test $i of $filename FAILED: Expecting a failure HttpStatus. ***")
-            }
-            try {
-                val tree = jacksonObjectMapper().readTree(json)
-                if (tree["id"] == null || tree["id"].isNull) {
-                    good("badcsv Test $i of $filename passed: No UUID was returned.")
-                } else {
-                    bad("***badcsv Test $i of $filename FAILED: RS returned a valid UUID for a bad CSV. ***")
-                }
-                if (tree["errorCount"].intValue() > 0) {
-                    good("badcsv Test $i of $filename passed: At least one error was returned.")
-                } else {
-                    bad("***badcsv Test $i of $filename FAILED: No error***")
-                }
-            } catch (e: Exception) {
-                bad("***badcsv Test $i of $filename FAILED***: Unexpected json returned")
-            }
-        }
-    }
-
-    // Strac format (only) to Redox format (only)
-    private fun doStracBasicTest(
-        environment: ReportStreamEnv
-    ) {
-        val fakeItemCount = 100
-        ugly("Starting stracbasic Test: sending Strac data to the ${redoxReceiver.name} receiver only.")
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            stracSender,
-            fakeItemCount,
-            receivingStates,
-            redoxReceiver.name,
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, stracSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            bad("***StracBasic Test FAILED***:  response code $responseCode")
-            return
-        }
-        val tree = jacksonObjectMapper().readTree(json)
-        val reportId = ReportId.fromString(tree["id"].textValue())
-        echo("Id of submitted report: $reportId")
-        waitABit(25, environment)
-        examineLineageResults(reportId, listOf(redoxReceiver), fakeItemCount)
-    }
-
-    // strac format to all output formats
-    private fun doStracTest(
-        environment: ReportStreamEnv
-    ) {
-        ugly("Starting bigly strac Test: sending Strac data to all of these receivers: $allGoodCounties!")
-        val itemsPerReceiver = 5
-        val fakeItemCount = allGoodReceivers.size * itemsPerReceiver
-        val file = FileUtilities.createFakeFile(
-            metadata,
-            stracSender,
-            fakeItemCount,
-            receivingStates,
-            allGoodCounties,
-            dir,
-        )
-        echo("Created datafile $file")
-        // Now send it to the Hub.
-        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, stracSender.name, key)
-        echo("Response to POST: $responseCode")
-        echo(json)
-        if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            bad("**Strac Test FAILED***:  response code $responseCode")
-            return
-        }
-        try {
-            val tree = jacksonObjectMapper().readTree(json)
-            val reportId = ReportId.fromString(tree["id"].textValue())
-            echo("Id of submitted report: $reportId")
-            val warningCount = tree["warningCount"].intValue()
-            if (warningCount == allGoodReceivers.size - 1) {
-                good("First part of strac Test passed: $warningCount warnings were returned.")
-            } else {
-                // Current expectation is that all non-REDOX counties fail.   If those issues get fixed,
-                // then we'll need to fix this test as well.
-                bad("***strac Test FAILED: Expecting ${allGoodReceivers.size - 1} warnings but got $warningCount***")
-            }
-            // OK, fine, the others failed.   All our hope now rests on you, REDOX - don't let us down!
-            waitABit(25, environment)
-            examineLineageResults(reportId, listOf(redoxReceiver), itemsPerReceiver)
-        } catch (e: Exception) {
-            bad("***strac Test FAILED***: Unexpected json returned")
-        }
-    }
+    lateinit var db: DatabaseAccess
 
     fun examineLineageResults(
         reportId: ReportId,
         receivers: List<Receiver>,
         totalRecords: Int,
-    ) {
+    ): Boolean {
+        var passed = true
         db = WorkflowEngine().db
         db.transact { txn ->
             val expected = totalRecords / receivers.size
@@ -656,6 +218,7 @@ Examples:
                             "*** TEST FAILED*** for ${receiver.fullName} action $action: " +
                                 " Expecting $expected item lineage records but got $count"
                         )
+                        passed = false
                     } else {
                         good(
                             "Test passed: for ${receiver.fullName} action $action: " +
@@ -665,14 +228,16 @@ Examples:
                 }
             }
         }
+        return passed
     }
 
-    private fun examineMergeResults(
+    fun examineMergeResults(
         reportId: ReportId,
         receivers: List<Receiver>,
         itemsPerReport: Int,
         reportCount: Int
-    ) {
+    ): Boolean {
+        var passed = true
         db = WorkflowEngine().db
         db.transact { txn ->
             val expected = (itemsPerReport * reportCount) / receivers.size
@@ -685,6 +250,7 @@ Examples:
                             "*** TEST FAILED*** for ${receiver.fullName} action $action: " +
                                 " Expecting sum(itemCount)=$expected but got $count"
                         )
+                        passed = false
                     } else {
                         good(
                             "Test passed: for ${receiver.fullName} action $action: " +
@@ -694,10 +260,10 @@ Examples:
                 }
             }
         }
+        return passed
     }
 
     companion object {
-        const val defaultWorkingDir = "./target/csv_test_files"
         val metadata = Metadata(Metadata.defaultMetadataDirectory)
         val settings = FileSettings(FileSettings.defaultSettingsDirectory)
 
@@ -738,11 +304,13 @@ Examples:
         const val ANSI_GREEN = "\u001B[32m"
         const val ANSI_BLUE = "\u001B[34m"
         const val ANSI_CYAN = "\u001B[36m"
-        fun good(msg: String) {
+        fun good(msg: String): Boolean {
             echo(ANSI_GREEN + msg + ANSI_RESET)
+            return true
         }
-        fun bad(msg: String) {
+        fun bad(msg: String): Boolean {
             echo(ANSI_RED + msg + ANSI_RESET)
+            return false
         }
         fun ugly(msg: String) {
             echo(ANSI_CYAN + msg + ANSI_RESET)
@@ -817,20 +385,507 @@ Examples:
     }
 }
 
+class Ping : CoolTest() {
+    override val name = "ping"
+    override val description = "CheckConnections: Is the reports endpoint alive and listening?"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        ugly("Starting ping Test: run CheckConnections of ${environment.endPoint}")
+        val (responseCode, json) = HttpUtilities.postReportBytes(
+            environment,
+            "x".toByteArray(),
+            orgName,
+            simpleReportSenderName,
+            key,
+            ReportFunction.Options.CheckConnections
+        )
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            bad("Ping/CheckConnections Test FAILED:  response code $responseCode")
+            exitProcess(-1) // other tests won't work.
+        }
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            if (tree["errorCount"].intValue() != 0 || tree["warningCount"].intValue() != 0) {
+                return bad("***Ping/CheckConnections Test FAILED***")
+            } else {
+                return good("Test passed: Ping/CheckConnections")
+            }
+        } catch (e: NullPointerException) {
+            return bad("***Ping/CheckConnections FAILED***: Unable to properly parse response json")
+        }
+    }
+}
+
+class End2End : CoolTest() {
+    override val name = "end2end"
+    override val description = "Create Fake data, submit, wait, confirm sent via database lineage data"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        ugly("Starting $name Test: send ${simpleRepSender.fullName} data to $allGoodCounties")
+        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            allGoodCounties,
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_CREATED) {
+            return bad("***end2end Test FAILED***:  response code $responseCode")
+        }
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            waitABit(25, environment)
+            return examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
+        } catch (e: NullPointerException) {
+            return bad("***end2end Test FAILED***: Unable to properly parse response json")
+        }
+    }
+}
+
+class Merge : CoolTest() {
+    override val name = "merge"
+    override val description = "Submit multiple files, wait, confirm via db that merge occurred"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
+        val numResends = 5
+        ugly("Starting merge test:  Merge $numResends reports, each of which sends to $allGoodCounties")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            allGoodCounties,
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub over and over
+        val reportIds = (1..numResends).map {
+            val (responseCode, json) =
+                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+            echo("Response to POST: $responseCode")
+            if (responseCode != HttpURLConnection.HTTP_CREATED) {
+                return bad("***Merge Test FAILED***:  response code $responseCode")
+            }
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            reportId
+        }
+        waitABit(40, environment)
+        return examineMergeResults(reportIds[0], allGoodReceivers, fakeItemCount, numResends)
+    }
+}
+
 /**
- * This was my last attempt to jooqify the above itemLineage query.
- *  Remaining issue is the call to (select from item_descendants(report_id) part.
- *  I'm sure there's a correct jooq way to call a stored fn that returns a set, but couldn't find it.
- *  Could also treat just that part as "plain SQL", but I didn't see the difference
- *  between doing that, and treating the entire thing as plain sql, as I did above.
-val nested = ctx.select().from(itemDescendants(reportId)).asTable("nested")
-val count = ctx.select(count())
- .from(ITEM_LINEAGE)
- .join(REPORT_FILE).on(REPORT_FILE.REPORT_ID.eq(ITEM_LINEAGE.CHILD_REPORT_ID))
- .join(ACTION).on(ACTION.ACTION_ID.eq(REPORT_FILE.ACTION_ID))
- .join(nested).on(ITEM_LINEAGE.ITEM_LINEAGE_ID.eq(nested))
- .where(REPORT_FILE.RECEIVING_ORG_SVC.eq(receivingOrgSvc)
- .and(ACTION.ACTION_NAME.eq(action)))
- .groupBy(REPORT_FILE.REPORT_ID, REPORT_FILE.RECEIVING_ORG,
- REPORT_FILE.RECEIVING_ORG_SVC, ACTION.ACTION_NAME).fetchOne().into(Int)
-*/
+ * Test using the NULL transport.
+ */
+class Hl7Null : CoolTest() {
+    override val name = "hl7null"
+    override val description = "The NULL transport does db work, but no transport.  Uses HL7 format"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = 40
+        ugly("Starting hl7null Test: test of many threads all doing database interactions, but no sends. ")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            "HL7_NULL",
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.   Make numResends > 1 to create merges.
+        val numResends = 1
+        val reportIds = (1..numResends).map {
+            val (responseCode, json) =
+                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+            echo("Response to POST: $responseCode")
+            echo(json)
+            if (responseCode != HttpURLConnection.HTTP_CREATED) {
+                return bad("***hl7null Test FAILED***:  response code $responseCode")
+            }
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            reportId
+        }
+        waitABit(30, environment)
+        return examineMergeResults(reportIds[0], listOf(hl7NullReceiver), fakeItemCount, numResends)
+    }
+}
+
+class TooManyCols : CoolTest() {
+    override val name = "toomanycols"
+    override val description = "Submit a file with more than $REPORT_MAX_ITEM_COLUMNS columns, which should error"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        ugly("Starting toomanycols Test: submitting a file with too many columns.")
+        val file = File("./src/test/csv_test_files/input/too-many-columns.csv")
+        if (!file.exists()) {
+            error("Unable to find file ${file.absolutePath} to do toomanycols test")
+        }
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            val firstError = ((tree["errors"] as ArrayNode)[0]) as ObjectNode
+            if (firstError["details"].textValue().contains("columns")) {
+                return good("toomanycols Test passed.")
+            } else {
+                return bad("***toomanycols Test FAILED***:  did not find the error.")
+            }
+        } catch (e: Exception) {
+            return bad("***toomanycols Test FAILED***: Unable to parse json response")
+        }
+    }
+}
+
+class BadCsv : CoolTest() {
+    override val name = "badcsv"
+    override val description = "Submit badly formatted csv files - should get errors"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val filenames = listOf("not-a-csv-file.csv", /* "column-headers-only.csv", */ "completely-empty-file.csv")
+        var passed = true
+        filenames.forEachIndexed { i, filename ->
+            ugly("Starting badcsv file Test $i: submitting $filename")
+            val file = File("./src/test/csv_test_files/input/$filename")
+            if (!file.exists()) {
+                error("Unable to find file ${file.absolutePath} to do badcsv test")
+            }
+            val (responseCode, json) = HttpUtilities.postReportFile(
+                environment,
+                file,
+                org.name,
+                simpleRepSender.name,
+                key
+            )
+            echo("Response to POST: $responseCode")
+            echo(json)
+            if (responseCode >= 400) {
+                good("badcsv Test $i of $filename passed: Failure HttpStatus code was returned.")
+            } else {
+                bad("***badcsv Test $i of $filename FAILED: Expecting a failure HttpStatus. ***")
+                passed = false
+            }
+            try {
+                val tree = jacksonObjectMapper().readTree(json)
+                if (tree["id"] == null || tree["id"].isNull) {
+                    good("badcsv Test $i of $filename passed: No UUID was returned.")
+                } else {
+                    bad("***badcsv Test $i of $filename FAILED: RS returned a valid UUID for a bad CSV. ***")
+                    passed = false
+                }
+                if (tree["errorCount"].intValue() > 0) {
+                    good("badcsv Test $i of $filename passed: At least one error was returned.")
+                } else {
+                    bad("***badcsv Test $i of $filename FAILED: No error***")
+                    passed = false
+                }
+            } catch (e: Exception) {
+                passed = bad("***badcsv Test $i of $filename FAILED***: Unexpected json returned")
+            }
+        }
+        return passed
+    }
+}
+
+class Strac : CoolTest() {
+    override val name = "strac"
+    override val description = "Submit data in strac schema, send to all formats and variety of schemas"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        ugly("Starting bigly strac Test: sending Strac data to all of these receivers: $allGoodCounties!")
+        var passed = true
+        val itemsPerReceiver = 5
+        val fakeItemCount = allGoodReceivers.size * itemsPerReceiver
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            stracSender,
+            fakeItemCount,
+            receivingStates,
+            allGoodCounties,
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, stracSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_CREATED) {
+            return bad("**Strac Test FAILED***:  response code $responseCode")
+        }
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            val warningCount = tree["warningCount"].intValue()
+            if (warningCount == allGoodReceivers.size - 1) {
+                good("First part of strac Test passed: $warningCount warnings were returned.")
+            } else {
+                // Current expectation is that all non-REDOX counties fail.   If those issues get fixed,
+                // then we'll need to fix this test as well.
+                bad("***strac Test FAILED: Expecting ${allGoodReceivers.size - 1} warnings but got $warningCount***")
+                passed = false
+            }
+            // OK, fine, the others failed.   All our hope now rests on you, REDOX - don't let us down!
+            waitABit(25, environment)
+            return passed && examineLineageResults(reportId, listOf(redoxReceiver), itemsPerReceiver)
+        } catch (e: Exception) {
+            return bad("***strac Test FAILED***: Unexpected json returned")
+        }
+    }
+}
+
+class StracBasic : CoolTest() {
+    override val name = "stracbasic"
+    override val description = "Submit data in strac schema, send to REDOX only"
+    override val status = TestStatus.DRAFT
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = 100
+        ugly("Starting stracbasic Test: sending Strac data to the ${redoxReceiver.name} receiver only.")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            stracSender,
+            fakeItemCount,
+            receivingStates,
+            redoxReceiver.name,
+            dir,
+        )
+        echo("Created datafile $file")
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, stracSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_CREATED) {
+            return bad("***StracBasic Test FAILED***:  response code $responseCode")
+        }
+        val tree = jacksonObjectMapper().readTree(json)
+        val reportId = ReportId.fromString(tree["id"].textValue())
+        echo("Id of submitted report: $reportId")
+        waitABit(25, environment)
+        return examineLineageResults(reportId, listOf(redoxReceiver), fakeItemCount)
+    }
+}
+
+class Garbage : CoolTest() {
+    override val name = "garbage"
+    override val description = "Garbage in - Nice error message out"
+    override val status = TestStatus.GOODSTUFF
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        ugly("Starting $name Test: send ${emptySender.fullName} data to $allGoodCounties")
+        var passed = true
+        val fakeItemCount = allGoodReceivers.size * 5 // 5 to each receiver
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            emptySender,
+            fakeItemCount,
+            receivingStates,
+            allGoodCounties,
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, emptySender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            val warningCount = tree["warningCount"].intValue()
+            if (warningCount == allGoodReceivers.size) {
+                good("garbage Test passed: $warningCount warnings were returned.")
+            } else {
+                passed =
+                    bad("***garbage Test FAILED: Expecting ${allGoodReceivers.size} warnings but got $warningCount***")
+            }
+            val destinationCount = tree["destinationCount"].intValue()
+            if (destinationCount == 0) {
+                good("garbage Test passed: Items went to $destinationCount destinations.")
+            } else {
+                passed = bad("***garbage Test FAILED: Expecting 0 destinationCount but got $destinationCount ***")
+            }
+        } catch (e: Exception) {
+            passed = bad("***garbage Test FAILED***: Unexpected json returned")
+        }
+        return passed
+    }
+}
+
+class Huge : CoolTest() {
+    override val name = "huge"
+    override val description = "Submit $REPORT_MAX_ITEMS line csv file, wait, confirm via db.  Slow."
+    override val status = TestStatus.SLOW
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = 10000
+        ugly("Starting huge Test: Attempting to send a report with $fakeItemCount items. This is terrapin slow.")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            csvReceiver.name,
+            dir,
+            Report.Format.CSV
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_CREATED) {
+            bad("***Huge Test FAILED***:  response code $responseCode")
+        }
+        val tree = jacksonObjectMapper().readTree(json)
+        val reportId = ReportId.fromString(tree["id"].textValue())
+        echo("Id of submitted report: $reportId")
+        waitABit(30, environment)
+        return examineLineageResults(reportId, listOf(csvReceiver), fakeItemCount)
+    }
+}
+
+// Bigger than Huge
+class TooBig : CoolTest() {
+    override val name = "toobig"
+    override val description = "Submit ${REPORT_MAX_ITEMS + 1} lines, which should be an error.  Slower ;)"
+    override val status = TestStatus.SLOW
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = REPORT_MAX_ITEMS + 1
+        ugly("Starting toobig test: Attempting to send a report with $fakeItemCount items. This is slllooooowww.")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            csvReceiver.name,
+            dir,
+            Report.Format.CSV
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.
+        val (responseCode, json) = HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        try {
+            val tree = jacksonObjectMapper().readTree(json)
+            val firstError = ((tree["errors"] as ArrayNode)[0]) as ObjectNode
+            if (firstError["details"].textValue().contains("rows")) {
+                return good("toobig Test passed.")
+            } else {
+                return bad("***toobig Test Test FAILED***: Did not find the error")
+            }
+        } catch (e: Exception) {
+            return bad("***toobig Test FAILED***: Unable to parse json response")
+        }
+    }
+}
+
+/**
+ * Test weirdness in Staging wherein we have strange HL7 'send' numbers
+ *
+ * This test, when it fails, exposes a database connection exception in Staging.
+ *
+ */
+class DbConnections : CoolTest() {
+    override val name = "dbconnections"
+    override val description = "Test weird issue wherein many 'sends' cause db connection failures"
+    override val status = TestStatus.FAILS
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = 40
+        ugly("Starting dbconnections Test: test of many threads attempting to sftp $fakeItemCount HL7s.")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            "HL7",
+            dir,
+        )
+        echo("Created datafile $file")
+        // Now send it to the Hub.   Make numResends > 1 to create merges.
+        val numResends = 1
+        val reportIds = (1..numResends).map {
+            val (responseCode, json) =
+                HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+            echo("Response to POST: $responseCode")
+            echo(json)
+            if (responseCode != HttpURLConnection.HTTP_CREATED) {
+                bad("***dbconnections Test FAILED***:  response code $responseCode")
+                return false
+            }
+            val tree = jacksonObjectMapper().readTree(json)
+            val reportId = ReportId.fromString(tree["id"].textValue())
+            echo("Id of submitted report: $reportId")
+            reportId
+        }
+        waitABit(30, environment)
+        return examineMergeResults(reportIds[0], listOf(hl7Receiver), fakeItemCount, numResends)
+    }
+}
+
+/**
+ * Test using the a receiver with a broken sftp site.  Note:  there are two failure modes here:
+ * - if the sftp auth stuff is set up, then RS get repeated IOException, and multiple retries.
+ * - if its NOT set up, then RS fails without retries.
+ *
+ * Either way, the lineage results for the 'send' step should be zero.
+ */
+class BadSftp : CoolTest() {
+    override val name = "badsftp"
+    override val description = "Test ReportStream's response to sftp connection failures. Tests RETRY too!"
+    override val status = TestStatus.DRAFT
+
+    override fun run(environment: ReportStreamEnv, key: String?, dir: String): Boolean {
+        val fakeItemCount = 40
+        ugly("Starting badsftp Test: test that our code handles sftp connectivity problems")
+        val file = FileUtilities.createFakeFile(
+            metadata,
+            simpleRepSender,
+            fakeItemCount,
+            receivingStates,
+            sftpFailReceiver.name,
+            dir,
+        )
+        echo("Created datafile $file")
+        val (responseCode, json) =
+            HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, key)
+        echo("Response to POST: $responseCode")
+        echo(json)
+        if (responseCode != HttpURLConnection.HTTP_CREATED) {
+            bad("***badsftp Test FAILED***:  response code $responseCode")
+            return false
+        }
+        val tree = jacksonObjectMapper().readTree(json)
+        val reportId = ReportId.fromString(tree["id"].textValue())
+        echo("Id of submitted report: $reportId")
+        waitABit(30, environment)
+        echo("For this test, failure during send, is a 'pass'.   Need to fix this.")
+        return examineLineageResults(reportId, listOf(sftpFailReceiver), fakeItemCount)
+    }
+}

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -22,6 +22,7 @@ import gov.cdc.prime.router.FileSource
 import gov.cdc.prime.router.Hl7Configuration
 import gov.cdc.prime.router.Metadata
 import gov.cdc.prime.router.Report
+import gov.cdc.prime.router.ResultDetail
 import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.SettingsProvider
 import gov.cdc.prime.router.Translator
@@ -372,10 +373,11 @@ class ProcessData : CliktCommand(
 
         // Transform reports
         val translator = Translator(metadata, fileSettings)
+        val warnings = mutableListOf<ResultDetail>()
         val outputReports: List<Pair<Report, Report.Format>> = when {
             route ->
                 translator
-                    .filterAndTranslateByReceiver(inputReport, getDefaultValues())
+                    .filterAndTranslateByReceiver(inputReport, getDefaultValues(), emptyList(), warnings)
                     .map { it.first to getOutputFormat(it.second.format) }
             routeTo != null -> {
                 val pair = translator.translate(
@@ -405,6 +407,14 @@ class ProcessData : CliktCommand(
                 listOf(Pair(toReport, getOutputFormat(Report.Format.CSV)))
             }
             else -> listOf(Pair(inputReport, getOutputFormat(Report.Format.CSV)))
+        }
+
+        if (warnings.size > 0) {
+            echo("Problems occurred during translation to output schema:")
+            warnings.forEach {
+                echo("${it.scope} ${it.id}: ${it.details}")
+            }
+            echo()
         }
 
         // Output reports

--- a/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
+++ b/prime-router/src/main/kotlin/secrets/AzureSecretService.kt
@@ -25,7 +25,7 @@ internal object AzureSecretService : SecretService() {
 
     override fun fetchSecretFromStore(secretName: String): String? {
         val azureSafeSecretName = secretName.toLowerCase().replace("_", "-")
-        return secretClient.getSecret("functionapp-${azureSafeSecretName}")?.let {
+        return secretClient.getSecret("functionapp-$azureSafeSecretName")?.let {
             return it.value
         }
     }

--- a/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
+++ b/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
@@ -87,14 +87,17 @@ class JurisdictionalFilterTests {
     }
 
     @Test
-    fun `test filterByCountyFails`() {
+    fun `test filterByCountyWithMissingColumns`() {
         val filter = FilterByCounty()
         val table = Table.create(
-            StringColumn.create("BOGUS"),
+            StringColumn.create("BOGUS", listOf("a", "b", "c", "d")),
+            StringColumn.create("BOGUS2", listOf("a", "b", "c", "d")),
         )
 
-        val args1 = listOf("a", "b") // correct # args.
-        assertFails { filter.getSelection(args1, table) } // However, table doesn't have the expected columns
+        val args1 = listOf("a", "a") // correct # args.
+        val selection = filter.getSelection(args1, table)
+        val filteredTable = table.where(selection)
+        assertEquals(0, filteredTable.rowCount())
     }
 
     @Test

--- a/prime-router/src/test/kotlin/SimpleReportTests.kt
+++ b/prime-router/src/test/kotlin/SimpleReportTests.kt
@@ -52,7 +52,10 @@ class SimpleReportTests {
         //        assertTrue(readResult.warnings.isEmpty())
         val inputReport = readResult.report ?: fail()
         // 2) Create transformed objects, according to the receiver table rules
-        val outputReports = Translator(metadata, settings).filterAndTranslateByReceiver(inputReport)
+        val outputReports = Translator(metadata, settings).filterAndTranslateByReceiver(
+            inputReport,
+            warnings = mutableListOf<ResultDetail>()
+        )
 
         // 3) Write transformed objs to files
         val outputFiles = mutableListOf<Pair<File, Receiver>>()

--- a/prime-router/src/test/kotlin/TranslatorTests.kt
+++ b/prime-router/src/test/kotlin/TranslatorTests.kt
@@ -85,7 +85,7 @@ class TranslatorTests {
         val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
         val table1 = Report(one, listOf(listOf("1", "2"), listOf("3", "4")), TestSource)
 
-        val result = translator.filterAndTranslateByReceiver(table1)
+        val result = translator.filterAndTranslateByReceiver(table1, warnings = mutableListOf<ResultDetail>())
 
         assertEquals(1, result.size)
         val (mappedTable, forReceiver) = result[0]


### PR DESCRIPTION
This PR enables us to expand to all 50 states.

Our current model is that, by default, any submitted data can go to any receiver anywhere, based on filters set by that receiver, not based on the sender's preferences.   However, there's no guarantee that the translation to a downstream receiver's desired format will actually work, and right now if it fails, the Sender's entire original submission fails with a 500 error.  This is not acceptable.   An example:   Right now, if someone whose home address is in Montana happens to get tested in PA using Strac, the entire Strac submission that includes that data will fail.

This PR fixes that problem, by turning the failure into a Warning.   For the above example, the Montana translation will fail, but the rest of the submission will succeed, with a Warning returned, which appears in the json returned to the Sender.   An example:

```
  "warnings" : [ {
    "scope" : "TRANSLATION",
    "id" : "TO:ignore.CSV:fl/fl-covid-19",
    "details" : "Error: To translate to ignore.CSV, fl/fl-covid-19, these elements are missing: ordering_facility_phone_number, message_id, testing_lab_clia"
  } ]
```

I chose to make it a Warning instead of an Error, because its really a ReportStream problem, not the fault of the Sender - there's no way they can fix it.   But making it visible this way means that we can at least notice and deal with it.

You could argue that we should make it an Exception, so that we get notified, but I did not do that at this time, as its not really an operational failure.

Note that if the problem is fixed, the data could be resent using the `routeTo=receiverFullName` parameter.

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [X] Added tests?
- [X] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- none known.

## Fixes

- This fix hides but does not fix the strac error noted in #632 .  Its still important to fix that error, so that we can send Strac data to patients in other states.

## To Be Done
- Strac issue in #632
(Strac to Any State except PA fails: can't send Strac data to Florida: Returns a 500, with this exception: java.lang.IllegalStateException: Error: To translate to fl/fl-covid-19, these elements are missing: ordering_facility_phone_number, message_id, testing_lab_clia)

