### PR TITLE
Further work related to redox sends

### DIFF
--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -183,7 +183,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             ?.into(ReportFile::class.java)
             ?: error(
                 "Could not find $reportId in REPORT_FILE" +
-                    if (org != null) { " associated with organization $org" } else ""
+                    if (org != null) { " associated with organization ${org.name}" } else ""
             )
     }
 

--- a/prime-router/src/main/kotlin/azure/RequeueFunction.kt
+++ b/prime-router/src/main/kotlin/azure/RequeueFunction.kt
@@ -62,7 +62,7 @@ class RequeueFunction : Logging {
             ?: return bad(request, "No such receiver fullname $fullName\n")
         // sanity checks throw exceptions inside here:
         workflowEngine.resendEvent(reportId, receiver, isFailedOnly, isTest, msgs)
-        return HttpUtilities.httpResponse(request, msgs.joinToString("\n")+"\n", HttpStatus.OK)
+        return HttpUtilities.httpResponse(request, msgs.joinToString("\n") + "\n", HttpStatus.OK)
     }
 
     fun bad(request: HttpRequestMessage<String?>, msg: String): HttpResponseMessage {

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -1,6 +1,7 @@
 package gov.cdc.prime.router.azure
 
 import com.microsoft.azure.functions.ExecutionContext
+import com.microsoft.azure.functions.annotation.BindingName
 import com.microsoft.azure.functions.annotation.FunctionName
 import com.microsoft.azure.functions.annotation.QueueTrigger
 import com.microsoft.azure.functions.annotation.StorageAccount
@@ -15,6 +16,7 @@ import gov.cdc.prime.router.transport.ITransport
 import gov.cdc.prime.router.transport.NullTransport
 import gov.cdc.prime.router.transport.RetryToken
 import java.time.OffsetDateTime
+import java.util.Date
 import java.util.UUID
 import java.util.logging.Level
 import kotlin.random.Random
@@ -36,14 +38,21 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
     @FunctionName(send)
     @StorageAccount("AzureWebJobsStorage")
     fun run(
-        @QueueTrigger(name = "msg", queueName = send)
-        message: String,
+        @QueueTrigger(name = "msg", queueName = send) message: String,
         context: ExecutionContext,
+        @BindingName("Id") messageId: String? = null,
+        @BindingName("DequeueCount") dequeueCount: Int? = null,
+        @BindingName("NextVisibleTime") nextVisibleTime: Date? = null,
+        @BindingName("InsertionTime") insertionTime: Date? = null,
     ) {
         val actionHistory = ActionHistory(TaskAction.send, context)
         actionHistory.trackActionParams(message)
+        context.logger.info(
+            "Started Send Function: $message, id=$messageId," +
+                " dequeueCount=$dequeueCount, " +
+                " nextVisibleTime=$nextVisibleTime, insertionTime=$insertionTime"
+        )
         try {
-            context.logger.info("Started Send Function: $message")
             val event = Event.parseQueueMessage(message) as ReportEvent
             if (event.eventAction != Event.EventAction.SEND) {
                 context.logger.warning("Send function received a $message")

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -52,6 +52,10 @@ class RedoxTransport() : ITransport, SecretManagement {
         val sendUrl = "${getBaseUrl(redoxTransportType)}$redoxEndpointPath"
         var resultMsg = ""
         var results = mutableListOf<RedoxTransport.SendResult>()
+        context.logger.info(
+            "The incoming retry item list for ${header.reportFile.reportId} is: " +
+                (retryItems?.joinToString(",") ?: "null")
+        )
         try {
             val (key, secret) = getKeyAndSecret(redoxTransportType)
             // DevNote: Redox access tokens live for many days
@@ -123,7 +127,7 @@ class RedoxTransport() : ITransport, SecretManagement {
         }
         if (nextRetryItems.isNotEmpty()) {
             context.logger.info(
-                "The retry item list for ${header.reportFile.reportId} is: " +
+                "The outgoing retry item list for ${header.reportFile.reportId} is: " +
                     nextRetryItems.joinToString(",")
             )
             return nextRetryItems


### PR DESCRIPTION
This PR 
- fixes a bug in the requeue feature, where if, for whatever reason, the system had not even attempted to send data to Redox, requeue's sendFailed interpreted that as a Success.  It should be interpreted as a failure.
- adds yet more logging, in an attempt to isolate the 'lateinit' exception as outlined in #768 

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


- #768 , not done.



