### PR TITLE
zeroth pass at Waters schema

### DIFF
--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -1,0 +1,1000 @@
+
+### Schema:         waters/waters-covid-19
+#### Description:   WATERS OTC,POC COVID-19 flat file
+
+---
+
+**Name**: testResult
+
+**Type**: CODE
+
+**Format**: $alt
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+260373001|Detected
+260415000|Not detected
+455371000124106|Invalid result
+
+**Alt Value Sets**
+
+Code | Display
+---- | -------
+260373001|Patient Tested Positive!
+260415000|Patient Tested Negative!
+455371000124106|Test Was Invalid
+
+**Documentation**:
+
+The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+
+---
+
+**Name**: testResultDate
+
+**Type**: DATETIME
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testReportDate
+
+**Type**: DATETIME
+
+**HL7 Field**: OBX-22
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimenCollectedDate
+
+**Type**: DATETIME
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The date which the specimen was collected. The default format is yyyyMMddHHmmsszz
+
+
+---
+
+**Name**: deviceIdentifier
+
+**Type**: TABLE
+
+**Format**: $display
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Model
+
+---
+
+**Name**: serialNumber
+
+**Type**: ID
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientAge
+
+**Type**: NUMBER
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientZip
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: patientCounty
+
+**Type**: TABLE_OR_BLANK
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: orderingProviderNpi
+
+**Type**: ID_NPI
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ordering provider’s National Provider Identifier
+
+---
+
+**Name**: performingFacility
+
+**Type**: ID_CLIA
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
+
+---
+
+**Name**: specimenSource
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: patientUniqueId
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientUniqueId
+
+**Type**: TEXT
+
+**HL7 Field**: PID-3-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientDob
+
+**Type**: DATE
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: patientNameLast
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The patient's last name
+
+---
+
+**Name**: patientNameFirst
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: patientNameMiddle
+
+**Type**: PERSON_NAME
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientHomeAddress
+
+**Type**: STREET
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: patientHomeAddress2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: patientCity
+
+**Type**: CITY
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patientState
+
+**Type**: TABLE
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The patient's state
+
+---
+
+**Name**: patientPhone
+
+**Type**: TELEPHONE
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: reportingFacility
+
+**Type**: TEXT
+
+**HL7 Field**: MSH-4-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's name
+
+---
+
+**Name**: testOrderedDate
+
+**Type**: DATE
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimenId
+
+**Type**: EI
+
+**HL7 Fields**: SPM-2
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
+
+---
+
+**Name**: patientRace
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: patientEthnicity
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+
+**Documentation**:
+
+The patient's ethnicity. There is a valueset defined based on the values in PID-22, but downstream
+consumers are free to define their own values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patientSex
+
+**Type**: CODE
+
+**Format**: $display
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: orderingProviderZip
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: performingFacilityZip
+
+**Type**: POSTAL_CODE
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: orderingProviderAddress
+
+**Type**: STREET
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: orderingProviderAddress2
+
+**Type**: STREET_OR_BLANK
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: orderingProviderCity
+
+**Type**: CITY
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: orderingProviderState
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: orderingProviderPhone
+
+**Type**: TELEPHONE
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: firstTest
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is this the patient's first test for this condition?
+
+---
+
+**Name**: previousTestType
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: previousTestDate
+
+**Type**: DATE
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: previousTestResult
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: healthcareEmployee
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient employed in health care?
+
+---
+
+**Name**: Patient_role
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: symptomatic
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient symptomatic?
+
+---
+
+**Name**: symptomsList
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: hospitalized
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient hospitalized?
+
+---
+
+**Name**: hospitalizedCode
+
+**Type**: CODE
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+
+---
+
+**Name**: symptomsIcu
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95420-6
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Is the patient in the ICU?
+
+---
+
+**Name**: congregateResident
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|Yes
+N|No
+UNK|Unknown
+
+**Documentation**:
+
+Does the patient reside in a congregate care setting?
+
+---
+
+**Name**: congregateResidentType
+
+**Type**: CODE
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+22232009|Hospital
+32074000|Long Term Care Hospital
+224929004|Secure Hospital
+42665001|Nursing Home
+30629002|Retirement Home
+74056004|Orphanage
+722173008|Prison-based care site
+20078004|Substance Abuse Treatment Center
+257573002|Boarding House
+224683003|Military Accommodation
+284546000|Hospice
+257628001|Hostel
+310207003|Sheltered Housing
+57656006|Penal Institution
+32911000|Homeless
+
+---
+
+**Name**: pregnant
+
+**Type**: CODE
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+77386006|Pregnant
+60001007|Not Pregnant
+261665006|Unknown
+
+**Documentation**:
+
+Is the patient pregnant?
+
+---
+
+**Name**: patientEmail
+
+**Type**: EMAIL
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testName
+
+**Type**: TABLE
+
+**HL7 Field**: OBR-4-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Ordered LOINC Long Name
+
+---
+
+**Name**: testResultText
+
+**Type**: CODE
+
+**HL7 Field**: OBX-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+A|Abnormal (applies to non-numeric results)
+>|Above absolute high-off instrument scale
+H|Above high normal
+HH|Above upper panic limits
+AC|Anti-complementary substances present
+<|Below absolute low-off instrument scale
+L|Below low normal
+LL|Below lower panic limits
+B|Better--use when direction not relevant
+TOX|Cytotoxic substance present
+DET|Detected
+IND|Indeterminate
+I|Intermediate. Indicates for microbiology susceptibilities only.
+MS|Moderately susceptible. Indicates for microbiology susceptibilities only.
+NEG|Negative
+null|No range defined, or normal ranges don't apply
+NR|Non-reactive
+N|Normal (applies to non-numeric results)
+ND|Not Detected
+POS|Positive
+QCF|Quality Control Failure
+RR|Reactive
+R|Resistant. Indicates for microbiology susceptibilities only.
+D|Significant change down
+U|Significant change up
+S|Susceptible. Indicates for microbiology susceptibilities only.
+AA|Very abnormal (applies to non-numeric units, analogous to panic limits for numeric units)
+VS|Very susceptible. Indicates for microbiology susceptibilities only.
+WR|Weakly reactive
+W|Worse--use when direction not relevant
+
+**Documentation**:
+
+This field is generated based on the normalcy status of the result. A = abnormal; N = normal
+
+---
+
+**Name**: testPerformed
+
+**Type**: TABLE
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-01-20
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+The LOINC code of the test performed. This is a standardized coded value describing the test
+
+---
+
+**Name**: orderingProviderLname
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: orderingProviderFname
+
+**Type**: PERSON_NAME
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: patientPhoneAreaCode
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: orderingProviderPhoneAreaCode
+
+**Type**: TEXT
+
+**Cardinality**: [0..1]
+
+---

