### PR TITLE
Fixes issue with the synthesizer scrambling TOO MUCH data

### DIFF
--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -196,9 +196,9 @@ class FakeReport(val metadata: Metadata) {
             "BD Veritor System for Rapid Detection of SARS-CoV-2*"
         )
         // find our state
-        val state = reportState ?: randomChoice("FL", "PA", "TX", "AZ", "ND", "CO", "LA", "NM", "VT", "GU")
+        val state: String = reportState ?: randomChoice("FL", "PA", "TX", "AZ", "ND", "CO", "LA", "NM", "VT", "GU")
         // find our county
-        val county = reportCounty ?: findLookupTable("fips-county")?.let {
+        val county: String = reportCounty ?: findLookupTable("fips-county")?.let {
             when (state) {
                 "AZ" -> randomChoice("Pima", "Yuma")
                 "PA" -> randomChoice("Bucks", "Chester", "Montgomery")
@@ -217,7 +217,7 @@ class FakeReport(val metadata: Metadata) {
                 )
             )
         } ?: faker.address().zipCode().toString()
-        val city = findLookupTable("zip-code-data")?.let {
+        val city: String? = findLookupTable("zip-code-data")?.let {
             randomChoice(
                 it.filter(
                     "city",

--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -217,7 +217,7 @@ class FakeReport(val metadata: Metadata) {
                 )
             )
         } ?: faker.address().zipCode().toString()
-        val city: String? = findLookupTable("zip-code-data")?.let {
+        val city: String = findLookupTable("zip-code-data")?.let {
             randomChoice(
                 it.filter(
                     "city",
@@ -228,7 +228,7 @@ class FakeReport(val metadata: Metadata) {
                     )
                 )
             )
-        }
+        } ?: faker.address().city().toString()
     }
 
     internal fun buildColumn(element: Element, context: RowContext): String {

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -3,6 +3,7 @@ package gov.cdc.prime.router
 import gov.cdc.prime.router.azure.WorkflowEngine
 import gov.cdc.prime.router.azure.db.tables.pojos.ItemLineage
 import org.jooq.Meta
+import tech.tablesaw.api.Row
 import tech.tablesaw.api.StringColumn
 import tech.tablesaw.api.Table
 import tech.tablesaw.columns.Column
@@ -379,6 +380,10 @@ class Report {
         targetCounty: String? = null,
         metadata: Metadata,
     ): Report {
+        fun maybeSetString(row: Row, columnName: String, value: String) {
+            if (row.columnNames().contains(columnName))
+                row.setString(columnName, value)
+        }
         val columns = schema.elements.map {
             val synthesizedColumn = synthesizeStrategies[it.name]?.let { strategy ->
                 // we want to guard against the possibility that there are too few records
@@ -449,14 +454,10 @@ class Report {
                 schema.name,
                 targetCounty
             )
-            if (table.columnNames().contains("patient_county"))
-                it.setString("patient_county", context.county)
-            if (table.columnNames().contains("patient_city"))
-                it.setString("patient_city", context.city)
-            if (table.columnNames().contains("patient_state"))
-                it.setString("patient_state", context.state)
-            if (table.columnNames().contains("patient_zip_code"))
-                it.setString("patient_zip_code", context.zipCode)
+            maybeSetString(it, "patient_county", context.county)
+            maybeSetString(it, "patient_city", context.city)
+            maybeSetString(it, "patient_state", context.state)
+            maybeSetString(it, "patient_zip_code", context.zipCode)
         }
         // return the new copy of the report here
         return Report(schema, table, fromThisReport("synthesizeData"))

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -2,7 +2,6 @@ package gov.cdc.prime.router
 
 import gov.cdc.prime.router.azure.WorkflowEngine
 import gov.cdc.prime.router.azure.db.tables.pojos.ItemLineage
-import org.jooq.Meta
 import tech.tablesaw.api.Row
 import tech.tablesaw.api.StringColumn
 import tech.tablesaw.api.Table
@@ -380,7 +379,7 @@ class Report {
         targetCounty: String? = null,
         metadata: Metadata,
     ): Report {
-        fun maybeSetString(row: Row, columnName: String, value: String) {
+        fun safeSetStringInRow(row: Row, columnName: String, value: String) {
             if (row.columnNames().contains(columnName))
                 row.setString(columnName, value)
         }
@@ -454,10 +453,10 @@ class Report {
                 schema.name,
                 targetCounty
             )
-            maybeSetString(it, "patient_county", context.county)
-            maybeSetString(it, "patient_city", context.city)
-            maybeSetString(it, "patient_state", context.state)
-            maybeSetString(it, "patient_zip_code", context.zipCode)
+            safeSetStringInRow(it, "patient_county", context.county)
+            safeSetStringInRow(it, "patient_city", context.city)
+            safeSetStringInRow(it, "patient_state", context.state)
+            safeSetStringInRow(it, "patient_zip_code", context.zipCode)
         }
         // return the new copy of the report here
         return Report(schema, table, fromThisReport("synthesizeData"))

--- a/prime-router/src/test/kotlin/FakeReportTests.kt
+++ b/prime-router/src/test/kotlin/FakeReportTests.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
 import kotlin.test.fail
 
 internal class FakeReportTests {
@@ -194,5 +195,43 @@ internal class FakeReportTests {
         val actual = FakeReport(metadata).buildMappedColumn(concatField, rowContext)
         val expected = "Any lab USA, Any facility USA"
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `test row context getting expected zip code results`() {
+        // arrange
+        val metadata = Metadata("./metadata")
+        assertNotNull(metadata)
+        val zipCodeTable = metadata.findLookupTable("zip-code-data")
+        assertNotNull(zipCodeTable)
+        val state = "VT"
+        val county = "Rutland"
+        val matchingCityRows = zipCodeTable.filter(
+            "city",
+            mapOf(
+                "state_abbr" to state,
+                "county" to county
+            )
+        )
+        val matchingZipRows = zipCodeTable.filter(
+            "zipcode",
+            mapOf(
+                "state_abbr" to state,
+                "county" to county
+            )
+        )
+        // act
+        val context = FakeReport.RowContext(
+            metadata::findLookupTable,
+            state,
+            null,
+            county
+        )
+        println(matchingCityRows.joinToString())
+        println(matchingZipRows.joinToString())
+        println("${context.city} - ${context.zipCode}")
+        // assert
+        assert(matchingCityRows.contains(context.city))
+        assert(matchingZipRows.contains(context.zipCode))
     }
 }

--- a/prime-router/src/test/kotlin/LookupTableTests.kt
+++ b/prime-router/src/test/kotlin/LookupTableTests.kt
@@ -102,4 +102,26 @@ class LookupTableTests {
         val value = table.lookupValue("c", "c", "a", false)
         assertTrue(value.isNullOrEmpty())
     }
+
+    @Test
+    fun `test zip code lookup`() {
+        // arrange
+        val metadata = Metadata("./metadata")
+        val zipCodeTable = metadata.findLookupTable("zip-code-data")
+        val state = "VT"
+        val county = "Rutland"
+        val zipCode = "05701"
+        // act
+        val matchingRows = zipCodeTable?.filter(
+            "city",
+            mapOf(
+                "state_abbr" to state,
+                "county" to county,
+                "zipcode" to zipCode
+            )
+        )
+        // assert
+        assertTrue(matchingRows?.isNotEmpty() == true)
+        assertTrue(matchingRows?.getOrElse(0) { null } == "Rutland")
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where the synthesizer is scrambling the data TOO much by recreating the row context for every single row in every single column. This ended up causing a problem where city, state, zip, and county would not match because they were all randomized.

Now, after the generation of the columns, we loop through the rows and set the city, state, zip, and county to the tied values created in the RowContext. This is obviously more expensive, but it's a more correct way to accomplish our goal. 

## Changes
- Adds new tests to verify that filtering of tables works
- Adds new test to verify that the chaining of lookup values in the `RowContext` works as expected
- Adds logic to walk the rows and set the address information to something that is correct

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [x] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


