### PR TITLE
Fixes issue with bad jurisdictional filter

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -542,7 +542,7 @@
         organizationName: mn-doh
         topic: covid-19
         jurisdictionalFilter:
-          - matches(ordering_facility_state, MN)
+          - orEquals(ordering_facility_state, MN, patient_state, MN)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -570,7 +570,7 @@
         organizationName: wi-dph
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, WI, patient_state, WI)
+          - orEquals(ordering_facility_state, WI, patient_state, WI)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -594,7 +594,7 @@
         organizationName: tn-doh
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, TN, patient_state, TN)
+          - orEquals(ordering_facility_state, TN, patient_state, TN)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -622,7 +622,7 @@
         organizationName: ms-doh
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, MS, patient_state, MS)
+          - orEquals(ordering_facility_state, MS, patient_state, MS)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -648,7 +648,7 @@
         organizationName: nc-dph
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, NC, patient_state, NC)
+          - orEquals(ordering_facility_state, NC, patient_state, NC)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -676,7 +676,7 @@
         organizationName: de-dph
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, DE, patient_state, DE)
+          - orEquals(ordering_facility_state, DE, patient_state, DE)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -700,7 +700,7 @@
         organizationName: ca-dph
         topic: covid-19
         jurisdictionalFilter:
-          - or(ordering_facility_state, CA, patient_state, CA)
+          - orEquals(ordering_facility_state, CA, patient_state, CA)
         translation:
           type: HL7
           useBatchHeaders: true

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -391,6 +391,160 @@
           receivingFacilityName: VDH
           receivingFacilityOID: 2.16.840.1.114222.4.1.185
 
+  - name: wi-dph
+    description: Wisconsin Department of Public Health
+    jurisdiction: STATE
+    stateCode: WI
+    receivers:
+      - name: elr
+        organizationName: wi-dph
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, WI, patient_state, WI)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
+
+      - name: tn-doh
+        description: Tennessee Department of Health
+        jurisdiction: STATE
+        stateCode: TN
+        receivers:
+          - name: elr
+            organizationName: tn-doh
+            topic: covid-19
+            jurisdictionalFilter:
+              - orEquals(ordering_facility_state, TN, patient_state, TN)
+            translation:
+              type: HL7
+              useBatchHeaders: true
+              receivingApplicationName: tdh-ELR
+              receivingApplicationOID: 2.16.840.1.113883.3.773.1.1.3
+              receivingFacilityName: TDH
+              receivingFacilityOID: 2.16.840.1.113883.3.773
+            transport:
+              type: SFTP
+              host: sftp
+              port: 22
+              filePath: ./upload
+            timing:
+              operation: MERGE
+              numberPerDay: 1440
+              initialTime: 00:00
+              timeZone: EASTERN
+
+      - name: ms-doh
+        description: Mississippi Department of Health
+        jurisdiction: STATE
+        stateCode: MS
+        receivers:
+          - name: elr
+            organizationName: ms-doh
+            topic: covid-19
+            jurisdictionalFilter:
+              - orEquals(ordering_facility_state, MS, patient_state, MS)
+            translation:
+              type: HL7
+              useBatchHeaders: true
+              receivingApplicationName: MSDH-ELR
+              receivingFacilityName: MSDOH
+            transport:
+              type: SFTP
+              host: sftp
+              port: 22
+              filePath: ./upload
+            timing:
+              operation: MERGE
+              numberPerDay: 1440
+              initialTime: 00:00
+              timeZone: EASTERN
+
+      - name: nc-dph
+        description: North Carolina Division of Public Health
+        jurisdiction: STATE
+        stateCode: NC
+        receivers:
+          - name: elr
+            organizationName: nc-dph
+            topic: covid-19
+            jurisdictionalFilter:
+              - orEquals(ordering_facility_state, NC, patient_state, NC)
+            translation:
+              type: HL7
+              useBatchHeaders: true
+              receivingApplicationName: NCDPH NCEDSS
+              receivingApplicationOID: 2.16.840.1.113883.3.591.3.1
+              receivingFacilityName: NCDPH EDS
+              receivingFacilityOID: 2.16.840.1.113883.3.591.1.1
+            transport:
+              type: SFTP
+              host: sftp
+              port: 22
+              filePath: ./upload
+            timing:
+              operation: MERGE
+              numberPerDay: 1440
+              initialTime: 00:00
+              timeZone: EASTERN
+
+      - name: de-dph
+        description: Delaware Division of Public Health
+        jurisdiction: STATE
+        stateCode: DE
+        receivers:
+          - name: elr
+            organizationName: de-dph
+            topic: covid-19
+            jurisdictionalFilter:
+              - orEquals(ordering_facility_state, DE, patient_state, DE)
+            translation:
+              type: HL7
+              useBatchHeaders: true
+            transport:
+              type: SFTP
+              host: sftp
+              port: 22
+              filePath: ./upload
+            timing:
+              operation: MERGE
+              numberPerDay: 1440
+              initialTime: 00:00
+              timeZone: EASTERN
+
+      - name: ca-dph
+        description: California Department of Public Health
+        jurisdiction: STATE
+        stateCode: CA
+        receivers:
+          - name: elr
+            organizationName: ca-dph
+            topic: covid-19
+            jurisdictionalFilter:
+              - orEquals(ordering_facility_state, CA, patient_state, CA)
+            translation:
+              type: HL7
+              useBatchHeaders: true
+            transport:
+              type: SFTP
+              host: sftp
+              port: 22
+              filePath: ./upload
+            timing:
+              operation: MERGE
+              numberPerDay: 1440
+              initialTime: 00:00
+              timeZone: EASTERN
+
   - name: pa-phd
     description: Pennsylvania Department of Health
     jurisdiction: STATE

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -415,135 +415,135 @@
           initialTime: 00:00
           timeZone: EASTERN
 
