### PR TITLE
Documentation for logging into Postgres via Active Directory

### DIFF
--- a/prime-router/docs/azure_database_login.md
+++ b/prime-router/docs/azure_database_login.md
@@ -32,8 +32,9 @@ Copy the value from `accessToken`. This will be your password and it will expire
 
 Using your PostgreSQL tool of choice, login with the following details:
 
-* User: `reportstream_pgsql_admin@dbservername`
-* Pasword: `<the accessToken from above>`
+* For write / schema access: `reportstream_pgsql_admin@dbservername`
+* For read-only access: `reportstream_pgsql_developer@dbservername`
+* Password: `<the accessToken from above>`
 
 Note: The tool pgAdmin is not supported at this time. [Microsoft notes access tokens are longer](https://docs.microsoft.com/en-us/azure/postgresql/howto-configure-sign-in-aad-authentication#connecting-to-azure-database-for-postgresql-using-azure-ad) than pgAdmin's char size for passwords.
 

--- a/prime-router/docs/azure_database_login.md
+++ b/prime-router/docs/azure_database_login.md
@@ -1,0 +1,45 @@
+# Azure Database Login
+
+This is the process for logging into our database via Azure Active Directory.
+
+## Login to Azure CLI
+
+```aidl
+az login
+```
+
+## Request a token for Active Directory
+
+```aidl
+az account get-access-token --resource-type oss-rdbms
+```
+
+You will receive a response that looks like:
+
+```aidl
+{
+  "accessToken": "token",
+  "expiresOn": "2021-04-22 16:22:54.350957",
+  "subscription": "sub",
+  "tenant": "id",
+  "tokenType": "Bearer"
+}
+```
+
+Copy the value from `accessToken`. This will be your password and it will expire in one hour after request. If your token expires, run this command again.
+
+## Login to PostgreSQL
+
+Using your PostgreSQL tool of choice, login with the following details:
+
+* User: `reportstream_pgsql_admin@dbservername`
+* Pasword: `<the accessToken from above>`
+
+Note: The tool pgAdmin is not supported at this time. [Microsoft notes access tokens are longer](https://docs.microsoft.com/en-us/azure/postgresql/howto-configure-sign-in-aad-authentication#connecting-to-azure-database-for-postgresql-using-azure-ad) than pgAdmin's char size for passwords.
+
+### Example in staging
+
+```aidl
+export PGPASSWORD=<accessToken>
+psql "host=pdhstaging-pgsql.postgres.database.azure.com user=reportstream_pgsql_admin@pdhstaging-pgsql dbname=prime_data_hub sslmode=require"
+```


### PR DESCRIPTION
This PR adds documentation for authenticating to Postgres via Azure Active Directory.

* Resolves CDCGov/prime-devops#5
* Resolves #556

## Steps to Verify

- Reviewers should follow the steps documented and verify they have access to postgres.
- Verify both the write and read users to ensure permissions are correct.