--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -4,6 +4,24 @@
 
 ---
 
+**Name**: orderingFacilityState
+
+**Type**: TABLE
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the facility which the test was ordered from
+
+---
+
 **Name**: testResult
 
 **Type**: CODE
@@ -230,7 +248,7 @@ The specimen source, such as Blood or Serum
 
 ---
 
-**Name**: patientUniqueId
+**Name**: patientUniqueIdType
 
 **Type**: TEXT
 
@@ -395,19 +413,15 @@ The reporting facility's name
 
 **Name**: specimenId
 
-**Type**: EI
+**Type**: ID
 
-**HL7 Fields**: SPM-2
+**HL7 Field**: MSH-10
 
-**Cardinality**: [0..1]
-
-
-**Reference URL**:
-[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+**Cardinality**: [1..1]
 
 **Documentation**:
 
-A unique code for this specimen
+unique id to track the usage of the message
 
 ---
 

--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -107,11 +107,9 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 ---
 
-**Name**: deviceIdentifier
+**Name**: equipmentModelName
 
 **Type**: TABLE
-
-**Format**: $display
 
 **Cardinality**: [0..1]
 
@@ -187,18 +185,15 @@ The ordering provider’s National Provider Identifier
 
 **Name**: performingFacility
 
-**Type**: ID_CLIA
+**Type**: TEXT
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Field**: OBX-23-1
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Documentation**:
 
-CLIA Number from the laboratory that sends the message to DOH
-
-An example of the ID is 03D2159846
-
+The name of the laboratory which performed the test, can be the same as the sending facility name
 
 ---
 

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -53,7 +53,8 @@ elements:
   - name: ordering_provider_id
     csvFields: [{ name: orderingProviderNpi}]
 
-  - name: testing_lab_clia
+  # Doublecheck this.  Is the 'performing facility' the same as the 'testing lab'?
+  - name: testing_lab_name
     csvFields: [{ name: performingFacility}]
 
   # Edited.  Done as a set of alternate values, to show how that works.
@@ -207,6 +208,8 @@ elements:
   - name: ordering_provider_first_name
     csvFields: [{ name: orderingProviderFname}]
 
+  #  Is the area code also included in the phone number?  If yes, then why do we need this?
+  #  If no, then we need to merge area code and the rest of the phone number
   - name: patient_phone_area_code   # Edited this.
     type: TEXT
     csvFields: [{ name: patientPhoneAreaCode}]

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -1,7 +1,7 @@
 ---
 name: waters-covid-19
 description: WATERS OTC,POC COVID-19 flat file
-topic: covid-19
+topic: covid-19-otc
 trackingElement: equipment_instance_id
 basedOn: covid-19
 elements:

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -9,6 +9,10 @@ elements:
 #  - name: ordered_test_code
 #    csvFields: [{ name: testOrdered}]
 
+  # Edited. Added 'ordering_facility_state', because it lets us test mapping to many of our states
+  - name: ordering_facility_state
+    csvFields: [{ name: orderingFacilityState }]
+
   - name: test_result    # Edited.  Was 'patient_positive' to 'test_result'
     altValues:
       - display: Patient Tested Positive!
@@ -59,7 +63,7 @@ elements:
     csvFields: [{ name: patientUniqueId}]
 
   - name: patient_id_type    # Edited.  Added this, to complement patient_id.
-    csvFields: [{ name: patientUniqueId}]
+    csvFields: [{ name: patientUniqueIdType}]
 
   - name: patient_dob
     csvFields: [{ name: patientDob}]
@@ -94,7 +98,10 @@ elements:
   - name: order_test_date
     csvFields: [{ name: testOrderedDate}]
 
-  - name: specimen_id
+  #  Edited.  This was specimen_id, I changed to 'message_id', because our states tend to expect that.
+  # Need to figure out what to use for this.  Currently covid-19.schema expects a message_id
+  # Note this is a good example of where the external customer-facing name can be different, as needed.
+  - name: message_id
     csvFields: [{ name: specimenId}]
 
   - name: patient_race    # There was another one with csvField = patientRaceText.  Removed for now.

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -5,11 +5,19 @@ topic: covid-19
 trackingElement: equipment_instance_id
 basedOn: covid-19
 elements:
-  - name: ordered_test_code
-    csvFields: [{ name: testOrdered}]
+#  I removed this - we can pull it from the equipment_model_name lookup
+#  - name: ordered_test_code
+#    csvFields: [{ name: testOrdered}]
 
   - name: test_result    # Edited.  Was 'patient_positive' to 'test_result'
-    csvFields: [{ name: testResult}]
+    altValues:
+      - display: Patient Tested Positive!
+        code: 260373001
+      - display: Patient Tested Negative!
+        code: 260415000
+      - display: Test Was Invalid
+        code: 455371000124106
+    csvFields: [{ name: testResult, format: $alt}]
 
   - name: test_result_date  # Edited.  Was 'patient_results' to 'test_result_date'
     csvFields: [{ name: testResultDate}]
@@ -23,7 +31,7 @@ elements:
   # Edited.  This appeared twice.  I eliminated one.  The other was csvField = 'deviceName'
   #  Note:  value here should come from LIVD table
   - name: equipment_model_name
-    csvFields: [{ name: deviceIdentifier}]
+    csvFields: [{ name: deviceIdentifier, format: $display}]
 
   - name: equipment_instance_id     # Edited.  Was 'kit_id'
     csvFields: [{ name: serialNumber}]
@@ -43,8 +51,9 @@ elements:
   - name: testing_lab_clia
     csvFields: [{ name: performingFacility}]
 
+  # Edited.  Done as a set of alternate values, to show how that works.
   - name: specimen_type
-    csvFields: [{ name: specimenSource}]
+    csvFields: [{ name: specimenSource, format: $display}]
 
   - name: patient_id    # Edited.  Was 'patient_dl'.
     csvFields: [{ name: patientUniqueId}]
@@ -89,13 +98,13 @@ elements:
     csvFields: [{ name: specimenId}]
 
   - name: patient_race    # There was another one with csvField = patientRaceText.  Removed for now.
-    csvFields: [{ name: patientRace}]
+    csvFields: [{ name: patientRace, format: $display}]
 
   - name: patient_ethnicity      # There was another one with csvField = patientEthnicityText.  Removed for now.
-    csvFields: [{ name: patientEthnicity}]
+    csvFields: [{ name: patientEthnicity, format: $display}]
 
   - name: patient_gender    # Edited.   Was patient_sex
-    csvFields: [{ name: patientSex}]
+    csvFields: [{ name: patientSex, format: $display}]
 
   - name: ordering_provider_zip_code
     csvFields: [{ name: orderingProviderZip}]

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -34,9 +34,9 @@ elements:
     csvFields: [{ name: specimenCollectedDate}]
 
   # Edited.  This appeared twice.  I eliminated one.  The other was csvField = 'deviceName'
-  #  Note:  value here should come from LIVD table
+  #  Note:  value here must come from Column B, 'Model', LIVD table
   - name: equipment_model_name
-    csvFields: [{ name: deviceIdentifier, format: $display}]
+    csvFields: [{ name: equipmentModelName }]
 
   - name: equipment_instance_id     # Edited.  Was 'kit_id'
     csvFields: [{ name: serialNumber}]

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -1,0 +1,200 @@
+---
+name: waters-covid-19
+description: WATERS OTC,POC COVID-19 flat file
+topic: covid-19
+trackingElement: equipment_instance_id
+basedOn: covid-19
+elements:
+  - name: ordered_test_code
+    csvFields: [{ name: testOrdered}]
+
+  - name: test_result    # Edited.  Was 'patient_positive' to 'test_result'
+    csvFields: [{ name: testResult}]
+
+  - name: test_result_date  # Edited.  Was 'patient_results' to 'test_result_date'
+    csvFields: [{ name: testResultDate}]
+
+  - name: test_result_report_date
+    csvFields: [{ name: testReportDate}]
+
+  - name: specimen_collection_date_time
+    csvFields: [{ name: specimenCollectedDate}]
+
+  # Edited.  This appeared twice.  I eliminated one.  The other was csvField = 'deviceName'
+  #  Note:  value here should come from LIVD table
+  - name: equipment_model_name
+    csvFields: [{ name: deviceIdentifier}]
+
+  - name: equipment_instance_id     # Edited.  Was 'kit_id'
+    csvFields: [{ name: serialNumber}]
+
+  - name: patient_age
+    csvFields: [{ name: patientAge}]
+
+  - name: patient_zip_code   # Edited.  Was patient_zip
+    csvFields: [{ name: patientZip}]
+
+  - name: patient_county
+    csvFields: [{ name: patientCounty}]
+
+  - name: ordering_provider_id
+    csvFields: [{ name: orderingProviderNpi}]
+
+  - name: testing_lab_clia
+    csvFields: [{ name: performingFacility}]
+
+  - name: specimen_type
+    csvFields: [{ name: specimenSource}]
+
+  - name: patient_id    # Edited.  Was 'patient_dl'.
+    csvFields: [{ name: patientUniqueId}]
+
+  - name: patient_id_type    # Edited.  Added this, to complement patient_id.
+    csvFields: [{ name: patientUniqueId}]
+
+  - name: patient_dob
+    csvFields: [{ name: patientDob}]
+
+  - name: patient_last_name
+    csvFields: [{ name: patientNameLast}]
+
+  - name: patient_first_name
+    csvFields: [{ name: patientNameFirst}]
+
+  - name: patient_middle_name
+    csvFields: [{ name: patientNameMiddle}]
+
+  - name: patient_street
+    csvFields: [{ name: patientHomeAddress}]
+
+  - name: patient_street2
+    csvFields: [{ name: patientHomeAddress2}]
+
+  - name: patient_city
+    csvFields: [{ name: patientCity}]
+
+  - name: patient_state
+    csvFields: [{ name: patientState}]
+
+  - name: patient_phone_number    # Edited.  Was 'patient_callback_number'
+    csvFields: [{ name: patientPhone}]
+
+  - name: reporting_facility_name
+    csvFields: [{ name: reportingFacility}]
+
+  - name: order_test_date
+    csvFields: [{ name: testOrderedDate}]
+
+  - name: specimen_id
+    csvFields: [{ name: specimenId}]
+
+  - name: patient_race    # There was another one with csvField = patientRaceText.  Removed for now.
+    csvFields: [{ name: patientRace}]
+
+  - name: patient_ethnicity      # There was another one with csvField = patientEthnicityText.  Removed for now.
+    csvFields: [{ name: patientEthnicity}]
+
+  - name: patient_gender    # Edited.   Was patient_sex
+    csvFields: [{ name: patientSex}]
+
+  - name: ordering_provider_zip_code
+    csvFields: [{ name: orderingProviderZip}]
+
+  - name: testing_lab_zip_code
+    csvFields: [{ name: performingFacilityZip}]
+
+  - name: ordering_provider_street
+    csvFields: [{ name: orderingProviderAddress}]
+
+  - name: ordering_provider_street2
+    csvFields: [{ name: orderingProviderAddress2}]
+
+  - name: ordering_provider_city
+    csvFields: [{ name: orderingProviderCity}]
+
+  - name: ordering_provider_state
+    csvFields: [{ name: orderingProviderState}]
+
+  - name: ordering_provider_phone_number
+    csvFields: [{ name: orderingProviderPhone}]
+
+  - name: first_test
+    csvFields: [{ name: firstTest}]
+
+  - name: previous_test_type
+    type: TEXT
+    csvFields: [{ name: previousTestType}]
+
+  - name: previous_test_date
+    type: DATE
+    csvFields: [{ name: previousTestDate}]
+
+  - name: previous_test_result
+    type: TEXT
+    csvFields: [{ name: previousTestResult}]
+
+  - name: employed_in_healthcare
+    csvFields: [{ name: healthcareEmployee}]
+
+    # Edited.  Was 'healthcareEmployeeType - as I thought patient_role was more general.
+    # Eg, Staff, Resident, Visitor, Student are the values used in SimpleReport.
+  - name: patient_role 
+    csvFields: [{name: Patient_role}]
+    type: TEXT
+
+  - name: symptomatic_for_disease
+    csvFields: [{ name: symptomatic}]
+
+  - name: symptoms_list   # Edited.  Was 'patient_symptom_onset'
+    type: TEXT
+    csvFields: [{ name: symptomsList}]
+
+  - name: hospitalized
+    csvFields: [{ name: hospitalized}]
+
+  - name: hospitalized_test_result    # Edited.  Was 'hospitalized_code'.  The example value was a 'test_result' valueset value.
+    type: CODE
+    valueSet: covid-19/test_result
+    documentation: The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+    csvFields: [{ name: hospitalizedCode}]
+
+  - name: icu
+    csvFields: [{ name: symptomsIcu}]
+
+  - name: resident_congregate_setting
+    csvFields: [{ name: congregateResident}]
+
+  - name: site_of_care     # Edited name and now using the site_of_care valueset.
+    type: CODE
+    valueSet: site_of_care
+    csvFields: [{ name: congregateResidentType}]
+
+  - name: pregnant    # This appeared twice.  I eliminated one.  Edited.  was 'patient_pregnant'
+    csvFields: [{ name: pregnant}]
+
+  - name: patient_email
+    csvFields: [{ name: patientEmail}]
+
+  - name: ordered_test_name
+    csvFields: [{ name: testName}]
+
+  - name: abnormal_flag
+    csvFields: [{ name: testResultText}]
+
+  - name: test_performed_code
+    csvFields: [{ name: testPerformed}]
+
+  - name: ordering_provider_last_name
+    csvFields: [{ name: orderingProviderLname}]
+
+  - name: ordering_provider_first_name
+    csvFields: [{ name: orderingProviderFname}]
+
+  - name: patient_phone_area_code   # Edited this.
+    type: TEXT
+    csvFields: [{ name: patientPhoneAreaCode}]
+
+  - name: ordering_provider_phone_area_code
+    type: TEXT
+    csvFields: [{ name: orderingProviderPhoneAreaCode}]
+

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -11,6 +11,7 @@ elements:
 
   # Edited. Added 'ordering_facility_state', because it lets us test mapping to many of our states
   - name: ordering_facility_state
+    cardinality: ZERO_OR_ONE
     csvFields: [{ name: orderingFacilityState }]
 
   - name: test_result    # Edited.  Was 'patient_positive' to 'test_result'

--- a/prime-router/quick-test.sh
+++ b/prime-router/quick-test.sh
@@ -56,6 +56,7 @@ do
     vt | VT) RUN_VT=1;;
     mt | MT) RUN_MT=1;;
     ca | CA) RUN_CA=1;;
