### PR TITLE
Onboarding NJ and MN

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -497,6 +497,60 @@
           initialTime: 00:00
           timeZone: EASTERN
 
+  - name: nj-doh
+    description: New Jersey Department of Health
+    jurisdiction: STATE
+    stateCode: NJ
+    receivers:
+      - name: elr
+        organizationName: nj-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, NJ)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: NJELR
+          receivingFacilityName: NJ-ELR
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
+
+  - name: mn-doh
+    description: Minnesota Department of Health
+    jurisdiction: STATE
+    stateCode: MN
+    receivers:
+      - name: elr
+        organizationName: mn-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, MN)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: MEDSS-ELR
+          receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
+          receivingFacilityName: MN DOH
+          receivingFacilityOID: 2.16.840.1.114222.4.1.3661
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
+
   - name: pa-phd
     description: Pennsylvania Department of Health
     jurisdiction: STATE

--- a/prime-router/settings/organizations-test.yml
+++ b/prime-router/settings/organizations-test.yml
@@ -441,6 +441,60 @@
         initialTime: 00:00
         timeZone: EASTERN
 
+- name: nj-doh
+  description: New Jersey Department of Health
+  jurisdiction: STATE
+  stateCode: NJ
+  receivers:
+    - name: elr
+      organizationName: nj-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, NJ)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: NJELR
+        receivingFacilityName: NJ-ELR
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
+      timing:
+        operation: MERGE
+        numberPerDay: 1440
+        initialTime: 00:00
+        timeZone: EASTERN
+
+- name: mn-doh
+  description: Minnesota Department of Health
+  jurisdiction: STATE
+  stateCode: MN
+  receivers:
+    - name: elr
+      organizationName: mn-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, MN)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: MEDSS-ELR
+        receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
+        receivingFacilityName: MN DOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3661
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload
+      timing:
+        operation: MERGE
+        numberPerDay: 1440
+        initialTime: 00:00
+        timeZone: EASTERN
+
 - name: co-phd
   description: Colorado Department of Health
   jurisdiction: STATE

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -296,6 +296,39 @@
           initialTime: 00:00
           timeZone: MOUNTAIN
 
+  - name: nj-doh
+    description: New Jersey Department of Health
+    jurisdiction: STATE
+    stateCode: NJ
+    receivers:
+      - name: elr
+        organizationName: nj-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, NJ)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: NJELR
+          receivingFacilityName: NJ-ELR
+
+  - name: mn-doh
+    description: Minnesota Department of Health
+    jurisdiction: STATE
+    stateCode: MN
+    receivers:
+      - name: elr
+        organizationName: mn-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - matches(ordering_facility_state, MN)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: MEDSS-ELR
+          receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
+          receivingFacilityName: MN DOH
+          receivingFacilityOID: 2.16.840.1.114222.4.1.3661
 
   - name: tx-doh
     description: Texas Department of Health

--- a/prime-router/settings/prod/0007-nj-doh.yml
+++ b/prime-router/settings/prod/0007-nj-doh.yml
@@ -1,0 +1,21 @@
+# NJ DOH elr connection
+- name: nj-doh
+  description: New Jersey Department of Health
+  jurisdiction: STATE
+  stateCode: NJ
+  receivers:
+    - name: elr
+      organizationName: nj-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, NJ)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: NJELR
+        receivingFacilityName: NJ-ELR
+      timing:
+        operation: MERGE
+        numberPerDay: 1 # once a day
+        initialTime: 09:15
+        timeZone: EASTERN

--- a/prime-router/settings/prod/0008-mn-doh.yml
+++ b/prime-router/settings/prod/0008-mn-doh.yml
@@ -1,0 +1,23 @@
+# MN DOH
+- name: mn-doh
+  description: Minnesota Department of Health
+  jurisdiction: STATE
+  stateCode: MN
+  receivers:
+    - name: elr
+      organizationName: mn-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, MN)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: MEDSS-ELR
+        receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
+        receivingFacilityName: MN DOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3661
+      timing:
+        operation: MERGE
+        numberPerDay: 1 # once a day
+        initialTime: 09:15
+        timeZone: EASTERN

--- a/prime-router/settings/staging/0001-nj-doh.yml
+++ b/prime-router/settings/staging/0001-nj-doh.yml
@@ -1,0 +1,26 @@
+# NJ DOH elr connection
+- name: nj-doh
+  description: New Jersey Department of Health
+  jurisdiction: STATE
+  stateCode: NJ
+  receivers:
+    - name: elr
+      organizationName: nj-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, NJ)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: NJELR
+        receivingFacilityName: NJ-ELR
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: EASTERN
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload

--- a/prime-router/settings/staging/0002-mn-doh.yml
+++ b/prime-router/settings/staging/0002-mn-doh.yml
@@ -1,0 +1,28 @@
+# MN DOH
+- name: mn-doh
+  description: Minnesota Department of Health
+  jurisdiction: STATE
+  stateCode: MN
+  receivers:
+    - name: elr
+      organizationName: mn-doh
+      topic: covid-19
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, MN)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        receivingApplicationName: MEDSS-ELR
+        receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
+        receivingFacilityName: MN DOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3661
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: CENTRAL
+      transport:
+        type: SFTP
+        host: 10.0.2.4
+        port: 22
+        filePath: ./upload


### PR DESCRIPTION
This PR adds entries in the organizations for MN and NJ. 

## Changes
- Adds MN to organization files
- Adds NJ to organization files
- Adds yamlitos to submit to staging and prod

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?



