### PR TITLE
HHS Protect Blob Storage Changes

### DIFF
--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -221,6 +221,7 @@ resource "azurerm_storage_account" "storage_partner" {
   location = var.location
   account_tier = "Standard"
   account_kind = "StorageV2"
+  is_hns_enabled = true # This enable Data Lake v2 for HHS Protect
   account_replication_type = "GRS"
   min_tls_version = "TLS1_2"
   allow_blob_public_access = false

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -228,7 +228,7 @@ resource "azurerm_storage_account" "storage_partner" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = []
+    ip_rules = split(",", data.azurerm_key_vault_secret.hhsprotect_ip_ingress.value)
     virtual_network_subnet_ids = [var.public_subnet_id]
   }
 
@@ -244,6 +244,11 @@ resource "azurerm_storage_account" "storage_partner" {
   tags = {
     environment = var.environment
   }
+}
+
+data "azurerm_key_vault_secret" "hhsprotect_ip_ingress" {
+  name = "hhsprotect-ip-ingress"
+  key_vault_id = var.key_vault_id
 }
 
 # Grant the storage account Key Vault access, to access encryption keys


### PR DESCRIPTION
This PR makes some changes to our partner storage account, allowing HHS Protect to connect.

## Changes
- Switches the blob storage container to using "HNS" or hierarchical namespace. This allows the blob storage to accept Hadoop data connectors.
- Whitelists HHS Protect's ip addresses.

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
* HHS Protect IP addresses are stored in the Key Vault as a secret, to not expose their IPs
