### PR TITLE
Fixes jurisdictional filter bug

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -731,7 +731,7 @@
         organizationName: ma-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MA, patient_state, MA)
+          - orEquals(ordering_facility_state, MA, patient_state, MA)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -755,7 +755,7 @@
         organizationName: nh-dphs
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, NH, patient_state, NH)
+          - orEquals(ordering_facility_state, NH, patient_state, NH)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -782,7 +782,7 @@
         organizationName: al-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, AL, patient_state, AL)
+          - orEquals(ordering_facility_state, AL, patient_state, AL)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -806,7 +806,7 @@
         organizationName: mi-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MI, patient_state, MI)
+          - orEquals(ordering_facility_state, MI, patient_state, MI)
         translation:
           type: HL7
           useBatchHeaders: true

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -554,7 +554,7 @@
         organizationName: ma-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MA, patient_state, MA)
+          - orEquals(ordering_facility_state, MA, patient_state, MA)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -568,7 +568,7 @@
         organizationName: nh-dphs
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, NH, patient_state, NH)
+          - orEquals(ordering_facility_state, NH, patient_state, NH)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -585,7 +585,7 @@
         organizationName: al-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, AL, patient_state, AL)
+          - orEquals(ordering_facility_state, AL, patient_state, AL)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -599,7 +599,7 @@
         organizationName: mi-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MI, patient_state, MI)
+          - orEquals(ordering_facility_state, MI, patient_state, MI)
         translation:
           type: HL7
           useBatchHeaders: true

--- a/prime-router/settings/prod/0012-nh-ma-organizations.yml
+++ b/prime-router/settings/prod/0012-nh-ma-organizations.yml
@@ -7,7 +7,7 @@
       organizationName: ma-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, MA, patient_state, MA)
+        - orEquals(ordering_facility_state, MA, patient_state, MA)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -26,7 +26,7 @@
       organizationName: nh-dphs
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, NH, patient_state, NH)
+        - orEquals(ordering_facility_state, NH, patient_state, NH)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -48,7 +48,7 @@
       organizationName: al-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, AL, patient_state, AL)
+        - orEquals(ordering_facility_state, AL, patient_state, AL)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -67,7 +67,7 @@
       organizationName: mi-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, MI, patient_state, MI)
+        - orEquals(ordering_facility_state, MI, patient_state, MI)
       translation:
         type: HL7
         useBatchHeaders: true

--- a/prime-router/settings/staging/0005-nh-ma-organizations.yml
+++ b/prime-router/settings/staging/0005-nh-ma-organizations.yml
@@ -7,7 +7,7 @@
       organizationName: ma-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, MA, patient_state, MA)
+        - orEquals(ordering_facility_state, MA, patient_state, MA)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -31,7 +31,7 @@
       organizationName: nh-dphs
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, NH, patient_state, NH)
+        - orEquals(ordering_facility_state, NH, patient_state, NH)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -58,7 +58,7 @@
       organizationName: al-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, AL, patient_state, AL)
+        - orEquals(ordering_facility_state, AL, patient_state, AL)
       translation:
         type: HL7
         useBatchHeaders: true
@@ -82,7 +82,7 @@
       organizationName: mi-phd
       topic: covid-19
       jurisdictionalFilter:
-        - orElse(ordering_facility_state, MI, patient_state, MI)
+        - orEquals(ordering_facility_state, MI, patient_state, MI)
       translation:
         type: HL7
         useBatchHeaders: true


### PR DESCRIPTION
This PR fixes a bug with the organizations where I tried to use `orElse` instead of `orEquals`. 

## Changes
- Fixes issue with organizations I introduced

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

