### PR TITLE
Queue Connection Tweaks

### DIFF
--- a/prime-router/host.json
+++ b/prime-router/host.json
@@ -6,7 +6,8 @@
   },
   "extensions": {
     "queues": {
-      "batchSize": 8
+      "batchSize": 4,
+      "newBatchThreshold": 2
     }
   }
 }

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -521,7 +521,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             // See this info why these are a good value
             //  https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
             config.minimumIdle = 2
-            config.maximumPoolSize = 10
+            config.maximumPoolSize = 15
             // This strongly recommended to be set "be several seconds shorter than any database or infrastructure
             // imposed connection time limit". Not sure what value is but have observed that connection are closed
             // after about 10 minutes

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -516,13 +516,12 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             config.addDataSourceProperty("cachePrepStmts", "true")
             config.addDataSourceProperty("prepStmtCacheSize", "250")
             config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048")
-            config.addDataSourceProperty("maximumPoolSize", "20") // Default is 10
             config.addDataSourceProperty("connectionTimeout", "60000") // Default is 30000 (30 seconds)
 
             // See this info why these are a good value
             //  https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
             config.minimumIdle = 2
-            config.maximumPoolSize = 8
+            config.maximumPoolSize = 10
             // This strongly recommended to be set "be several seconds shorter than any database or infrastructure
             // imposed connection time limit". Not sure what value is but have observed that connection are closed
             // after about 10 minutes


### PR DESCRIPTION
This PR resolves several conflicts with the number of concurrent messages processing and the number of open database connections.

## Changes
- Fixes an unexpected override of the `maximumPoolSize` in our database configuration. We thought the value was set at 20, but it was overridden to 8
- Sets the `maximumPoolSize` to 15
- Lowers the queue batch size to 4
- Explicitly sets the `newBatchThershold` at 2

With the above settings, the maximum number of open connections we should have at a time will 12; three lower than the `maximumPoolSize`. This is calculated with the below equation:

```
2 listening queues [BatchFunction and SendFunction]
x
6 [4 items fetched from the queue  + 2 items in the queue when fetched]
---
= 12 concurrent items processing in the queue

12 items < 15 maximumPoolSize
```

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

