### PR TITLE
Jim/redox

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -516,6 +516,10 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
       - name: elr-chester-local
         topic: covid-19
         organizationName: pa-phd
@@ -530,6 +534,10 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
       - name: elr-montgomery-local
         organizationName: pa-phd
         topic: covid-19
@@ -544,6 +552,10 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
       - name: elr-philadelphia-local
         organizationName: pa-phd
         topic: covid-19
@@ -559,6 +571,11 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
+
 
   - name: pa-chester-phd
     description: Health Department - Chester County, Pennsylvania

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -367,6 +367,10 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
       - name: elr-chester-debug
         organizationName: pa-phd
         topic: covid-19
@@ -381,6 +385,10 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
       - name: elr-montgomery-debug
         organizationName: pa-phd
         topic: covid-19
@@ -395,22 +403,29 @@
             redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
             redox_source_name: "Prime Data Hub (Staging)"
           format: REDOX
-
-  - name: pa-philadelphia-phd
-    description: Philadelphia Department of Public Health
-    jurisdiction: COUNTY
-    stateCode: CO
-    countyName: Philadelphia
-    receivers:
-      - name: elr-philadelphia-download
-        organizationName: pa-philadelphia-phd
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
+      - name: elr-philadelphia-local
+        organizationName: pa-phd
         topic: covid-19
         jurisdictionalFilter: [ "matches(ordering_facility_state, PA)", "matches(ordering_facility_county, Philadelphia)" ]
         deidentify: false
         translation:
           type: CUSTOM
-          schemaName: strac/strac-covid-19
-          format: CSV
+          schemaName: pa/pa-covid-19-redox
+          defaults:
+            processing_mode_code: T
+            redox_destination_id: 09261a90-bc55-4a88-953c-eff0240feab1
+            redox_destination_name: "CDC Philadelphia PDH Destination (p)"
+            redox_source_id: d89d4057-930f-4c5b-bb39-8cddb326e928
+            redox_source_name: "Prime Data Hub (Staging)"
+          format: REDOX
+        timing:
+          operation: MERGE
+          numberPerDay: 1440 # Every minute
+          initialTime: 00:00
 
   - name: md-doh
     description: Maryland

--- a/prime-router/settings/prod/0006-pa-phd-add-batch-timings.yml
+++ b/prime-router/settings/prod/0006-pa-phd-add-batch-timings.yml
@@ -1,0 +1,124 @@
+---
+- name: "pa-phd"
+  description: "Pennsylvania Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "PA"
+  countyName: null
+  senders: []
+  receivers:
+  - name: "elr-bucks-prod"
+    organizationName: "pa-phd"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "pa/pa-covid-19-redox"
+      format: "REDOX"
+      defaults:
+        processing_mode_code: "P"
+        redox_source_name: "Prime Data Hub (Prod)"
+        redox_destination_id: "fcafe93a-9e04-4e3f-9aac-203518f6c4c9"
+        redox_destination_name: "CDC Bucks County PDH Destination (p)"
+        redox_source_id: "a3834c9d-e3ff-4602-b360-dcb0ad08fce5"
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, PA)"
+    - "matches(ordering_facility_county, Bucks)"
+    deidentify: false
+    timing:
+      operation: MERGE
+      numberPerDay: 24 # Every hour at 35 mins past the hour
+      initialTime: 00:35
+      timeZone: EASTERN
+    description: ""
+    transport: !<REDOX>
+      apiKey: "9e7f9bd1-a876-4f10-9d17-0833dc7bf60d"
+      baseUrl: null
+      type: "REDOX"
+  - name: "elr-chester-prod"
+    organizationName: "pa-phd"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "pa/pa-covid-19-redox"
+      format: "REDOX"
+      defaults:
+        processing_mode_code: "P"
+        redox_source_name: "Prime Data Hub (Prod)"
+        redox_destination_id: "5e841ef0-447b-46d0-8a60-49ca4defaf00"
+        redox_destination_name: "CDC Chester County PDH Destination (p)"
+        redox_source_id: "a3834c9d-e3ff-4602-b360-dcb0ad08fce5"
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, PA)"
+    - "matches(ordering_facility_county, Chester, Delaware)"
+    deidentify: false
+    timing:
+      operation: MERGE
+      numberPerDay: 24 # Every hour at 40 mins past the hour
+      initialTime: 00:40
+      timeZone: EASTERN
+    description: ""
+    transport: !<REDOX>
+      apiKey: "9e7f9bd1-a876-4f10-9d17-0833dc7bf60d"
+      baseUrl: null
+      type: "REDOX"
+  - name: "elr-montgomery-prod"
+    organizationName: "pa-phd"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "pa/pa-covid-19-redox"
+      format: "REDOX"
+      defaults:
+        processing_mode_code: "P"
+        redox_source_name: "Prime Data Hub (Prod)"
+        redox_destination_id: "bb2947af-28dd-470d-9997-7445eb42252f"
+        redox_destination_name: "CDC Montgomery County PDH Destination (p)"
+        redox_source_id: "a3834c9d-e3ff-4602-b360-dcb0ad08fce5"
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, PA)"
+    - "matches(ordering_facility_county, Montgomery)"
+    deidentify: false
+    timing:
+      operation: MERGE
+      numberPerDay: 24 # Every hour at 45 mins past the hour
+      initialTime: 00:45
+      timeZone: EASTERN
+    description: ""
+    transport: !<REDOX>
+      apiKey: "9e7f9bd1-a876-4f10-9d17-0833dc7bf60d"
+      baseUrl: null
+      type: "REDOX"
+  - name: "elr-philadelphia-prod"
+    organizationName: "pa-phd"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "pa/pa-covid-19-redox"
+      format: "REDOX"
+      defaults:
+        processing_mode_code: "P"
+        redox_source_name: "Prime Data Hub (Prod)"
+        redox_destination_id: "09261a90-bc55-4a88-953c-eff0240feab1"
+        redox_destination_name: "CDC Philadelphia PDH Destination (p)"
+        redox_source_id: "a3834c9d-e3ff-4602-b360-dcb0ad08fce5"
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(ordering_facility_state, PA)"
+    - "matches(ordering_facility_county, Philadelphia)"
+    deidentify: false
+    timing:
+      operation: MERGE
+      numberPerDay: 24 # Every hour at 50 mins past the hour
+      initialTime: 00:50
+      timeZone: EASTERN
+    description: ""
+    transport: !<REDOX>
+      apiKey: "9e7f9bd1-a876-4f10-9d17-0833dc7bf60d"
+      baseUrl: null
+      type: "REDOX"

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -6,6 +6,7 @@ import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.azure.db.Tables
+import gov.cdc.prime.router.azure.db.Tables.REPORT_LINEAGE
 import gov.cdc.prime.router.azure.db.Tables.SETTING
 import gov.cdc.prime.router.azure.db.Tables.TASK
 import gov.cdc.prime.router.azure.db.enums.SettingType
