### PR TITLE
Make STRAC data feed work for all states

### DIFF
--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -69,6 +69,20 @@ An example of the ID is 03D2159846
 
 ---
 
+**Name**: ordering_provider_phone_number
+
+**Type**: TELEPHONE
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
 **Name**: ordering_facility_county
 
 **Type**: TABLE
@@ -831,20 +845,6 @@ The zip code of the provider
 **Type**: TEXT
 
 **Cardinality**: [0..1]
-
----
-
-**Name**: ordering_provider_phone_number
-
-**Type**: TELEPHONE
-
-**HL7 Fields**: ORC-14, OBR-17
-
-**Cardinality**: [0..1]
-
-**Documentation**:
-
-The phone number of the provider
 
 ---
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -50,13 +50,13 @@ The name of the facility which the test was ordered from
 
 **Type**: TELEPHONE
 
-**HL7 Fields**: ORC-14, OBR-17
+**HL7 Field**: ORC-23
 
-**Cardinality**: [0..1]
+**Cardinality**: [1..1]
 
 **Documentation**:
 
-The phone number of the provider
+The phone number of the facility which the test was ordered from
 
 ---
 
@@ -798,5 +798,36 @@ The name of the laboratory which performed the test, can be the same as the send
 **HL7 Field**: PID-3-5
 
 **Cardinality**: [0..1]
+
+---
+
+**Name**: message_id
+
+**Type**: ID
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+unique id to track the usage of the message
+
+---
+
+**Name**: testing_lab_clia
+
+**Type**: ID_CLIA
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
 
 ---

--- a/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
+++ b/prime-router/metadata/schemas/PA/pa-covid-19-redox.schema
@@ -32,6 +32,10 @@ elements:
     mapper: lookup(ordering_provider_state, ordering_provider_county)
     redoxOutputFields: ["Orders[0].Provider.Address.County"]
 
+  # Yes, PA wants the facility phone number mapped to provider
+  - name: ordering_provider_phone_number
+    mapper: use(ordering_facility_phone_number)
+
   - name: ordering_facility_county
     redoxOutputFields: []
 

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -166,3 +166,11 @@ elements:
 
   - name: patient_id_type
     mapper: ifPresent(patient_id, PI)
+
+  # the kit_id is the serial number on the test kit
+  - name: message_id
+    mapper: use(filler_order_id)
+
+  # reporting facility and testing lab operate under the same CLIA with STRAC
+  - name: testing_lab_clia
+    mapper: use(reporting_facility_clia)

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -18,8 +18,7 @@ elements:
   - name: ordering_facility_name
     csvFields: [{name: Ordering_Facility_Name}]
 
-  # Yes, PA wants the facility phone number mapped to provider
-  - name: ordering_provider_phone_number
+  - name: ordering_facility_phone_number
     csvFields: [{name: Ordering_Facility_Phone_Number}]
 
   - name: ordering_facility_street

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -704,13 +704,14 @@ class Strac : CoolTest() {
             val tree = jacksonObjectMapper().readTree(json)
             val reportId = ReportId.fromString(tree["id"].textValue())
             echo("Id of submitted report: $reportId")
+            val expectedWarningCount = 0
             val warningCount = tree["warningCount"].intValue()
-            if (warningCount == allGoodReceivers.size - 1) {
+            if (warningCount == expectedWarningCount) {
                 good("First part of strac Test passed: $warningCount warnings were returned.")
             } else {
                 // Current expectation is that all non-REDOX counties fail.   If those issues get fixed,
                 // then we'll need to fix this test as well.
-                bad("***strac Test FAILED: Expecting ${allGoodReceivers.size - 1} warnings but got $warningCount***")
+                bad("***strac Test FAILED: Expecting ${expectedWarningCount} warnings but got $warningCount***")
                 passed = false
             }
             // OK, fine, the others failed.   All our hope now rests on you, REDOX - don't let us down!


### PR DESCRIPTION
This PR fixes a bug where a report from STRAC would fail on many states. 

## Changes
- Added mappings to the STRAC schema to provide required data elements
- Moved a mapping for PA from the STRAC schema to PA schema

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Other testing
Generated fake STRAC data for AZ. This data failed before because of missing elements. Now it succeeds.
```
rickhawes@MacBook-Pro-16 ~/P/p/prime-router (rick/fix-strac-to-allstates)> ./prime data --input result_files/fake-az-strac.csv --input-schema=strac/strac-covid-19 --route --output-dir routed_files
10:37:19.263 [main][1] INFO  ca.uhn.hl7v2.util.Home - hapi.home is set to /Users/rickhawes/Projects/prime-data-hub/prime-router/.
10:37:19.274 [main][1] INFO  ca.uhn.hl7v2.VersionLogger - HAPI version is: 2.3
10:37:19.277 [main][1] INFO  ca.uhn.hl7v2.VersionLogger - Default Structure libraries found for HL7 versions 2.5.1,
Loaded schema and receivers
Opened: /Users/rickhawes/Projects/prime-data-hub/prime-router/result_files/fake-az-strac.csv
Creating these files:
/Users/rickhawes/Projects/prime-data-hub/prime-router/routed_files/az-covid-19-917da57a-3eed-4e28-9ef2-bd02a91700a0-20210423103719.csv
/Users/rickhawes/Projects/prime-data-hub/prime-router/routed_files/covid-19-295a5bf6-076a-4e8e-a0d9-3a2190028c34-20210423103719.hl7
/Users/rickhawes/Projects/prime-data-hub/prime-router/routed_files/pima-az-covid-19-ef4184a1-a1dc-48f8-aa9d-5686848e86c3-20210423103719.csv
rickhawes@MacBook-Pro-16 ~/P/p/prime-router (rick/fix-strac-to-allstates)>
```

## Security
None

## Fixes
*List GitHub issues this PR fixes*
- #632

## To Be Done
None

