### PR TITLE
508 tweaks

### DIFF
--- a/frontend/src/_data/content/index.yaml
+++ b/frontend/src/_data/content/index.yaml
@@ -1,9 +1,9 @@
 ---
 title: ReportStream makes it easier to share public health data
 summary: >-
-  ReportStream is a free, open-sourced data platform that makes it easier for public health data to be more easily transferred between senders and public health departments
+  ReportStream is a free, open source data platform that makes it easier for public health data to be more easily transferred between senders and public health departments
 heroImg: report-stream-application.png
-heroImgAlt: Screenshot of the ReportStream web application
+heroImgAlt: Example screenshot of the ReportStream web application
 
 partners:
   - type: State

--- a/frontend/src/_includes/identifier.liquid
+++ b/frontend/src/_includes/identifier.liquid
@@ -1,25 +1,16 @@
-<div class="usa-identifier">
-  <section
-    class="usa-identifier__section usa-identifier__section--masthead"
-    aria-label="Agency identifier">
+<footer class="usa-identifier" aria-label="Agency identifier">
+  <section class="usa-identifier__section usa-identifier__section--masthead"
+    >
     <div class="usa-identifier__container"><div class="usa-identifier__logos">
-        <a href="javascript:void(0);" class="usa-identifier__logo">
-          <img
-            class="usa-identifier__logo-img"
-            
-            src="https://upload.wikimedia.org/wikipedia/commons/4/45/US-CDC-Logo.png"
-            
-            
-            alt="CDC logo"
-            
-            role="img">
+        <a href="{{ site.orgs.CDC.url }}" class="usa-identifier__logo">
+          <img class="usa-identifier__logo-img" src="{{ site.imgPath }}/cdc-logo.svg" alt="CDC logo" role="img">
         </a></div><div class="usa-identifier__identity" aria-label="Agency description">
         <p class="usa-identifier__identity-domain">cdc.gov</p>
-        <p class="usa-identifier__identity-disclaimer">An official website of the <a href="http://cdc.gov">Centers for Disease Control and Prevention</a></p>
+        <p class="usa-identifier__identity-disclaimer">An official website of the <a href="{{ site.orgs.CDC.url }}">{{ site.orgs.CDC.name }}</a></p>
       </div>
     </div>
   </section>
-  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
+  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Footer navigation">
     <div class="usa-identifier__container">
       <ul class="usa-identifier__required-links-list">
         <li class="usa-identifier__required-links-item">
@@ -52,4 +43,4 @@
       <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
     </div>
   </section>
-  </div>
+</footer>

--- a/frontend/src/_layouts/protected.liquid
+++ b/frontend/src/_layouts/protected.liquid
@@ -54,9 +54,7 @@ local_styles:
 {% endif %}
 </main>
 
-<section>
-  {% include identifier %}
-</section>
+{% include identifier %}
 
   {% for entry in post_scripts %}
     <script src="{{entry.src}}" integrity="{{entry.integrity}}" crossorigin="anonymous"></script>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,7 +9,7 @@ show_menu: false
 
 <div id="main-content">
 
-  <section class="rs-hero">
+  <section class="rs-hero" role="region">
     <div class="grid-container usa-section margin-bottom-0">
       <div class="grid-row grid-gap margin-bottom-0 rs-hero__flex-center">
         <div class="tablet:grid-col-6">
@@ -17,14 +17,14 @@ show_menu: false
           <p class="font-sans-lg line-height-sans-4">{{ content.index.summary }}</p>
         </div>
         <div class="tablet:grid-col-6">
-          <img class="shadow-2" src="{{ site.imgPath }}{{ content.index.heroImg }}" alt="{{ content.index.heroImgAlt }}" />
+          <img class="shadow-2" src="{{ site.imgPath }}{{ content.index.heroImg }}" title="{{ content.index.heroImgAlt }}" />
         </div>
       </div>
     </div>
   </section>
 
-  <section class="grid-container usa-section margin-bottom-0 padding-bottom-0">
-    {% for partner in content.index.partners %}
+  {% for partner in content.index.partners %}
+    <section class="grid-container usa-section margin-bottom-0 padding-bottom-0" role="region">
       <div class="grid-row grid-gap margin-top-4 margin-bottom-1">
         <div class="tablet:grid-col-8">
           <h2 class="font-sans-xl margin-top-0 tablet:margin-bottom-0">{{ partner.title }}</h2>
@@ -42,10 +42,10 @@ show_menu: false
           </div>
         {% endfor %}
       </div>
-    {% endfor %}
-  </section>
+    </section>
+  {% endfor %}
 
-  <section class="grid-container usa-section margin-top-0 padding-top-0">
+  <section class="grid-container usa-section margin-y-0 padding-y-0" role="region">
     <div class="grid-row grid-gap  margin-bottom-2 padding-top-2">
       <div class="tablet:grid-col-8">
         <h2 class="font-sans-xl margin-top-0 tablet:margin-bottom-0">{{ content.index.documentation.title }}</h2>
@@ -59,12 +59,14 @@ show_menu: false
             <div class="usa-card__body">
               <img src="{{ site.imgPath }}file_present.svg" class="usa-icon--size-4 float-left margin-right-3" aria-hidden="true" focusable="false" alt="Icon of an attached document"/>
               <h3 class="usa-collection__heading">{{file.name}}</h3>
-              <a class="usa-link" href="{{ site.pdfPath }}{{ file.url }}">Download PDF</a>
+              <a class="usa-link" aria-label="Download PDF copy of '{{ file.name }}'" href="{{ site.pdfPath }}{{ file.url }}">Download PDF</a>
             </div>
           </div>
         </li>
       {% endfor %}
     </ul>
+  </section>
+  <section class="grid-container usa-section margin-top-0 padding-top-0" role="region">
     <div class="grid-row grid-gap  margin-bottom-2 padding-top-4">
       <div class="tablet:grid-col-8">
         <h2 class="font-sans-xl margin-top-0 tablet:margin-bottom-0">{{ content.index.cta.title }}</h2>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -17,7 +17,7 @@ show_menu: false
           <p class="font-sans-lg line-height-sans-4">{{ content.index.summary }}</p>
         </div>
         <div class="tablet:grid-col-6">
-          <img class="shadow-2" src="{{ site.imgPath }}{{ content.index.heroImg }}" title="{{ content.index.heroImgAlt }}" />
+          <img class="shadow-2" src="{{ site.imgPath }}{{ content.index.heroImg }}" alt="{{ content.index.heroImgAlt }}" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR ... 

Fixes #829 and makes some 508-ish related updates.

## Changes
- Add `aria-label` to PDF download links on homepage
- Move product img text from `alt` to `title`
- Turn `div usa-identifier` into `footer`
- Add labels to footer
- Add more sections to main with `role=region`
- Remove multiple main elements in layout

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