+    waters | WATERS) RUN_WATERS=1;;
     all | ALL) RUN_ALL=1;;
     merge | MERGE) RUN_MERGE=1;;
   esac
@@ -316,12 +317,24 @@ then
   parse_prime_output_for_filename "$text" "[/\\]mt.*\.hl7"
 fi
 
-# run vt
+# run CA
 if [ $RUN_CA -ne 0 ]
 then
   echo Generate fake CA data, CSV!
   text=$(./prime data --input-fake 50 --input-schema ca/ca-scc-covid-19 --output-dir $outputdir --target-states CA --target-counties 'Santa Clara' --output-format CSV)
   parse_prime_output_for_filename "$text" "[/\\]ca.*\.csv"
+fi
+
+# run Waters
+if [ $RUN_WATERS -ne 0 ]
+then
+  echo Generate fake WATERS data, CSV!
+  text=$(./prime data --input-fake 50 --input-schema waters/waters-covid-19 --output-dir $outputdir --target-states CA --target-counties 'Santa Clara' --output-format CSV)
+  parse_prime_output_for_filename "$text" "[/\\]waters.*\.csv"
+  actual_waters=$filename
+  echo Test sending WATERS data into its own Schema again:
+  text=$(./prime data --input-schema waters/waters-covid-19 --input $actual_waters --output-dir $outputdir)
+  parse_prime_output_for_filename "$text" "[/\\]waters.*\.csv"
 fi
 
 exit 0

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -12,6 +12,16 @@
         schemaName: primedatainput/pdi-covid-19
         format: CSV
 
