### PR TITLE
Static Storage Account

### DIFF
--- a/.github/vpn/dev.ovpn
+++ b/.github/vpn/dev.ovpn
@@ -1,6 +1,6 @@
 client
-remote azuregateway-7d480077-2d7e-4cd4-9e7d-ec4689efeaae-b98ea967a325.vpn.azure.com 443
-verify-x509-name '7d480077-2d7e-4cd4-9e7d-ec4689efeaae.vpn.azure.com' name
+remote azuregateway-baa20077-683b-4e57-bc65-6d65264ded69-f09662ccc71f.vpn.azure.com 443
+verify-x509-name 'baa20077-683b-4e57-bc65-6d65264ded69.vpn.azure.com' name
 remote-cert-tls server
 
 dev tun

--- a/.github/vpn/staging.ovpn
+++ b/.github/vpn/staging.ovpn
@@ -20,6 +20,7 @@ key-direction 1
 dhcp-option DNS 10.0.2.5
 dhcp-option DOMAIN azure.net
 dhcp-option DOMAIN azurewebsites.net
+dhcp-option DOMAIN windows.net
 
 verb 3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           path: prime-router/target
           retention-days: 7
 
-  build_frontend:
+  build_frontend_release:
     name: Build Frontend
     runs-on: ubuntu-latest
     defaults:
@@ -74,7 +74,7 @@ jobs:
 
   deploy_release_dev:
     name: "Deploy Release: DEV"
-    needs: [ build_release, build_frontend ]
+    needs: [ build_release, build_frontend_release ]
     if: github.ref == 'refs/heads/ronheft/static-storageaccount'
     environment: staging
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
 
   deploy_release_staging:
     name: "Deploy Release: STAGING"
-    needs: [build_release, build_frontend]
+    needs: [build_release, build_frontend_release]
     if: github.ref == 'refs/heads/master'
     environment: staging
     runs-on: ubuntu-latest
@@ -205,7 +205,7 @@ jobs:
 
   deploy_release_prod:
     name: "Deploy Release: PROD"
-    needs: [build_release, build_frontend]
+    needs: [build_release, build_frontend_release]
     if: github.ref == 'refs/heads/production'
     environment: prod
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Artifact
+      - name: Download Router Artifact
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/target
 
-      - name: Download Artifact
+      - name: Download Frontend Artifact
         uses: actions/download-artifact@v2
         with:
           name: static_website-${{ github.run_id }}
@@ -150,13 +150,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Artifact
+      - name: Download Router Artifact
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/target
 
-      - name: Download Artifact
+      - name: Download Frontend Artifact
         uses: actions/download-artifact@v2
         with:
           name: static_website-${{ github.run_id }}
@@ -216,13 +216,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Artifact
+      - name: Download Router Artifact
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/target
 
-      - name: Download Artifact
+      - name: Download Frontend Artifact
         uses: actions/download-artifact@v2
         with:
           name: static_website-${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to Azure
 
 on:
   push:
-    branches: [ master, production ]
+    branches: [ master, production, ronheft/static-storageaccount ]
 
 defaults:
   run:
@@ -71,6 +71,71 @@ jobs:
 
       - name: Validate static website server
         run: bash ci_validate.bash
+
+  deploy_release_dev:
+    name: "Deploy Release: DEV"
+    needs: [ build_release, build_frontend ]
+    if: github.ref == 'refs/heads/ronheft/static-storageaccount'
+    environment: staging
+    runs-on: ubuntu-latest
+    env:
+      RESOURCE_GROUP: prime-dev-rheft
+      ACR_REPO: rheftcontainerregistry.azurecr.io
+      PREFIX: rheft
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: prime-router-build-${{ github.run_id }}
+          path: prime-router/target
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: static_website-${{ github.run_id }}
+          path: frontend/dist
+
+      - name: Build Docker Image
+        run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
+
+      - name: Install OpenVPN
+        run: |
+          sudo apt-get install openvpn
+          sudo apt install openvpn-systemd-resolved
+
+      - name: Connect VPN
+        uses: golfzaptw/action-connect-ovpn@master
+        id: connect_vpn
+        with:
+          PING_URL: '127.0.0.1'
+          FILE_OVPN: '.github/vpn/dev.ovpn'
+          TLS_KEY: ${{ secrets.TLS_KEY }}
+        env:
+          CA_CRT: ${{ secrets.CA_CRT}}
+          USER_CRT: ${{ secrets.USER_CRT }}
+          USER_KEY: ${{ secrets.USER_KEY }}
+
+      - name: Login to Azure CLI
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
+
+      - name: ACR Login
+        run: az acr login --name ${{ env.ACR_REPO }}
+
+      - name: Push Docker Image
+        run: docker push ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
+
+      - name: Restart Azure Functions App
+        run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.PREFIX }}-functionapp
+
+      - name: Upload Static Site
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .
 
   deploy_release_staging:
     name: "Deploy Release: STAGING"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to Azure
 
 on:
   push:
