### PR TITLE
Fixes issue with translation config being cached

### DIFF
--- a/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
@@ -2676,7 +2676,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/az-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19.md
@@ -28,7 +28,7 @@
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 

--- a/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
@@ -621,7 +621,7 @@ Is the patient symptomatic?
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -984,7 +984,7 @@ The name of the facility which the test was ordered from
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/ca-ca-scc-covid-19.md
+++ b/prime-router/docs/schema_documentation/ca-ca-scc-covid-19.md
@@ -22,7 +22,7 @@ The name of the facility which the test was ordered from
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 

--- a/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
@@ -1028,7 +1028,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -1051,7 +1051,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/covid-19-redox.md
@@ -1028,7 +1028,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -1051,7 +1051,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19.md
+++ b/prime-router/docs/schema_documentation/covid-19.md
@@ -2676,7 +2676,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/fl-fl-covid-19.md
+++ b/prime-router/docs/schema_documentation/fl-fl-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/gu-gu-covid-19.md
+++ b/prime-router/docs/schema_documentation/gu-gu-covid-19.md
@@ -2237,7 +2237,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2254,7 +2254,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/la-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/la-la-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
@@ -705,7 +705,7 @@ Is the patient symptomatic?
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 
@@ -719,7 +719,7 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nd-nd-covid-19.md
+++ b/prime-router/docs/schema_documentation/nd-nd-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19-csv.md
@@ -250,6 +250,7 @@ ASKU|Asked, but unknown
 2106-3|White
 2131-1|Other
 UNK|Unknown
+ASKU|Asked, but unknown
 
 **Alt Value Sets**
 
@@ -262,6 +263,7 @@ Code | Display
 2106-3|W
 2131-1|Other
 UNK|U
+ASKU|U
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/oh-oh-covid-19.md
+++ b/prime-router/docs/schema_documentation/oh-oh-covid-19.md
@@ -2263,7 +2263,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2280,7 +2280,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
@@ -2676,7 +2676,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -8,7 +8,7 @@
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [0..1]
 
@@ -1111,7 +1111,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -679,7 +679,7 @@ Is the patient symptomatic?
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 
@@ -693,7 +693,7 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 

--- a/prime-router/docs/schema_documentation/standard-standard-covid-19.md
+++ b/prime-router/docs/schema_documentation/standard-standard-covid-19.md
@@ -2157,7 +2157,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2174,7 +2174,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -771,7 +771,7 @@ Z|No record of this patient
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
+++ b/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
@@ -634,7 +634,7 @@ The last name of provider who ordered the test
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 
@@ -712,7 +712,7 @@ The name of the laboratory which performed the test, can be the same as the send
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 

--- a/prime-router/docs/schema_documentation/tx-tx-covid-19.md
+++ b/prime-router/docs/schema_documentation/tx-tx-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/vt-vt-covid-19.md
+++ b/prime-router/docs/schema_documentation/vt-vt-covid-19.md
@@ -2247,7 +2247,7 @@ The accession number of the specimen collected
 
 **Type**: ID_CLIA
 
-**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
 
 **Cardinality**: [1..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -186,7 +186,7 @@ The ordering provider’s National Provider Identifier
 
 **Type**: TEXT
 
-**HL7 Field**: OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/NM/nm-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/NM/nm-covid-19-csv.schema
@@ -87,6 +87,8 @@ elements:
         code: 2131-1
       - display: U
         code: UNK
+      - display: U
+        code: ASKU
 
   - name: patient_ethnicity
     csvFields:

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -1103,7 +1103,7 @@ elements:
     natFlatFileField: Testing_lab_id
     hhsGuidanceField:
     hl7Field: OBX-23-10
-    hl7OutputFields: [ OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3 ]
+    hl7OutputFields: [ OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3 ]
     documentation: |
         CLIA Number from the laboratory that sends the message to DOH
 
@@ -1114,6 +1114,7 @@ elements:
     natFlatFileField: Testing_lab_name
     hhsGuidanceField:
     hl7Field: OBX-23-1
+    hl7OutputFields: [ ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2 ]
     documentation: The name of the laboratory which performed the test, can be the same as the sending facility name
 
   - name: testing_lab_specimen_id

--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -42,7 +42,7 @@ class BlobAccess(
             Report.Format.INTERNAL -> csvSerializer.writeInternal(report, outputStream)
             // HL7 needs some additional configuration we set on the translation in organization
             Report.Format.HL7 -> hl7Serializer.write(report, outputStream, report.destination?.translation)
-            Report.Format.HL7_BATCH -> hl7Serializer.writeBatch(report, outputStream, report.destination?.translation)
+            Report.Format.HL7_BATCH -> hl7Serializer.writeBatch(report, outputStream)
             Report.Format.CSV -> csvSerializer.write(report, outputStream)
             Report.Format.REDOX -> redoxSerializer.write(report, outputStream)
         }

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -435,8 +435,12 @@ class ProcessData : CliktCommand(
             when (format) {
                 Report.Format.INTERNAL -> csvSerializer.writeInternal(report, stream)
                 Report.Format.CSV -> csvSerializer.write(report, stream)
-                Report.Format.HL7 -> hl7Serializer.write(report, stream, hl7Configuration)
-                Report.Format.HL7_BATCH -> hl7Serializer.writeBatch(report, stream, hl7Configuration)
+                Report.Format.HL7 -> {
+                    hl7Serializer.write(report, stream)
+                }
+                Report.Format.HL7_BATCH -> {
+                    hl7Serializer.writeBatch(report, stream)
+                }
                 Report.Format.REDOX -> redoxSerializer.write(report, stream)
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the `TranslationConfiguration` was being cached in some instances causing information from one out report to leak into another. 

## Changes
- Removes the `hl7Config` property and always pulls the translation configuration directly from the report

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?