@@ -235,6 +236,19 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             .where(cond)
             .fetch()
             .into(ReportFile::class.java).toList()
+    }
+
+    fun fetchChildReports(
+        parentReportId: UUID,
+        txn: DataAccessTransaction? = null,
+    ): List<ReportId> {
+        val ctx = if (txn != null) DSL.using(txn) else create
+        return ctx
+            .select(REPORT_LINEAGE.CHILD_REPORT_ID)
+            .from(REPORT_LINEAGE)
+            .where(REPORT_LINEAGE.PARENT_REPORT_ID.eq(parentReportId))
+            .fetch()
+            .into(ReportId::class.java).toList()
     }
 
     /**

--- a/prime-router/src/main/kotlin/azure/RequeueFunction.kt
+++ b/prime-router/src/main/kotlin/azure/RequeueFunction.kt
@@ -31,11 +31,12 @@ class RequeueFunction : Logging {
         val workflowEngine = WorkflowEngine()
         val actionHistory = ActionHistory(TaskAction.resend, context)
         actionHistory.trackActionParams(request)
+        var msgs = mutableListOf<String>()
         val response = try {
-            doResend(request, workflowEngine, actionHistory)
+            doResend(request, workflowEngine, msgs)
         } catch (t: Throwable) {
-            val msg: String = t.cause?.let { "${t.cause!!.localizedMessage}\n" } + t.localizedMessage
-            bad(request, msg + "\n")
+            msgs.add(t.cause?.let { "${t.cause!!.localizedMessage}\n" } ?: "" + t.localizedMessage)
+            bad(request, msgs.joinToString("\n") + "\n")
         }
         actionHistory.trackActionResult(response)
         workflowEngine.recordAction(actionHistory)
@@ -45,21 +46,23 @@ class RequeueFunction : Logging {
     fun doResend(
         request: HttpRequestMessage<String?>,
         workflowEngine: WorkflowEngine,
-        actionHistory: ActionHistory
+        msgs: MutableList<String>,
     ): HttpResponseMessage {
-        if (request.queryParameters.size != 2) return bad(request, "Expecting 2 parameters\n")
+        val isTest = ! request.queryParameters["test"].isNullOrEmpty()
+        if (isTest) msgs.add("Here is what would happen if this were NOT a test:")
+        if (request.queryParameters.size < 2 || request.queryParameters.size > 4)
+            return bad(request, "Expecting 2 to 4 parameters\n")
         val reportIdStr = request.queryParameters["reportId"]
             ?: return bad(request, "Missing option reportId\n")
         val reportId = UUID.fromString(reportIdStr)
         val fullName = request.queryParameters["receiver"]
             ?: return bad(request, "Missing option receiver\n")
+        val isFailedOnly = ! request.queryParameters["failedOnly"].isNullOrEmpty()
         val receiver = workflowEngine.settings.findReceiver(fullName)
             ?: return bad(request, "No such receiver fullname $fullName\n")
-        workflowEngine.resendEvent(reportId, receiver) // sanity checks throw exceptions
-        return HttpUtilities.httpResponse(
-            request, "Report $reportId queued to resend immediately to ${receiver.fullName}\n",
-            HttpStatus.OK
-        )
+        // sanity checks throw exceptions inside here:
+        workflowEngine.resendEvent(reportId, receiver, isFailedOnly, isTest, msgs)
+        return HttpUtilities.httpResponse(request, msgs.joinToString("\n")+"\n", HttpStatus.OK)
     }
 
     fun bad(request: HttpRequestMessage<String?>, msg: String): HttpResponseMessage {

--- a/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
@@ -64,6 +64,7 @@ class SendFunctionTests {
     fun setupLogger() {
         every { context.logger }.returns(logger)
         every { logger.log(any(), any(), any<Throwable>()) }.returns(Unit)
+        every { logger.warning(any<String>()) }.returns(Unit)
         every { logger.info(any<String>()) }.returns(Unit)
     }
 
@@ -95,8 +96,8 @@ class SendFunctionTests {
         var nextEvent: ReportEvent? = null
         setupLogger()
         setupWorkflow()
-        every { workflowEngine.handleReportEvent(any(), any()) }.answers {
-            val block = secondArg() as
+        every { workflowEngine.handleReportEvent(any(), context, any()) }.answers {
+            val block = thirdArg() as
                 (header: WorkflowEngine.Header, retryToken: RetryToken?, txn: Configuration?) -> ReportEvent
             val header = makeHeader()
             nextEvent = block(header, null, null)
@@ -118,8 +119,8 @@ class SendFunctionTests {
         // Setup
         var nextEvent: ReportEvent? = null
         setupLogger()
-        every { workflowEngine.handleReportEvent(any(), any()) }.answers {
-            val block = secondArg() as
+        every { workflowEngine.handleReportEvent(any(), context, any()) }.answers {
+            val block = thirdArg() as
                 (header: WorkflowEngine.Header, retryToken: RetryToken?, txn: Configuration?) -> ReportEvent
             val header = makeHeader()
             nextEvent = block(header, null, null)
@@ -143,8 +144,8 @@ class SendFunctionTests {
         // Setup
         var nextEvent: ReportEvent? = null
         setupLogger()
-        every { workflowEngine.handleReportEvent(any(), any()) }.answers {
-            val block = secondArg() as
+        every { workflowEngine.handleReportEvent(any(), context, any()) }.answers {
+            val block = thirdArg() as
                 (header: WorkflowEngine.Header, retryToken: RetryToken?, txn: Configuration?) -> ReportEvent
             val task = Task(
                 reportId,
@@ -191,8 +192,8 @@ class SendFunctionTests {
         var nextEvent: ReportEvent? = null
         setupLogger()
         val reportId = UUID.randomUUID()
-        every { workflowEngine.handleReportEvent(any(), any()) }.answers {
-            val block = secondArg() as
+        every { workflowEngine.handleReportEvent(any(), context, any()) }.answers {
+            val block = thirdArg() as
                 (header: WorkflowEngine.Header, retryToken: RetryToken?, txn: Configuration?) -> ReportEvent
             val header = makeHeader()
             // Should be high enough retry count that the next action should have an error
@@ -217,8 +218,7 @@ class SendFunctionTests {
     @Test
     fun `Test with a bad message`() {
         // Setup
-        every { context.logger }.returns(logger)
-        every { logger.log(any(), any(), any<Throwable>()) }.returns(Unit)
+        setupLogger()
         every { workflowEngine.recordAction(any()) }.returns(Unit)
 
         // Invoke

--- a/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
+++ b/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
@@ -211,7 +211,7 @@ class WorkflowEngineTests {
         every { actionHistoryMock.trackActionResult(any() as String) }.returns(Unit)
         every { ActionHistory.Companion.sanityCheckReport(any(), any(), any()) }.returns(Unit)
 
-        engine.handleReportEvent(event) { header, _, _ ->
+        engine.handleReportEvent(event, null) { header, _, _ ->
             assertEquals(task, header.task)
             nextAction
         }


### PR DESCRIPTION
## Changes
1. Modifying REDOX Sends so they are batched, then the batches send spaced out at 35, 40, 45, 50, 55 mins past the hour.  Strac normally sends on the half hour, so this is a short delay.   Bucks is at :35, because get little or no data from them.
2. Added logging.
3. Adds two optional parameters to the `requeue/send` endpoint;
   a.  failedOnly.   If this is set true, then read the lineage to determine which Items have already been successfully sent, and only send the others.
   b.  test.    If this is set true, then do everything except actually submit the requeue.   This is nice to test what's going to happen before you actually do it.

Example use of requeue/send:
```
curl -H content-length:0 -X POST "http://localhost:7071/api/requeue/send?reportId=6655a154-18e1-47c3-bb45-1549a8af9acd&receiver=ignore.REDOX&failedOnly=true&test=true"
```

Note: This PR includes changes to the Prod settings for pa-phd.  Before I roll these change to Prod, I'll pull those pa-phd settings and compare:
```
./prime multiple-settings get --env prod --filter pa-phd --output compare-pa-phd.yml
diff compare-pa-phd.yml settings/prod/0006-pa-phd-add-batch-timings.yml
```

Can also test loading the settings locally:
`./prime multiple-settings set --env local --input settings/prod/0006-pa-phd-add-batch-timings.yml`

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
- no known issues

## Fixes
- #768



