### PR TITLE
Fixes issue with LA name not using 'prod' and wrong value type for AOE date questions for VT

### DIFF
--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -300,6 +300,7 @@
           receivingApplicationName: LA-ELR
           receivingFacilityName: LADOH
           nameFormat: APHL
+          useTestProcessingMode: false
         timing:
           operation: MERGE
           numberPerDay: 1440 # Every minute

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -216,6 +216,7 @@
           - matches(ordering_facility_state, LA)
         translation:
           type: HL7
+          useTestProcessingMode: false
           useBatchHeaders: true
           receivingApplicationName: LA-ELR
           receivingFacilityName: LADOH

--- a/prime-router/settings/prod/0014-la-doh.yml
+++ b/prime-router/settings/prod/0014-la-doh.yml
@@ -1,0 +1,28 @@
+name: la-doh
+description: Louisiana Department of Health
+jurisdiction: STATE
+stateCode: LA
+receivers:
+  - name: elr
+    organizationName: la-doh
+    topic: covid-19
+    jurisdictionalFilter:
+      - matches(ordering_facility_state, LA)
+    translation:
+      type: HL7
+      useBatchHeaders: true
+      receivingOrganization: LAOPH
+      receivingApplicationName: LA-ELR
+      receivingFacilityName: LADOH
+      nameFormat: APHL
+      useTestProcessingMode: false
+    timing:
+      operation: MERGE
+      numberPerDay: 12
+      initialTime: 01:15
+      timeZone: EASTERN
+    transport:
+      type: SFTP
+      host: 204.58.124.41
+      port: 22
+      filePath: ./

