### PR TITLE
#763: Front Door static site changes

### DIFF
--- a/operations/app/src/modules/front_door/main.tf
+++ b/operations/app/src/modules/front_door/main.tf
@@ -10,10 +10,10 @@ locals {
   metabase_address = (var.environment == "test" || var.environment == "prod" ? "${var.resource_prefix}-metabase.azurewebsites.net" : null)
   static_address = trimprefix(trimsuffix(var.storage_web_endpoint, "/"), "https://")
 
-  function_certs = [for cert in var.https_cert_names: cert if regex("^[[:alnum:]]*?-?prime.*$", cert)]
+  function_certs = [for cert in var.https_cert_names: cert if length(regexall("^[[:alnum:]]*?-?prime.*$", cert)) > 0]
   frontend_endpoints = (length(local.function_certs) > 0) ? concat(["DefaultFrontendEndpoint"], local.function_certs) : ["DefaultFrontendEndpoint"]
 
-  static_certs = [for cert in var.https_cert_names: cert if regex("^[[:alnum:]]*?-?reportstream.*$", cert)]
+  static_certs = [for cert in var.https_cert_names: cert if length(regexall("^[[:alnum:]]*?-?reportstream.*$", cert)) > 0]
   static_endpoints = local.static_certs
 
   metabase_env = var.environment == "test" || var.environment == "prod" ? [1] : []

--- a/operations/app/src/modules/front_door/main.tf
+++ b/operations/app/src/modules/front_door/main.tf
@@ -1,12 +1,23 @@
 terraform {
-    required_version = ">= 0.14"
+  required_version = ">= 0.14"
 }
 
 locals {
-    name = var.environment != "dev" ? "prime-data-hub-${var.environment}" : "prime-data-hub-${var.resource_prefix}"
-    functionapp_address = "${var.resource_prefix}-functionapp.azurewebsites.net"
-    metabase_address = (var.environment == "test" || var.environment == "prod" ? "${var.resource_prefix}-metabase.azurewebsites.net" : null)
-    frontend_endpoints = (length(var.https_cert_names) > 0) ? concat(["DefaultFrontendEndpoint"], var.https_cert_names) : ["DefaultFrontendEndpoint"]
+  name = var.environment != "dev" ? "prime-data-hub-${var.environment}" : "prime-data-hub-${var.resource_prefix}"
+  name_static = var.environment != "dev" ? "prime-data-hub-${var.environment}-static" : "prime-data-hub-${var.resource_prefix}-static"
+
+  functionapp_address = "${var.resource_prefix}-functionapp.azurewebsites.net"
+  metabase_address = (var.environment == "test" || var.environment == "prod" ? "${var.resource_prefix}-metabase.azurewebsites.net" : null)
+  static_address = trimprefix(trimsuffix(var.storage_web_endpoint, "/"), "https://")
+
+  function_certs = [for cert in var.https_cert_names: cert if regex("^[[:alnum:]]*?-?prime.*$", cert)]
+  frontend_endpoints = (length(local.function_certs) > 0) ? concat(["DefaultFrontendEndpoint"], local.function_certs) : ["DefaultFrontendEndpoint"]
+
+  static_certs = [for cert in var.https_cert_names: cert if regex("^[[:alnum:]]*?-?reportstream.*$", cert)]
+  static_endpoints = local.static_certs
+
+  metabase_env = var.environment == "test" || var.environment == "prod" ? [1] : []
+  static_env = length(local.static_endpoints) > 0 ? [1] : []
 }
 
 // TODO: Terraform does not support Azure's rules engine yet
@@ -14,151 +25,237 @@ locals {
 // Ticket tracking rules engine in Terraform: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7455
 
 resource "azurerm_frontdoor" "front_door" {
-    name = local.name
-    resource_group_name = var.resource_group
-    enforce_backend_pools_certificate_name_check = true
-    backend_pools_send_receive_timeout_seconds = 30
-    friendly_name = local.name
+  name = local.name
+  resource_group_name = var.resource_group
+  enforce_backend_pools_certificate_name_check = true
+  backend_pools_send_receive_timeout_seconds = 30
+  friendly_name = local.name
 
-    backend_pool_load_balancing {
-      name = "functionsLoadBalancingSettings"
+
+  /* General */
+
+  frontend_endpoint {
+    name = "DefaultFrontendEndpoint"
+    host_name = "${local.name}.azurefd.net"
+    custom_https_provisioning_enabled = false
+  }
+
+  dynamic "frontend_endpoint" {
+    for_each = var.https_cert_names
+    content {
+      name = frontend_endpoint.value
+      host_name = replace(frontend_endpoint.value, "-", ".")
+      // This will change test-prime-cdc-gov to test.prime.cdc.gov
+      custom_https_provisioning_enabled = true
+
+      custom_https_configuration {
+        certificate_source = "AzureKeyVault"
+        azure_key_vault_certificate_secret_name = frontend_endpoint.value
+        azure_key_vault_certificate_secret_version = "Latest"
+        azure_key_vault_certificate_vault_id = var.key_vault_id
+      }
+    }
+  }
+
+
+  /* Function app */
+
+  backend_pool {
+    name = "functions"
+    health_probe_name = "functionsHealthProbeSettings"
+    load_balancing_name = "functionsLoadBalancingSettings"
+
+    backend {
+      address = local.functionapp_address
+      host_header = local.functionapp_address
+      http_port = 80
+      https_port = 443
+    }
+  }
+
+  backend_pool_load_balancing {
+    name = "functionsLoadBalancingSettings"
+    sample_size = 4
+    successful_samples_required = 2
+    additional_latency_milliseconds = 0
+  }
+
+  backend_pool_health_probe {
+    name = "functionsHealthProbeSettings"
+    path = "/"
+    interval_in_seconds = 30
+    protocol = "Https"
+    probe_method = "HEAD"
+  }
+
+  routing_rule {
+    name = "HttpToHttpsRedirect"
+    frontend_endpoints = local.frontend_endpoints
+    accepted_protocols = ["Http"]
+    patterns_to_match = ["/", "/*", "/api/*", "/download"]
+
+    redirect_configuration {
+      redirect_protocol = "HttpsOnly"
+      redirect_type = "Moved"
+    }
+  }
+
+  routing_rule {
+    name = "api"
+    frontend_endpoints = local.frontend_endpoints
+    accepted_protocols = ["Https"]
+    patterns_to_match = ["/*", "/api/*"]
+
+    forwarding_configuration {
+      backend_pool_name = "functions"
+      forwarding_protocol = "HttpsOnly"
+    }
+  }
+
+  routing_rule {
+    name = "download"
+    frontend_endpoints = local.frontend_endpoints
+    accepted_protocols = ["Https"]
+    patterns_to_match = ["/", "/download"]
+
+    forwarding_configuration {
+      backend_pool_name = "functions"
+      forwarding_protocol = "HttpsOnly"
+      custom_forwarding_path = "/api/download"
+    }
+  }
+
+
+  /* Metabase */
+
+  dynamic "backend_pool" {
+    for_each = local.metabase_env
+    content {
+      name = "metabase"
+      health_probe_name = "metabaseHealthProbeSettings"
+      load_balancing_name = "metabaseLoadBalancingSettings"
+
+      backend {
+        address = local.metabase_address
+        host_header = local.metabase_address
+        http_port = 80
+        https_port = 443
+      }
+    }
+  }
+
+  dynamic "backend_pool_load_balancing" {
+    for_each = local.metabase_env
+    content {
+      name = "metabaseLoadBalancingSettings"
       sample_size = 4
       successful_samples_required = 2
       additional_latency_milliseconds = 0
     }
+  }
 
-    dynamic "backend_pool_load_balancing" {
-      for_each = (var.environment == "test" || var.environment == "prod" ? [1] : [])
-      content {
-        name = "metabaseLoadBalancingSettings"
-        sample_size = 4
-        successful_samples_required = 2
-        additional_latency_milliseconds = 0
-      }
-    }
-
-    dynamic "backend_pool_health_probe" {
-        for_each = (var.environment == "test" || var.environment == "prod" ? [1] : [])
-        content {
-          name = "metabaseHealthProbeSettings"
-          path = "/"
-          interval_in_seconds = 30
-          protocol = "Https"
-          probe_method = "HEAD"
-        }
-    }
-
-    dynamic "backend_pool" {
-      for_each = (var.environment == "test" || var.environment == "prod" ? [1] : [])
-      content {
-        name = "metabase"
-        health_probe_name = "metabaseHealthProbeSettings"
-        load_balancing_name = "metabaseLoadBalancingSettings"
-
-        backend {
-          address = local.metabase_address
-          host_header = local.metabase_address
-          http_port = 80
-          https_port = 443
-        }
-      }
-    }
-
-    backend_pool_health_probe {
-      name = "functionsHealthProbeSettings"
+  dynamic "backend_pool_health_probe" {
+    for_each = local.metabase_env
+    content {
+      name = "metabaseHealthProbeSettings"
       path = "/"
       interval_in_seconds = 30
       protocol = "Https"
       probe_method = "HEAD"
     }
+  }
 
-    backend_pool {
-      name = "functions"
-      health_probe_name = "functionsHealthProbeSettings"
-      load_balancing_name = "functionsLoadBalancingSettings"
+  dynamic "routing_rule" {
+    for_each = local.metabase_env
+    content {
+      name = "HttpToHttpsRedirectMetabase"
+      frontend_endpoints = local.frontend_endpoints
+      accepted_protocols = ["Http"]
+      patterns_to_match = ["/metabase", "/metabase/*"]
 
-      backend {
-        address = local.functionapp_address
-        host_header = local.functionapp_address
-        http_port = 80
-        https_port = 443
+      redirect_configuration {
+        redirect_protocol = "HttpsOnly"
+        redirect_type = "Moved"
       }
     }
+  }
 
-    frontend_endpoint {
-        name = "DefaultFrontendEndpoint"
-        host_name = "${local.name}.azurefd.net"
-        custom_https_provisioning_enabled = false
-    }
+  dynamic "routing_rule" {
+    for_each = local.metabase_env
+    content {
+      name = "metabase"
+      frontend_endpoints = local.frontend_endpoints
+      accepted_protocols = ["Https"]
+      patterns_to_match = ["/metabase", "/metabase/*"]
 
-    dynamic "frontend_endpoint" {
-        for_each = var.https_cert_names
-        content {
-          name = frontend_endpoint.value
-          host_name = replace(frontend_endpoint.value, "-", ".") // This will change test-prime-cdc-gov to test.prime.cdc.gov
-          custom_https_provisioning_enabled = true
-          
-          custom_https_configuration {
-            certificate_source = "AzureKeyVault"
-            azure_key_vault_certificate_secret_name = frontend_endpoint.value
-            azure_key_vault_certificate_secret_version = "Latest"
-            azure_key_vault_certificate_vault_id = var.key_vault_id
-          }
-        }
-      }
-
-    routing_rule {
-        name = "HttpToHttpsRedirect"
-        frontend_endpoints = local.frontend_endpoints
-        accepted_protocols = ["Http"]
-        patterns_to_match = (var.environment == "test" || var.environment == "prod" ? ["/", "/*", "/api/*", "/download", "/metabase", "/metabase/*"] : ["/", "/*", "/api/*", "/download"])
-
-        redirect_configuration {
-            redirect_protocol = "HttpsOnly"
-            redirect_type = "Moved"
-        }
-    }
-
-    routing_rule {
-        name = "download"
-        frontend_endpoints = local.frontend_endpoints
-        accepted_protocols = ["Https"]
-        patterns_to_match = ["/", "/download"]
-
-        forwarding_configuration {
-            backend_pool_name = "functions"
-            forwarding_protocol = "HttpsOnly"
-            custom_forwarding_path = "/api/download"
-        }
-    }
-
-    dynamic "routing_rule" {
-      for_each = (var.environment == "test" || var.environment == "prod" ? [1] : [])
-      content {
-        name = "metabase"
-        frontend_endpoints = local.frontend_endpoints
-        accepted_protocols = ["Https"]
-        patterns_to_match = ["/metabase", "/metabase/*"]
-
-        forwarding_configuration {
-          backend_pool_name = "metabase"
-          forwarding_protocol = "HttpsOnly"
-          custom_forwarding_path = "/"
-        }
+      forwarding_configuration {
+        backend_pool_name = "metabase"
+        forwarding_protocol = "HttpsOnly"
+        custom_forwarding_path = "/"
       }
     }
+  }
 
-    routing_rule {
-        name = "api"
-        frontend_endpoints = local.frontend_endpoints
-        accepted_protocols = ["Https"]
-        patterns_to_match = ["/*", "/api/*"]
 
-        forwarding_configuration {
-            backend_pool_name = "functions"
-            forwarding_protocol = "HttpsOnly"
-        }
+  /* Static site */
+
+  backend_pool {
+    name = "static"
+    health_probe_name = "staticHealthProbeSettings"
+    load_balancing_name = "staticLoadBalancingSettings"
+
+    backend {
+      address = local.static_address
+      host_header = local.static_address
+      http_port = 80
+      https_port = 443
     }
+  }
+
+  backend_pool_load_balancing {
+    name = "staticLoadBalancingSettings"
+    sample_size = 4
+    successful_samples_required = 2
+    additional_latency_milliseconds = 0
+  }
+
+  backend_pool_health_probe {
+    name = "staticHealthProbeSettings"
+    path = "/"
+    interval_in_seconds = 30
+    protocol = "Https"
+    probe_method = "HEAD"
+  }
+
+  dynamic "routing_rule" {
+    for_each = local.static_env
+    content {
+      name = "HttpToHttpsRedirectStatic"
+      frontend_endpoints = local.static_endpoints
+      accepted_protocols = ["Http"]
+      patterns_to_match = ["/", "/*"]
+
+      redirect_configuration {
+        redirect_protocol = "HttpsOnly"
+        redirect_type = "Moved"
+      }
+    }
+  }
+
+  dynamic "routing_rule" {
+    for_each = local.static_env
+    content {
+      name = "Static"
+      frontend_endpoints = local.static_endpoints
+      accepted_protocols = ["Https"]
+      patterns_to_match = ["/", "/*"]
+
+      forwarding_configuration {
+        backend_pool_name = "static"
+        forwarding_protocol = "HttpsOnly"
+      }
+    }
+  }
 
   lifecycle {
     ignore_changes = [
@@ -171,12 +268,12 @@ resource "azurerm_frontdoor" "front_door" {
 }
 
 module "frontdoor_access_log_event_hub_log" {
-    source = "../event_hub_log"
-    resource_type = "front_door"
-    log_type = "access"
-    eventhub_namespace_name = var.eventhub_namespace_name
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
+  source = "../event_hub_log"
+  resource_type = "front_door"
+  log_type = "access"
+  eventhub_namespace_name = var.eventhub_namespace_name
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
 }
 
 resource "azurerm_monitor_diagnostic_setting" "frontdoor_access_log" {
@@ -187,7 +284,7 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_access_log" {
 
   log {
     category = "FrontdoorAccessLog"
-    enabled  = true
+    enabled = true
 
     retention_policy {
       days = 0
@@ -197,7 +294,7 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_access_log" {
 
   log {
     category = "FrontdoorWebApplicationFirewallLog"
-    enabled  = false
+    enabled = false
 
     retention_policy {
       days = 0
@@ -210,19 +307,19 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_access_log" {
     enabled = false
 
     retention_policy {
-        days = 0
-        enabled = false
+      days = 0
+      enabled = false
     }
   }
 }
 
 module "frontdoor_waf_log_event_hub_log" {
-    source = "../event_hub_log"
-    resource_type = "front_door"
-    log_type = "waf"
-    eventhub_namespace_name = var.eventhub_namespace_name
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
+  source = "../event_hub_log"
+  resource_type = "front_door"
+  log_type = "waf"
+  eventhub_namespace_name = var.eventhub_namespace_name
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
 }
 
 resource "azurerm_monitor_diagnostic_setting" "frontdoor_waf_log" {
@@ -233,7 +330,7 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_waf_log" {
 
   log {
     category = "FrontdoorAccessLog"
-    enabled  = false
+    enabled = false
 
     retention_policy {
       days = 0
@@ -243,7 +340,7 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_waf_log" {
 
   log {
     category = "FrontdoorWebApplicationFirewallLog"
-    enabled  = true
+    enabled = true
 
     retention_policy {
       days = 0
@@ -256,22 +353,22 @@ resource "azurerm_monitor_diagnostic_setting" "frontdoor_waf_log" {
     enabled = false
 
     retention_policy {
-        days = 0
-        enabled = false
+      days = 0
+      enabled = false
     }
   }
 }
 
 data "azurerm_key_vault_secret" "https_cert" {
-    count = length(var.https_cert_names)
-    key_vault_id = var.key_vault_id
-    name = var.https_cert_names[count.index]
+  count = length(var.https_cert_names)
+  key_vault_id = var.key_vault_id
+  name = var.https_cert_names[count.index]
 }
 
 output "id" {
-    value = azurerm_frontdoor.front_door.id
+  value = azurerm_frontdoor.front_door.id
 }
 
 output "cname" {
-    value = azurerm_frontdoor.front_door.cname
+  value = azurerm_frontdoor.front_door.cname
 }

--- a/operations/app/src/modules/front_door/variables.tf
+++ b/operations/app/src/modules/front_door/variables.tf
@@ -32,3 +32,8 @@ variable "https_cert_names" {
   type = list
   description = "The HTTPS cert to associate with the front door. Omitting will not associate a domain to the front door."
 }
+
+variable "storage_web_endpoint" {
+  type = string
+  description = "Where the static site is located"
+}

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -105,6 +105,7 @@ module "front_door" {
     eventhub_namespace_name = module.event_hub.eventhub_namespace_name
     eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
     https_cert_names = var.https_cert_names
+    storage_web_endpoint = module.storage.storage_web_endpoint
 }
 
 module "sftp_container" {


### PR DESCRIPTION
This PR completes work on #763

## Changes
- prime.cdc.gov is existing download site
- reportstream.cdc.gov is new static site
- Refactors Front Door module to be easier to read

This has been deployed in staging and can be verified there:
https://staging.prime.cdc.gov
https://staging.reportstream.cdc.gov

## Checklist
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