-      - name: tn-doh
-        description: Tennessee Department of Health
-        jurisdiction: STATE
-        stateCode: TN
-        receivers:
-          - name: elr
-            organizationName: tn-doh
-            topic: covid-19
-            jurisdictionalFilter:
-              - orEquals(ordering_facility_state, TN, patient_state, TN)
-            translation:
-              type: HL7
-              useBatchHeaders: true
-              receivingApplicationName: tdh-ELR
-              receivingApplicationOID: 2.16.840.1.113883.3.773.1.1.3
-              receivingFacilityName: TDH
-              receivingFacilityOID: 2.16.840.1.113883.3.773
-            transport:
-              type: SFTP
-              host: sftp
-              port: 22
-              filePath: ./upload
-            timing:
-              operation: MERGE
-              numberPerDay: 1440
-              initialTime: 00:00
-              timeZone: EASTERN
+  - name: tn-doh
+    description: Tennessee Department of Health
+    jurisdiction: STATE
+    stateCode: TN
+    receivers:
+      - name: elr
+        organizationName: tn-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, TN, patient_state, TN)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: tdh-ELR
+          receivingApplicationOID: 2.16.840.1.113883.3.773.1.1.3
+          receivingFacilityName: TDH
+          receivingFacilityOID: 2.16.840.1.113883.3.773
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
 
-      - name: ms-doh
-        description: Mississippi Department of Health
-        jurisdiction: STATE
-        stateCode: MS
-        receivers:
-          - name: elr
-            organizationName: ms-doh
-            topic: covid-19
-            jurisdictionalFilter:
-              - orEquals(ordering_facility_state, MS, patient_state, MS)
-            translation:
-              type: HL7
-              useBatchHeaders: true
-              receivingApplicationName: MSDH-ELR
-              receivingFacilityName: MSDOH
-            transport:
-              type: SFTP
-              host: sftp
-              port: 22
-              filePath: ./upload
-            timing:
-              operation: MERGE
-              numberPerDay: 1440
-              initialTime: 00:00
-              timeZone: EASTERN
+  - name: ms-doh
+    description: Mississippi Department of Health
+    jurisdiction: STATE
+    stateCode: MS
+    receivers:
+      - name: elr
+        organizationName: ms-doh
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, MS, patient_state, MS)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: MSDH-ELR
+          receivingFacilityName: MSDOH
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
 
-      - name: nc-dph
-        description: North Carolina Division of Public Health
-        jurisdiction: STATE
-        stateCode: NC
-        receivers:
-          - name: elr
-            organizationName: nc-dph
-            topic: covid-19
-            jurisdictionalFilter:
-              - orEquals(ordering_facility_state, NC, patient_state, NC)
-            translation:
-              type: HL7
-              useBatchHeaders: true
-              receivingApplicationName: NCDPH NCEDSS
-              receivingApplicationOID: 2.16.840.1.113883.3.591.3.1
-              receivingFacilityName: NCDPH EDS
-              receivingFacilityOID: 2.16.840.1.113883.3.591.1.1
-            transport:
-              type: SFTP
-              host: sftp
-              port: 22
-              filePath: ./upload
-            timing:
-              operation: MERGE
-              numberPerDay: 1440
-              initialTime: 00:00
-              timeZone: EASTERN
+  - name: nc-dph
+    description: North Carolina Division of Public Health
+    jurisdiction: STATE
+    stateCode: NC
+    receivers:
+      - name: elr
+        organizationName: nc-dph
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, NC, patient_state, NC)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+          receivingApplicationName: NCDPH NCEDSS
+          receivingApplicationOID: 2.16.840.1.113883.3.591.3.1
+          receivingFacilityName: NCDPH EDS
+          receivingFacilityOID: 2.16.840.1.113883.3.591.1.1
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
 
