### PR TITLE
CsvSerialization update

### DIFF
--- a/prime-router/docs/releases/2021-04-26-release-notes.md
+++ b/prime-router/docs/releases/2021-04-26-release-notes.md
@@ -1,0 +1,19 @@
+#  Report Stream April 26, 2021
+
+## General useful links:
+
+- All Schemas are documented here:  [Link to detailed schema dictionaries](../schema_documentation)
+- The Hub API is documented here: [Hub OpenApi Spec](../openapi.yml)
+- [Click here for all release notes](../releases)
+
+## For this release
+
+### The `/api/reports` end-point handles malformed CSVs differently
+
+A POST to the end-point (i.e. a submission of a report) will error if the CSV contains a malformed row. 
+Examples of malformed rows include:
+ - Empty rows
+ - Rows with different number of columns
+
+Previously, the row would be skipped and warning would be given for the row. 
+The new behavior is to error on these malformed CSV files. 

--- a/prime-router/pom.xml
+++ b/prime-router/pom.xml
@@ -57,6 +57,13 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+            <id>kotlinx</id>
+            <url>https://kotlin.bintray.com/kotlinx</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>

--- a/prime-router/pom.xml
+++ b/prime-router/pom.xml
@@ -57,13 +57,6 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>kotlinx</id>
-            <url>https://kotlin.bintray.com/kotlinx</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -483,7 +476,7 @@
         <dependency>
             <groupId>com.github.doyaaaaaken</groupId>
             <artifactId>kotlin-csv-jvm</artifactId>
-            <version>0.15.1</version>
+            <version>0.15.2</version>
         </dependency>
         <dependency>
             <groupId>tech.tablesaw</groupId>

--- a/prime-router/src/test/kotlin/serializers/CsvSerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/CsvSerializerTests.kt
@@ -226,6 +226,7 @@ class CsvSerializerTests {
 
     @Test
     fun `test missing column`() {
+        // setup a malformed CSV
         val one = Schema(
             name = "one",
             topic = "test",
@@ -239,11 +240,38 @@ class CsvSerializerTests {
             1,2
         """.trimIndent()
         val csvConverter = CsvSerializer(Metadata(schema = one))
+        // Run it
         val result = csvConverter.readExternal("one", ByteArrayInputStream(csv.toByteArray()), TestSource)
-        assertEquals(0, result.errors.size)
-        assertEquals(1, result.warnings.size)
-        assertEquals("", result.report?.getString(0, "b"))
-        assertEquals("1", result.report?.getString(0, "a"))
+        // Expect the converter to catch the error. Our serializer will error on malformed CSVs.
+        assertEquals(1, result.errors.size)
+        assertEquals(0, result.warnings.size)
+        assertNull(result.report)
+    }
+
+
+    @Test
+    fun `test missing row`() {
+        // setup a malformed CSV
+        val one = Schema(
+            name = "one",
+            topic = "test",
+            elements = listOf(
+                Element("a", csvFields = Element.csvFields("a")),
+                Element("b", csvFields = Element.csvFields("b"))
+            )
+        )
+        val csv = """
+            a,b
+            
+            1,2
+        """.trimIndent()
+        val csvConverter = CsvSerializer(Metadata(schema = one))
+        // Run it
+        val result = csvConverter.readExternal("one", ByteArrayInputStream(csv.toByteArray()), TestSource)
+        // Expect the converter to catch the error. Our serializer will error on malformed CSVs.
+        assertEquals(1, result.errors.size)
+        assertEquals(0, result.warnings.size)
+        assertNull(result.report)
     }
 
     @Test


### PR DESCRIPTION
This PR upgrades the `csv-kotlin-jvm` package and updates the behavior of the CsvSerialization.

## Background
Dependabot submitted a PR to upgrade the `csv-kotlin-jvm` package. Unfortunately, this PR broke the build because a CsvSerialization test failed.  

After an investigation, it was found that the new version of the package had better CSV formatting checking, which had the side effect of throwing an exception when none was thrown before.  See [https://github.com/CDCgov/prime-data-hub/pull/834](https://github.com/CDCgov/prime-data-hub/pull/834)

## Changes
- Handle the new exceptions thrown by the package
- Release notes: Since the API behavior has changed a little for malformed CSV submissions. 

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [x] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [x] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Reviewers
- Think about what tests should be tried for this change
- 