-    branches: [ master, production, ronheft/static-storageaccount ]
+    branches: [ master, production, dev-rheft ]
 
 defaults:
   run:
@@ -75,7 +75,7 @@ jobs:
   deploy_release_dev:
     name: "Deploy Release: DEV"
     needs: [ build_release, build_frontend_release ]
-    if: github.ref == 'refs/heads/ronheft/static-storageaccount'
+    if: github.ref == 'refs/heads/dev-rheft'
     environment: staging
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   build_release:
-    name: Build Release
+    name: Build Router
     runs-on: ubuntu-latest
     env:
       # These are for CI and not credentials of any system

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist
 
   deploy_release_staging:
     name: "Deploy Release: STAGING"
@@ -200,7 +200,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist
 
 
   deploy_release_prod:
@@ -266,4 +266,4 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,32 @@ jobs:
           path: prime-router/target
           retention-days: 7
 
+  build_frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Build Script
+        run: bash ci_build.bash
+
+      - name: Save Static Website
+        uses: actions/upload-artifact@v2
+        with:
+          name: static_website-${{ github.run_id }}
+          path: frontend/dist
+          retention-days: 7
+
+      - name: Validate static website server
+        run: bash ci_validate.bash
+
   deploy_release_staging:
     name: "Deploy Release: STAGING"
-    needs: build_release
+    needs: [build_release, build_frontend]
     if: github.ref == 'refs/heads/master'
     environment: staging
     runs-on: ubuntu-latest
@@ -67,6 +90,12 @@ jobs:
         with:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/target
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: static_website-${{ github.run_id }}
+          path: frontend/dist
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
@@ -102,10 +131,16 @@ jobs:
       - name: Restart Azure Functions App
         run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.PREFIX }}-functionapp
 
+      - name: Upload Static Site
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .
+
 
   deploy_release_prod:
     name: "Deploy Release: PROD"
-    needs: build_release
+    needs: [build_release, build_frontend]
     if: github.ref == 'refs/heads/production'
     environment: prod
     runs-on: ubuntu-latest
@@ -121,6 +156,12 @@ jobs:
         with:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/target
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: static_website-${{ github.run_id }}
+          path: frontend/dist
 
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
@@ -155,3 +196,9 @@ jobs:
 
       - name: Restart Azure Functions App
         run: az functionapp restart --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.PREFIX }}-functionapp
+
+      - name: Upload Static Site
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   build_release:
-    name: Build Router
+    name: "Release: Build Router"
     runs-on: ubuntu-latest
     env:
       # These are for CI and not credentials of any system
@@ -50,7 +50,7 @@ jobs:
           retention-days: 7
 
   build_frontend_release:
-    name: Build Frontend
+    name: "Release: Build Frontend"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -143,10 +143,51 @@ resource "azurerm_monitor_diagnostic_setting" "storageaccount_access_log" {
   }
 }
 
+
+// Static website
+
+resource "azurerm_storage_account" "storage_public" {
+  resource_group_name = var.resource_group
+  name = "${var.resource_prefix}public"
+  location = var.location
+  account_tier = "Standard"
+  account_kind = "StorageV2"
+  account_replication_type = "GRS"
+  min_tls_version = "TLS1_2"
+  allow_blob_public_access = false
+
+  static_website {
+    index_document = "index.html"
+    error_404_document = "404.html"
+  }
+
+  network_rules {
+    default_action = "Allow"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+
+
 output "storage_account_name" {
   value = azurerm_storage_account.storage_account.name
 }
 
 output "storage_account_key" {
   value = azurerm_storage_account.storage_account.primary_access_key
+}
+
+output "storage_account_public_id" {
+  value = azurerm_storage_account.storage_public.id
+}
+
+output "storage_web_endpoint" {
+  value = azurerm_storage_account.storage_public.primary_web_endpoint
 }


### PR DESCRIPTION
This PR add the necessary infrastructure changes to deploy out the static website (#512). An example of the deployment can be seen at:

https://rheftpublic.z13.web.core.windows.net/

The URL for staging server will be known after the first deployment.

## Changes
- Adds a storage account with public access designated for the website: ex. `rheftstatic`
  - Azure storage account must be named with lowercase characters only, no special characters
- Adds a static website deployment step to our release GitHub action
- Improves the GitHub action with a DEV deployment flow, to make testing GitHub actions easier

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- The storage account bucket is for public data only and will not be used to store any other type of data

## To Be Done
- Deploy Terraform state before merging or release pipeline will fail
- When the website is ready for production, changes will be needed for the Front Door (#763)