-      - name: de-dph
-        description: Delaware Division of Public Health
-        jurisdiction: STATE
-        stateCode: DE
-        receivers:
-          - name: elr
-            organizationName: de-dph
-            topic: covid-19
-            jurisdictionalFilter:
-              - orEquals(ordering_facility_state, DE, patient_state, DE)
-            translation:
-              type: HL7
-              useBatchHeaders: true
-            transport:
-              type: SFTP
-              host: sftp
-              port: 22
-              filePath: ./upload
-            timing:
-              operation: MERGE
-              numberPerDay: 1440
-              initialTime: 00:00
-              timeZone: EASTERN
+  - name: de-dph
+    description: Delaware Division of Public Health
+    jurisdiction: STATE
+    stateCode: DE
+    receivers:
+      - name: elr
+        organizationName: de-dph
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, DE, patient_state, DE)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
 
-      - name: ca-dph
-        description: California Department of Public Health
-        jurisdiction: STATE
-        stateCode: CA
-        receivers:
-          - name: elr
-            organizationName: ca-dph
-            topic: covid-19
-            jurisdictionalFilter:
-              - orEquals(ordering_facility_state, CA, patient_state, CA)
-            translation:
-              type: HL7
-              useBatchHeaders: true
-            transport:
-              type: SFTP
-              host: sftp
-              port: 22
-              filePath: ./upload
-            timing:
-              operation: MERGE
-              numberPerDay: 1440
-              initialTime: 00:00
-              timeZone: EASTERN
+  - name: ca-dph
+    description: California Department of Public Health
+    jurisdiction: STATE
+    stateCode: CA
+    receivers:
+      - name: elr
+        organizationName: ca-dph
+        topic: covid-19
+        jurisdictionalFilter:
+          - orEquals(ordering_facility_state, CA, patient_state, CA)
+        translation:
+          type: HL7
+          useBatchHeaders: true
+        transport:
+          type: SFTP
+          host: sftp
+          port: 22
+          filePath: ./upload
+        timing:
+          operation: MERGE
+          numberPerDay: 1440
+          initialTime: 00:00
+          timeZone: EASTERN
 
   - name: pa-phd
     description: Pennsylvania Department of Health

--- a/prime-router/settings/prod/0011-imagemover-orgs.yml
+++ b/prime-router/settings/prod/0011-imagemover-orgs.yml
@@ -7,7 +7,7 @@
       organizationName: wi-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, WI, patient_state, WI)
+        - orEquals(ordering_facility_state, WI, patient_state, WI)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -26,7 +26,7 @@
       organizationName: tn-doh
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, TN, patient_state, TN)
+        - orEquals(ordering_facility_state, TN, patient_state, TN)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -49,7 +49,7 @@
       organizationName: ms-doh
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, MS, patient_state, MS)
+        - orEquals(ordering_facility_state, MS, patient_state, MS)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -70,7 +70,7 @@
       organizationName: nc-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, NC, patient_state, NC)
+        - orEquals(ordering_facility_state, NC, patient_state, NC)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -93,7 +93,7 @@
       organizationName: de-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, DE, patient_state, DE)
+        - orEquals(ordering_facility_state, DE, patient_state, DE)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -112,7 +112,7 @@
       organizationName: ca-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, CA, patient_state, CA)
+        - orEquals(ordering_facility_state, CA, patient_state, CA)
       translation:
         type: HL7
         useBatchHeaders: true

--- a/prime-router/settings/staging/0004-imagemover-orgs.yml
+++ b/prime-router/settings/staging/0004-imagemover-orgs.yml
@@ -7,7 +7,7 @@
       organizationName: wi-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, WI, patient_state, WI)
+        - orEquals(ordering_facility_state, WI, patient_state, WI)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -31,7 +31,7 @@
       organizationName: tn-doh
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, TN, patient_state, TN)
+        - orEquals(ordering_facility_state, TN, patient_state, TN)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -59,7 +59,7 @@
       organizationName: ms-doh
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, MS, patient_state, MS)
+        - orEquals(ordering_facility_state, MS, patient_state, MS)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -85,7 +85,7 @@
       organizationName: nc-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, NC, patient_state, NC)
+        - orEquals(ordering_facility_state, NC, patient_state, NC)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -113,7 +113,7 @@
       organizationName: de-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, DE, patient_state, DE)
+        - orEquals(ordering_facility_state, DE, patient_state, DE)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -137,7 +137,7 @@
       organizationName: ca-dph
       topic: covid-19
       jurisdictionalFilter:
-        - or(ordering_facility_state, CA, patient_state, CA)
+        - orEquals(ordering_facility_state, CA, patient_state, CA)
       translation:
         type: HL7
         useBatchHeaders: true


### PR DESCRIPTION
This PR fixes a problem with the jurisdictional filter.

## Changes
- It's `orEquals` not `or`.

## Checklist
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