+  - name: waters
+    description: Test Sender from Waters
+    jurisdiction: FEDERAL
+    senders:
+      - name: default
+        organizationName: waters
+        topic: covid-19-otc
+        schemaName: waters/waters-covid-19
+        format: CSV
+
   - name: strac
     description: STRAC POC testing app
     jurisdiction: FEDERAL
@@ -650,6 +660,29 @@
           numberPerDay: 1440
           initialTime: 00:00
           timeZone: EASTERN
+
+  - name: "hhsprotect"
+    description: "HHS Protect"
+    jurisdiction: "FEDERAL"
+    receivers:
+    - name: "elr"
+      organizationName: "hhsprotect"
+      topic: "covid-19-otc"
+      translation:
+        type: "CUSTOM"
+        schemaName: "waters/waters-covid-19"
+        format: "CSV"
+      deidentify: true
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1440
+        initialTime: "00:00"
+        timeZone: "EASTERN"
+      transport:
+        host: "sftp"
+        port: "22"
+        filePath: "./upload"
+        type: "SFTP"
 
   # 'ignore' is a test organization, designed to be safely usable across all our environments.
   # It has four receivers, each named _exactly_ the same as the format of data.

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -12,6 +12,16 @@
         schemaName: primedatainput/pdi-covid-19
         format: CSV
 
