### PR TITLE
Fix for Redox bug, fix to Mappers bug, minor test cleanup

### DIFF
--- a/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
@@ -589,6 +589,17 @@ Y|No order on record for this test
 Z|No record of this patient
 C|Corrected, final
 F|Final results
+X|No results available; Order canceled
+A|Some, but not all, results available
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+Y|No order on record for this test
+Z|No record of this patient
 
 **Alt Value Sets**
 
@@ -596,6 +607,17 @@ Code | Display
 ---- | -------
 C|Corrected
 F|Final
+X|Canceled
+A|Preliminary
+I|Unavailable
+M|Corrected
+N|Preliminary
+O|Preliminary
+P|Preliminary
+R|Preliminary
+S|Unavailable
+Y|Unavailable
+Z|Unavailable
 
 ---
 

--- a/prime-router/docs/schema_documentation/covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/covid-19-redox.md
@@ -589,6 +589,17 @@ Y|No order on record for this test
 Z|No record of this patient
 C|Corrected, final
 F|Final results
+X|No results available; Order canceled
+A|Some, but not all, results available
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+Y|No order on record for this test
+Z|No record of this patient
 
 **Alt Value Sets**
 
@@ -596,6 +607,17 @@ Code | Display
 ---- | -------
 C|Corrected
 F|Final
+X|Canceled
+A|Preliminary
+I|Unavailable
+M|Corrected
+N|Preliminary
+O|Preliminary
+P|Preliminary
+R|Preliminary
+S|Unavailable
+Y|Unavailable
+Z|Unavailable
 
 ---
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -678,6 +678,17 @@ Y|No order on record for this test
 Z|No record of this patient
 C|Corrected, final
 F|Final results
+X|No results available; Order canceled
+A|Some, but not all, results available
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+Y|No order on record for this test
+Z|No record of this patient
 
 **Alt Value Sets**
 
@@ -685,6 +696,17 @@ Code | Display
 ---- | -------
 C|Corrected
 F|Final
+X|Canceled
+A|Preliminary
+I|Unavailable
+M|Corrected
+N|Preliminary
+O|Preliminary
+P|Preliminary
+R|Preliminary
+S|Unavailable
+Y|Unavailable
+Z|Unavailable
 
 ---
 

--- a/prime-router/metadata/schemas/covid-19-redox.schema
+++ b/prime-router/metadata/schemas/covid-19-redox.schema
@@ -179,6 +179,28 @@ elements:
         code: C
       - display: Final
         code: F
+      - display: Canceled
+        code: X
+      - display: Preliminary
+        code: A
+      - display: Unavailable
+        code: I
+      - display: Corrected
+        code: M
+      - display: Preliminary
+        code: N
+      - display: Preliminary
+        code: O
+      - display: Preliminary
+        code: P
+      - display: Preliminary
+        code: R
+      - display: Unavailable
+        code: S
+      - display: Unavailable
+        code: Y
+      - display: Unavailable
+        code: Z
 
   - name: ordered_test_code
     redoxOutputFields: ["Orders[0].Procedure.Code"]

--- a/prime-router/src/main/kotlin/Mappers.kt
+++ b/prime-router/src/main/kotlin/Mappers.kt
@@ -80,6 +80,8 @@ class MiddleInitialMapper : Mapper {
             return null
         } else {
             if (values.size != 1) error("Found ${values.size} values.  Expecting 1 value. Args: $args, Values: $values")
+            if (values.first().value.isEmpty())
+                return null
             return values.first().value.substring(0..0).toUpperCase()
         }
     }

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -45,7 +45,6 @@ import kotlin.time.measureTime
 enum class TestStatus(val description: String) {
     DRAFT("Experimental"), // Tests that are experimental
     FAILS("Always fails"), // For tests that just always fail, and we haven't fixed the issue yet.
-    SLOW("Good test, but slow"), // For tests that are crazy slow
     LOAD("Load Test"),
     GOODSTUFF("Part of Smoke test"), // Only Smoke the Good Stuff.
 }
