### PR TITLE
Updated quick test for Windows compatibility

### DIFF
--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -199,8 +199,14 @@ Unit tests are run as part of the build.  To run the unit tests, run the followi
 mvn test
 ```
 
+### Data Conversion Quick Test
+The quick test is meant to test the data conversion and generation code.  Use the following command to run all quick tests.  On Windows OS, use Git Bash or similar Linux shell to run this command.
+```
+./quick-test.sh all
+```
+
 ### Local End-to-end Tests
-End-to-end tests check if the deployed system is configured correctly.  The test uses an organization called IGNORE for running the tests.  
+End-to-end tests check if the deployed system is configured correctly.  The test uses an organization called IGNORE for running the tests.  On Windows OS, use Git Bash or similar Linux shell to run these commands.
 1. Refer to the [SFTP-SETUP document](SFTP_SETUP.md) to setup a local SFTP server to receive the resulting data.
 1. Setup the required SFTP credentials for the test organization using the following commands.  Use the username and password assigned to the local SFTP server and change the arguments for the --user and --pass as needed:
     ```bash 

--- a/prime-router/quick-test.sh
+++ b/prime-router/quick-test.sh
@@ -94,7 +94,9 @@ function parse_prime_output_for_filename {
     fi
     if [ $ready -eq 1 ] ; then 
       if grep -q $match_string <<< $name ; then
-        filename=$name
+        # Force the removal of inserted whitespace and/or quotes in Windows with this echo.
+        filename=`echo $name`
+        break;
       fi
     fi
   done
@@ -141,8 +143,9 @@ then
   text=$(./prime data --input-schema $starter_schema --input ./src/test/csv_test_files/input/simplereport.csv --output-dir $outputdir --route)
 fi
 
-AZ_FILE_SEARCH_STR="/az.*\.csv"
-PIMA_FILE_SEARCH_STR="/pima.*\.csv"
+# Note that we use both forward and back slash to be compatible with Windows and Linux/MAC paths.
+AZ_FILE_SEARCH_STR="[/\\]az.*\.csv"
+PIMA_FILE_SEARCH_STR="[/\\]pima.*\.csv"
 
 # run arizona and pima
 if [ $RUN_AZ -ne 0 ]
@@ -174,7 +177,7 @@ then
 
   echo And now generate some fake simplereport data
   text=$(./prime data --input-fake 50 --input-schema $starter_schema --output-dir $outputdir)
-  parse_prime_output_for_filename "$text" "/pdi-covid-19"
+  parse_prime_output_for_filename "$text" "[/\\]pdi-covid-19"
   fake_data=$filename
 
   echo Now send that fake data thru the router.
@@ -205,7 +208,7 @@ fi
 
 if [ $RUN_MERGE -ne 0 ]
 then
-  STRAC_FILE_SEARCH_STR="/strac-covid-19.*\.csv"
+  STRAC_FILE_SEARCH_STR="[/\\]strac-covid-19.*\.csv"
   numitems=5
   echo Merge testing.  First, generate some fake STRAC data
    # Hack: put some unique strings in each one, so we can count lines.
@@ -213,12 +216,12 @@ then
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake1=$filename
 
- echo More fake STRAC data
+  echo More fake STRAC data
   text=$(./prime data --input-fake $numitems --input-schema strac/strac-covid-19 --output-dir $outputdir --target-counties brobdingnag)
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake2=$filename
 
- echo 3rd file of fake STRAC data
+  echo 3rd file of fake STRAC data
   text=$(./prime data --input-fake $numitems --input-schema strac/strac-covid-19 --output-dir $outputdir --target-counties houyhnhnm)
   parse_prime_output_for_filename "$text" $STRAC_FILE_SEARCH_STR
   fake3=$filename
@@ -239,7 +242,7 @@ fi
 # run florida
 if [ $RUN_FL -ne 0 ]
 then
-  FL_FILE_SEARCH_STR="/fl.*\.hl7"
+  FL_FILE_SEARCH_STR="[/\\]fl.*\.hl7"
   # FLORIDA, MAN
   echo Generate fake FL data
   text=$(./prime data --input-fake 50 --input-schema fl/fl-covid-19 --output-dir $outputdir --target-states FL --target-counties Broward --output-format HL7_BATCH)
@@ -249,7 +252,7 @@ fi
 # run guam
 if [ $RUN_GU -ne 0 ]
 then
-  GU_FILE_SEARCH_STR="/gu.*\.hl7"
+  GU_FILE_SEARCH_STR="[/\\]gu.*\.hl7"
   echo Generate fake Guam data
   text=$(./prime data --input-fake 50 --input-schema gu/gu-covid-19 --output-dir $outputdir --target-states GU --output-format HL7_BATCH)
   parse_prime_output_for_filename "$text" $GU_FILE_SEARCH_STR
@@ -258,7 +261,7 @@ fi
 # run louisiana
 if [ $RUN_LA -ne 0 ]
 then
-  LA_FILE_SEARCH_STR="/cdcprime.*\.hl7"
+  LA_FILE_SEARCH_STR="[/\\]cdcprime.*\.hl7"
   echo Generate synthetic LA data, HL7!
   text=$(./prime data --input-fake 50 --input-schema la/la-covid-19 --output-dir $outputdir --name-format APHL --output-receiving-org=LAOPH --target-states LA --output-format HL7_BATCH)
   parse_prime_output_for_filename "$text" "$LA_FILE_SEARCH_STR"
@@ -269,7 +272,7 @@ if [ $RUN_ND -ne 0 ]
 then
   echo Generate fake ND data, HL7!
   text=$(./prime data --input-fake 50 --input-schema nd/nd-covid-19 --output-dir $outputdir --target-states ND --target-counties Richland --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/nd.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]nd.*\.hl7"
 fi
 
 # run nm
@@ -277,18 +280,14 @@ if [ $RUN_NM -ne 0 ]
 then
   echo Generate fake NM data, HL7!
   text=$(./prime data --input-fake 50 --input-schema nm/nm-covid-19 --output-dir $outputdir --target-states NM --target-counties Hidalgo --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/nm.*\.hl7"
-
-  echo Generate fake NM data, CSV!
-  text=$(./prime data --input-fake 50 --input-schema nm/nm-covid-19-csv --output-dir $outputdir --target-states NM --target-counties Hidalgo --output-format CSV)
-  parse_prime_output_for_filename "$text" "/nm.*\.csv"
+  parse_prime_output_for_filename "$text" "[/\\]nm.*\.hl7"
 fi
 
 if [ $RUN_OH -ne 0 ]
 then
   echo Generate fake OH data, HL7!
   text=$(./prime data --input-fake 50 --input-schema oh/oh-covid-19 --output-dir $outputdir --name-format OHIO --target-states OH --target-counties Ashtabula --output-format HL7_BATCH --suppress-qst-for-aoe)
-  parse_prime_output_for_filename "$text" "/CDCPRIME.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]CDCPRIME.*\.hl7"
 fi
 
 # run tx
@@ -296,7 +295,7 @@ if [ $RUN_TX -ne 0 ]
 then
   echo Generate fake TX data, HL7!
   text=$(./prime data --input-fake 50 --input-schema tx/tx-covid-19 --output-dir $outputdir --target-states TX --target-counties Knox --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/tx.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]tx.*\.hl7"
 fi
 
 # run vt
@@ -304,7 +303,7 @@ if [ $RUN_VT -ne 0 ]
 then
   echo Generate fake VT data, HL7!
   text=$(./prime data --input-fake 50 --input-schema vt/vt-covid-19 --output-dir $outputdir --target-states VT --target-counties Essex --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/vt.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]vt.*\.hl7"
 fi
 
 # run MT
@@ -312,9 +311,9 @@ if [ $RUN_MT -ne 0 ]
 then
   echo Generate fake MT data, HL7 and CSV
   text=$(./prime data --input-fake 50 --input-schema mt/mt-covid-19 --output-dir $outputdir --target-states MT --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/mt.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]mt.*\.hl7"
   text=$(./prime data --input-fake 50 --input-schema mt/mt-covid-19-csv --output-dir $outputdir --target-states MT --output-format HL7_BATCH)
-  parse_prime_output_for_filename "$text" "/mt.*\.hl7"
+  parse_prime_output_for_filename "$text" "[/\\]mt.*\.hl7"
 fi
 
 # run vt
@@ -322,7 +321,7 @@ if [ $RUN_CA -ne 0 ]
 then
   echo Generate fake CA data, CSV!
   text=$(./prime data --input-fake 50 --input-schema ca/ca-scc-covid-19 --output-dir $outputdir --target-states CA --target-counties 'Santa Clara' --output-format CSV)
-  parse_prime_output_for_filename "$text" "/ca.*\.csv"
+  parse_prime_output_for_filename "$text" "[/\\]ca.*\.csv"
 fi
 
 exit 0


### PR DESCRIPTION
This PR adds Windows OS compatibility to the quick test.
**NOTE this change requires a test in Mac/Linux OS to make sure the script is not broken on those OS.**

## Test steps
1. Run quicktest all in a Windows OS workstation and verify all tests pass.
2. Run quicktest all in a Mac or Linux OS workstation and verify all tests pass.

## Changes
- Fixed issue with filename text having extra quote or newline, hence breaking the test
- Added backslash to filename search patterns.  -- A potential more generic change is to get rid of the slashes all together.  Thoughts?

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [x] Updated the release notes? 
- [x] Added tests?
- [x] Did you check for sensitive data, and remove any? 
- [x] Does logging contain sensitive data?  
- [x] Are additional approvals needed for this change?
- [x] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
N/A

## Fixes
N/A

## To Be Done
N/A