+  - name: waters
+    description: Test Sender from Waters
+    jurisdiction: FEDERAL
+    senders:
+      - name: default
+        organizationName: waters
+        topic: covid-19
+        schemaName: waters/waters-covid-19
+        format: CSV
+
   - name: strac
     description: STRAC POC testing app
     jurisdiction: FEDERAL
@@ -446,6 +456,29 @@
           numberPerDay: 1440
           initialTime: 00:00
           timeZone: EASTERN
+
+  - name: "hhsprotect"
+    description: "HHS Protect"
+    jurisdiction: "FEDERAL"
+    receivers:
+    - name: "elr"
+      organizationName: "hhsprotect"
+      topic: "covid-19-otc"
+      translation:
+        type: "CUSTOM"
+        schemaName: "waters/waters-covid-19"
+        format: "CSV"
+      deidentify: true
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1440
+        initialTime: "00:00"
+        timeZone: "EASTERN"
+      transport:
+        host: "sftp"
+        port: "22"
+        filePath: "./upload"
+        type: "SFTP"
 
   # 'ignore' is a test organization, designed to be safely usable across all our environments.
   # It has four receivers, each named _exactly_ the same as the format of data.

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -18,7 +18,7 @@
     senders:
       - name: default
         organizationName: waters
-        topic: covid-19
+        topic: covid-19-otc
         schemaName: waters/waters-covid-19
         format: CSV
 