--- a/prime-router/settings/staging/0006-la-org-update.yml
+++ b/prime-router/settings/staging/0006-la-org-update.yml
@@ -1,0 +1,28 @@
+name: la-doh
+description: Louisiana Department of Health
+jurisdiction: STATE
+stateCode: LA
+receivers:
+  - name: elr
+    organizationName: la-doh
+    topic: covid-19
+    jurisdictionalFilter:
+      - matches(ordering_facility_state, LA)
+    translation:
+      type: HL7
+      useBatchHeaders: true
+      receivingOrganization: LAOPH
+      receivingApplicationName: LA-ELR
+      receivingFacilityName: LADOH
+      nameFormat: APHL
+      useTestProcessingMode: false
+    timing:
+      operation: MERGE
+      numberPerDay: 1440 # Every minute
+      initialTime: 00:00
+      timeZone: CENTRAL
+    transport:
+      type: SFTP
+      host: 10.0.2.4
+      port: 22
+      filePath: ./upload

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -740,11 +740,7 @@ class Report {
             translationConfig: TranslatorConfiguration? = null
         ): String {
             val hl7Config = translationConfig as? Hl7Configuration?
-            val processingModeCode = if (hl7Config?.useTestProcessingMode == true) {
-                "T"
-            } else {
-                "P"
-            }
+            val processingModeCode = hl7Config?.processingModeCode ?: "P"
             return formFilename(
                 id,
                 schemaName,

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -126,8 +126,7 @@ class Report {
         schema.baseName,
         bodyFormat,
         createdDateTime,
-        destination?.translation?.nameFormat ?: NameFormat.STANDARD,
-        destination?.translation?.receivingOrganization
+        destination?.translation
     )
 
     /**
@@ -738,11 +737,35 @@ class Report {
             schemaName: String,
             fileFormat: Format?,
             createdDateTime: OffsetDateTime,
+            translationConfig: TranslatorConfiguration? = null
+        ): String {
+            val hl7Config = translationConfig as? Hl7Configuration?
+            val processingModeCode = if (hl7Config?.useTestProcessingMode == true) {
+                "T"
+            } else {
+                "P"
+            }
+            return formFilename(
+                id,
+                schemaName,
+                fileFormat,
+                createdDateTime,
+                hl7Config?.nameFormat ?: NameFormat.STANDARD,
+                hl7Config?.receivingOrganization,
+                "cdcprime",
+                processingModeCode
+            )
+        }
+
+        fun formFilename(
+            id: ReportId,
+            schemaName: String,
+            fileFormat: Format?,
+            createdDateTime: OffsetDateTime,
             nameFormat: NameFormat = NameFormat.STANDARD,
             receivingOrganization: String? = null,
             sendingFacility: String = "cdcprime",
             processingModeCode: String = "T",
-            translationConfig: TranslatorConfiguration? = null,
         ): String {
             fun mapProcessingModeCode(processingModeCode: String = "T"): String {
                 return when (processingModeCode.toLowerCase()) {

--- a/prime-router/src/main/kotlin/TranslatorConfiguration.kt
+++ b/prime-router/src/main/kotlin/TranslatorConfiguration.kt
@@ -93,6 +93,13 @@ data class Hl7Configuration
             "reporting_facility" to reportingFacility
         )
     }
+
+    @get:JsonIgnore
+    val processingModeCode: String get() = if (this.useTestProcessingMode) {
+        "T"
+    } else {
+        "P"
+    }
 }
 
 /**

--- a/prime-router/src/main/kotlin/cli/FileUtilities.kt
+++ b/prime-router/src/main/kotlin/cli/FileUtilities.kt
@@ -84,11 +84,7 @@ class FileUtilities {
                 // is this config HL7?
                 val hl7Config = report.destination?.translation as? Hl7Configuration?
                 // if it is, get the test processing mode
-                val processingMode = if (hl7Config?.useTestProcessingMode == false) {
-                    "P"
-                } else {
-                    "T"
-                }
+                val processingMode = hl7Config?.processingModeCode ?: "P"
                 val fileName = Report.formFilename(
                     report.id,
                     report.schema.baseName,

--- a/prime-router/src/main/kotlin/cli/FileUtilities.kt
+++ b/prime-router/src/main/kotlin/cli/FileUtilities.kt
@@ -1,11 +1,7 @@
 package gov.cdc.prime.router.cli
 
 import com.github.ajalt.clikt.output.TermUi.echo
-import gov.cdc.prime.router.FakeReport
-import gov.cdc.prime.router.FileSource
-import gov.cdc.prime.router.Metadata
-import gov.cdc.prime.router.Report
-import gov.cdc.prime.router.Sender
+import gov.cdc.prime.router.*
 import gov.cdc.prime.router.serializers.CsvSerializer
 import gov.cdc.prime.router.serializers.Hl7Serializer
 import gov.cdc.prime.router.serializers.RedoxSerializer
@@ -85,6 +81,14 @@ class FileUtilities {
             val outputFile = if (outputFileName != null) {
                 File(outputFileName)
             } else {
+                // is this config HL7?
+                val hl7Config = report.destination?.translation as? Hl7Configuration?
+                // if it is, get the test processing mode
+                val processingMode = if (hl7Config?.useTestProcessingMode == false) {
+                    "P"
+                } else {
+                    "T"
+                }
                 val fileName = Report.formFilename(
                     report.id,
                     report.schema.baseName,
@@ -92,6 +96,7 @@ class FileUtilities {
                     report.createdDateTime,
                     nameFormat = Report.NameFormat.STANDARD,
                     report.destination?.translation?.receivingOrganization,
+                    processingMode
                 )
                 File(outputDir ?: ".", fileName)
             }

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -256,14 +256,22 @@ class ProcessData : CliktCommand(
                 val outputFile = if (outputFileName != null) {
                     File(outputFileName!!)
                 } else {
-
+                    // is this config HL7?
+                    val hl7Config = report.destination?.translation as? Hl7Configuration?
+                    // if it is, get the test processing mode
+                    val processingMode = if (hl7Config?.useTestProcessingMode == false) {
+                        "P"
+                    } else {
+                        "T"
+                    }
                     val fileName = Report.formFilename(
                         report.id,
                         report.schema.baseName,
                         format,
                         report.createdDateTime,
                         getNameFormat(Report.NameFormat.STANDARD),
-                        receivingOrganization ?: report.destination?.translation?.receivingOrganization
+                        receivingOrganization ?: report.destination?.translation?.receivingOrganization,
+                        processingMode
                     )
                     File(outputDir ?: ".", fileName)
                 }

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -546,8 +546,14 @@ class Hl7Serializer(val metadata: Metadata) {
         units: String? = null,
         suppressQst: Boolean = false,
     ) {
+        // if the value type is a date, we need to specify that for the AOE questions
+        val valueType = if (element.type == Element.Type.DATE) {
+            "DT"
+        } else {
+            "CWE"
+        }
         terser.set(formPathSpec("OBX-1", aoeRep), (aoeRep + 1).toString())
-        terser.set(formPathSpec("OBX-2", aoeRep), "CWE")
+        terser.set(formPathSpec("OBX-2", aoeRep), valueType)
         val aoeQuestion = element.hl7AOEQuestion
             ?: error("Schema Error: missing hl7AOEQuestion for '${element.name}'")
         setCodeComponent(terser, aoeQuestion, formPathSpec("OBX-3", aoeRep), "covid-19/aoe")


### PR DESCRIPTION
This PR fixes an issue where the processing mode code was not carried through for Louisiana for their file name format, and VT flagged that date type AOE questions should be listed as `DT` value type, not `CWE`. 

## Changes
- Adds overload for translation config values to feed the file name creation
- Fixes logic for the `DT/CWE` value type for AOE questions

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

