### PR TITLE
Add Jim/Mo Key Vault Permissions + Container Restart Playbook

### DIFF
--- a/operations/app/src/modules/key_vault/main.tf
+++ b/operations/app/src/modules/key_vault/main.tf
@@ -5,14 +5,20 @@ terraform {
 locals {
   # These object ids correspond to developers with access
   # to key vault
-                     # Richard Teasley
-  dev_object_ids = [ "34232fe8-00ad-4bd0-9afb-eb9b3cc93ffe",
-                     # IAMB-Prod-KV
-                     "cd341fbc-26a3-405c-a350-c4237a27aa93",
-                     # Ron Heft
-                     "637fb7df-c200-4e0d-ba86-608576acb786",
-                     # Chris Glodosky
-                     "aabc25d7-dd99-42b9-8f3a-fd593b1f229a" ]
+  dev_object_ids = [
+    # Richard Teasley
+    "34232fe8-00ad-4bd0-9afb-eb9b3cc93ffe",
+    # IAMB-Prod-KV
+    "cd341fbc-26a3-405c-a350-c4237a27aa93",
+    # Ron Heft
+    "637fb7df-c200-4e0d-ba86-608576acb786",
+    # Maurice Reeves
+    "414537da-0ba5-4db1-93f6-dd828e9a480a",
+    # Jim Duff
+    "24669a80-a2d3-425a-8c80-92e05ea8341f",
+    # Chris Glodosky
+    "aabc25d7-dd99-42b9-8f3a-fd593b1f229a"
+  ]
 
   frontdoor_object_id = "270e4d1a-12bd-4564-8a4b-c9de1bbdbe95"
 }

--- a/prime-router/docs/playbooks/dns_or_sftp_restart.md
+++ b/prime-router/docs/playbooks/dns_or_sftp_restart.md
@@ -1,0 +1,17 @@
+## Conditions
+
+In the event the DNS or SFTP containers terminate unexpectingly they can be restarted via the command line.
+
+### Actions
+
+## Login to the Azure CLI
+
+```
+az login
+```
+
+## Restart the container
+
+```
+az container restart --name [container_name] --resource-group [resource_group] --no-wait
+```


### PR DESCRIPTION
This PR grants @mauricereeves and @jimduff-usds access to the Key Vaults, so they can administer credentials.

## Changes
- Adds Mo and Jim to the list of developer credentials.
- During deployment, it was discovered our DNS servers have all stopped over night, so it could not be deployed out. This PR also includes the directions to restart the DNS servers.

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [x] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
* Individually adding developers to resources is not the long term plan. We will be creating groups in #CDCGov/prime-devops#37

