### PR TITLE
Add frontend endpoint for reportstream.cdc.gov

### DIFF
--- a/operations/app/src/environments/dev/main.tf
+++ b/operations/app/src/environments/dev/main.tf
@@ -20,5 +20,5 @@ module "prime_data_hub" {
   resource_group = "prime-dev-${var.dev_name}"
   resource_prefix = var.dev_name
   okta_redirect_url = "https://prime-data-hub-${var.dev_name}.azurefd.net/download"
-  https_cert_name = null
+  https_cert_names = []
 }

--- a/operations/app/src/environments/prod/main.tf
+++ b/operations/app/src/environments/prod/main.tf
@@ -30,5 +30,5 @@ module "prime_data_hub" {
   resource_group = "prime-data-hub-${local.target_env}"
   resource_prefix = "pdhprod"
   okta_redirect_url = "https://prime.cdc.gov/download"
-  https_cert_name = "prime-cdc-gov"
+  https_cert_names = ["prime-cdc-gov", "reportstream-cdc-gov"]
 }

--- a/operations/app/src/environments/staging/main.tf
+++ b/operations/app/src/environments/staging/main.tf
@@ -30,5 +30,5 @@ module "prime_data_hub" {
   resource_group = "prime-data-hub-${local.target_env}"
   resource_prefix = "pdhstaging"
   okta_redirect_url = "https://staging.prime.cdc.gov/download"
-  https_cert_name = "staging-prime-cdc-gov"
+  https_cert_names = ["staging-prime-cdc-gov", "staging-reportstream-cdc-gov"]
 }

--- a/operations/app/src/environments/test/main.tf
+++ b/operations/app/src/environments/test/main.tf
@@ -30,5 +30,5 @@ module "prime_data_hub" {
   resource_group = "prime-data-hub-${local.target_env}"
   resource_prefix = "pdhtest"
   okta_redirect_url = "https://test.prime.cdc.gov/download"
-  https_cert_name = "test-prime-cdc-gov"
+  https_cert_names = ["test-prime-cdc-gov", "test-reportstream-cdc-gov"]
 }

--- a/operations/app/src/modules/front_door/variables.tf
+++ b/operations/app/src/modules/front_door/variables.tf
@@ -28,7 +28,7 @@ variable "eventhub_manage_auth_rule_id" {
   description = "Event Hub Manage Authorization Rule ID"
 }
 
-variable "https_cert_name" {
-  type = string
+variable "https_cert_names" {
+  type = list
   description = "The HTTPS cert to associate with the front door. Omitting will not associate a domain to the front door."
 }

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -99,7 +99,7 @@ module "front_door" {
     key_vault_id = module.key_vault.application_key_vault_id
     eventhub_namespace_name = module.event_hub.eventhub_namespace_name
     eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
-    https_cert_name = var.https_cert_name
+    https_cert_names = var.https_cert_names
 }
 
 module "sftp_container" {

--- a/operations/app/src/modules/prime_data_hub/variables.tf
+++ b/operations/app/src/modules/prime_data_hub/variables.tf
@@ -13,8 +13,8 @@ variable "resource_prefix" {
     description = "Resource Prefix"
 }
 
-variable "https_cert_name" {
-    type = string
+variable "https_cert_names" {
+    type = list
     description = "The HTTPS cert to associate with the front door. Omitting will not associate a domain to the front door."
 }
 


### PR DESCRIPTION
This PR adds the `reportstream.cdc.gov` frontend endpoint to the Front Door for the appropriate environment.