### PR TITLE
Rotate Production Keys to Use CDC Keys

### DIFF
--- a/operations/app/src/environments/prod/main.tf
+++ b/operations/app/src/environments/prod/main.tf
@@ -31,6 +31,6 @@ module "prime_data_hub" {
   resource_prefix = "pdhprod"
   okta_redirect_url = "https://prime.cdc.gov/download"
   https_cert_names = ["prime-cdc-gov", "reportstream-cdc-gov"]
-  rsa_key_2048 = null
-  rsa_key_4096 = null
+  rsa_key_2048 = "pdhprod-2048-key"
+  rsa_key_4096 = "pdhprod-4096-key"
 }


### PR DESCRIPTION
This PR will rotate the keys used for our storage account and database to use the CDC-managed keys. All access policies and service profiles have already been deployed out.

## Changes
- Flips the switch to rotate keys
- 

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

