### PR TITLE
Storage account for HHS protect

### DIFF
--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -213,6 +213,98 @@ resource "azurerm_storage_account" "storage_public" {
 }
 
 
+// Partner
+
+resource "azurerm_storage_account" "storage_partner" {
+  resource_group_name = var.resource_group
+  name = "${var.resource_prefix}partner"
+  location = var.location
+  account_tier = "Standard"
+  account_kind = "StorageV2"
+  account_replication_type = "GRS"
+  min_tls_version = "TLS1_2"
+  allow_blob_public_access = false
+
+  network_rules {
+    default_action = "Deny"
+    ip_rules = []
+    virtual_network_subnet_ids = [var.public_subnet_id]
+  }
+
+  # Required for customer-managed encryption
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    environment = var.environment
+  }
+}
+
+# Grant the storage account Key Vault access, to access encryption keys
+resource "azurerm_key_vault_access_policy" "storage_partner_policy" {
+  key_vault_id = var.key_vault_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = azurerm_storage_account.storage_partner.identity.0.principal_id
+
+  key_permissions = ["get", "unwrapkey", "wrapkey"]
+}
+
+resource "azurerm_storage_account_customer_managed_key" "storage_partner_key" {
+  count = var.rsa_key_4096 != null && var.rsa_key_4096 != "" ? 1 : 0
+  key_name = var.rsa_key_4096
+  key_vault_id = var.key_vault_id
+  key_version = null // Null allows automatic key rotation
+  storage_account_id = azurerm_storage_account.storage_partner.id
+
+  depends_on = [azurerm_key_vault_access_policy.storage_partner_policy]
+}
+
+module "storageaccountpartner_blob_private_endpoint" {
+  source = "../common/private_endpoint"
+  resource_id = azurerm_storage_account.storage_partner.id
+  name = azurerm_storage_account.storage_partner.name
+  type = "storage_account_blob"
+  resource_group = var.resource_group
+  location = var.location
+  endpoint_subnet_id = var.endpoint_subnet_id
+}
+
+resource "azurerm_storage_container" "storage_container_hhsprotect" {
+  name = "hhsprotect"
+  storage_account_name = azurerm_storage_account.storage_partner.name
+}
+
+resource "azurerm_storage_management_policy" "storage_partner_retention_policy" {
+  storage_account_id = azurerm_storage_account.storage_partner.id
+
+  rule {
+    name = "30dayretention"
+    enabled = true
+
+    filters {
+      prefix_match = ["hhsprotect/"]
+      blob_types = ["blockBlob", "appendBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 30
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = 30
+      }
+      # Terraform does not appear to support deletion of versions
+      # This needs to be manually checked in the policy and set to 30 days
+    }
+  }
+}
+
+
 
 output "storage_account_name" {
   value = azurerm_storage_account.storage_account.name


### PR DESCRIPTION
This PR creates a partner-specific storage account for HHS Protect exports.

## Changes
- Creates a partner storage account
- Sets up a private endpoint for the storage account
- Encrypts the storage account using CDC encryption keys
- Creates a blob container `hhsprotect` for HHS Protect files
- Adds a storage policy to delete files after 30 days

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
* Azure policy will automatically capture logs
* IP addresses of HHS Protect will not be exposed in logs
* A separate storage account was created to maintain separation of concerns

## To Be Done
* After deployment, configure access keys for HHS Protect