@@ -378,7 +377,7 @@ abstract class CoolTest {
         }
 
         /**
-         * A hack attempt to wait enough time, but not too long, for Hub to finish.
+         * A hack attempt to wait enough time, but not too long, for ReportStream to finish.
          * This assumes the batch/send executes on the minute boundary.
          */
         fun waitABit(plusSecs: Int, env: ReportStreamEnv, silent: Boolean = false) {
@@ -391,7 +390,7 @@ abstract class CoolTest {
                 // Or, we are in Test or Staging, which don't execute on the top of the minute.
                 waitSecs += 90
             }
-            echo("Waiting $waitSecs seconds for the Hub to fully receive, batch, and send the data")
+            echo("Waiting $waitSecs seconds for ReportStream to fully receive, batch, and send the data")
             for (i in 1..waitSecs) {
                 sleep(1000)
                 if (!silent) print(".")
@@ -497,7 +496,7 @@ class End2End : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.
+        // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
         echo("Response to POST: $responseCode")
@@ -537,7 +536,7 @@ class Merge : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub over and over
+        // Now send it to ReportStream over and over
         val reportIds = (1..options.submits).map {
             val (responseCode, json) =
                 HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
@@ -575,7 +574,7 @@ class Hl7Null : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.   Make numResends > 1 to create merges.
+        // Now send it to ReportStream.   Make numResends > 1 to create merges.
         val numResends = 1
         val reportIds = (1..numResends).map {
             val (responseCode, json) =
@@ -692,7 +691,7 @@ class Strac : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.
+        // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, stracSender.name, options.key)
         echo("Response to POST: $responseCode")
@@ -740,7 +739,7 @@ class StracPack : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub over and over
+        // Now send it to ReportStream over and over
         var reportIds = mutableListOf<ReportId>()
         var passed = true
         // submit in thread grouping somewhat smaller than our database pool size.
@@ -814,8 +813,8 @@ class RepeatWaters : CoolTest() {
         ugly("Starting $name Test: sending Waters data ${options.submits} times.")
         var allPassed = true
         var totalItems = 0
-        val sleepBetweenSubmitMillis = 1000
-        val variationMillis = 1000
+        val sleepBetweenSubmitMillis = 360
+        val variationMillis = 360
         val pace = (3600000 / sleepBetweenSubmitMillis) * options.items
         echo("Submitting at an expected pace of $pace items per hour")
         options.muted = true
@@ -871,7 +870,7 @@ class HammerTime : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub over and over
+        // Now send it to ReportStream over and over
         var reportIds = mutableListOf<ReportId>()
         var passed = true
         // submit in thread grouping somewhat smaller than our database pool size.
@@ -921,7 +920,7 @@ class Garbage : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.
+        // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, emptySender.name, options.key)
         echo("Response to POST: $responseCode")
@@ -953,7 +952,7 @@ class Garbage : CoolTest() {
 class Huge : CoolTest() {
     override val name = "huge"
     override val description = "Submit $REPORT_MAX_ITEMS line csv file, wait, confirm via db.  Slow."
-    override val status = TestStatus.SLOW
+    override val status = TestStatus.LOAD
 
     override fun run(environment: ReportStreamEnv, options: CoolTestOptions): Boolean {
         val fakeItemCount = REPORT_MAX_ITEMS
@@ -968,7 +967,7 @@ class Huge : CoolTest() {
             Report.Format.CSV
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.
+        // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
         echo("Response to POST: $responseCode")
@@ -988,7 +987,7 @@ class Huge : CoolTest() {
 class TooBig : CoolTest() {
     override val name = "toobig"
     override val description = "Submit ${REPORT_MAX_ITEMS + 1} lines, which should be an error.  Slower ;)"
-    override val status = TestStatus.SLOW
+    override val status = TestStatus.LOAD
 
     override fun run(environment: ReportStreamEnv, options: CoolTestOptions): Boolean {
         val fakeItemCount = REPORT_MAX_ITEMS + 1
@@ -1003,7 +1002,7 @@ class TooBig : CoolTest() {
             Report.Format.CSV
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.
+        // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
         echo("Response to POST: $responseCode")
@@ -1026,12 +1025,12 @@ class TooBig : CoolTest() {
  * Test weirdness in Staging wherein we have strange HL7 'send' numbers
  *
  * This test, when it fails, exposes a database connection exception in Staging.
- *
+ * I think this is actually passing now, but the query isn't quite right.
  */
 class DbConnections : CoolTest() {
     override val name = "dbconnections"
-    override val description = "Test weird issue wherein many 'sends' cause db connection failures"
-    override val status = TestStatus.FAILS
+    override val description = "Test issue wherein many 'sends' caused db connection failures"
+    override val status = TestStatus.DRAFT
 
     override fun run(environment: ReportStreamEnv, options: CoolTestOptions): Boolean {
         ugly("Starting dbconnections Test: test of many threads attempting to sftp ${options.items} HL7s.")
@@ -1044,7 +1043,7 @@ class DbConnections : CoolTest() {
             options.dir,
         )
         echo("Created datafile $file")
-        // Now send it to the Hub.   Make numResends > 1 to create merges.
+        // Now send it to ReportStream.   Make numResends > 1 to create merges.
         val reportIds = (1..options.submits).map {
             val (responseCode, json) =
                 HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
@@ -1060,7 +1059,12 @@ class DbConnections : CoolTest() {
             reportId
         }
         waitABit(30, environment)
-        return examineMergeResults(reportIds[0], listOf(hl7Receiver), options.items, options.submits)
+        var passed = true
+        reportIds.forEach {
+            passed = passed and
+                examineLineageResults(it, listOf(hl7Receiver), options.items)
+        }
+        return passed
     }
 }
 


### PR DESCRIPTION
This PR fixes #920 

## Changes
- Added altValues to the base covid-19-redox schema to cover the 'X' value coming from SimpleReport.    I went ahead and added all the other values too - not clear if they will ever be used.
- Fixed a bug I saw in the mapper while messing with the CO data.
- minor cleanup to TestReportStream

## Checklist
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [X] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
None known at this time

## Fixes
- #920 


