### PR TITLE
Higher processing concurrency

### DIFF
--- a/prime-router/host.json
+++ b/prime-router/host.json
@@ -6,8 +6,8 @@
   },
   "extensions": {
     "queues": {
-      "batchSize": 4,
-      "newBatchThreshold": 2
+      "batchSize": 8,
+      "newBatchThreshold": 4
     }
   }
 }

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -521,7 +521,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             // See this info why these are a good value
             //  https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
             config.minimumIdle = 2
-            config.maximumPoolSize = 15
+            config.maximumPoolSize = 25
             // This strongly recommended to be set "be several seconds shorter than any database or infrastructure
             // imposed connection time limit". Not sure what value is but have observed that connection are closed
             // after about 10 minutes


### PR DESCRIPTION
This PR is a tweak of https://github.com/CDCgov/prime-data-hub/pull/779 by attempting to process more items at once.

## Changes
- Sets the maximumPoolSize to 25
- Set queue batch size to 8
- Sets the newBatchThershold at 4

```
2 listening queues [BatchFunction and SendFunction]
x
12 [8 items fetched from the queue  + 4 items in the queue when fetched]
---
= 24 concurrent items processing in the queue

24 items < 25 maximumPoolSize
```

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