--- a/prime-router/settings/staging/0001-hhsprotect.yml
+++ b/prime-router/settings/staging/0001-hhsprotect.yml
@@ -1,0 +1,34 @@
+---
+# Run this:   ./prime multiple-settings set --input ./settings/staging/0001-hhsprotect.yml --env staging
+- name: waters
+  description: Test Sender from Waters
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: waters
+      topic: covid-19-otc
+      schemaName: waters/waters-covid-19
+      format: CSV
+
+- name: "hhsprotect"
+  description: "HHS Protect"
+  jurisdiction: "FEDERAL"
+  receivers:
+  - name: "elr"
+    organizationName: "hhsprotect"
+    topic: "covid-19-otc"
+    translation:
+      type: "CUSTOM"
+      schemaName: "waters/waters-covid-19"
+      format: "CSV"
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+    transport:
+      type: SFTP
+      host: 10.0.2.4
+      port: 22
+      filePath: ./upload


### PR DESCRIPTION
This PR adds a working waters schema, so we can make changes to it.
For more readable version of the schema, look here: 
https://github.com/CDCgov/prime-data-hub/blob/jim/waters-schema/prime-router/docs/schema_documentation/waters-waters-covid-19.md

I made several of the value set fields to use the more human readable "display" value, so you can see how that works.   If those are still not human-readable enough, we can try the "$alt" feature to create ad-hoc valuesets.  I added one example of that.

I made one field, test_result, a set of "alternate values", including silly values, so you can see how to use that feature, to create expected inputs that might be more human readable if needed.

Commands to try using the schema - to generate fake data, then try to route it thru the system:
```
mkdir ./junk
./prime data --input-fake 1000 --input-schema waters/waters-covid-19 --output ./junk/waters.csv
./prime data --route --input ./junk/waters.csv --input-schema waters/waters-covid-19 --output-dir ./junk
```
