### PR TITLE
BinTray shutdown

### DIFF
--- a/prime-router/pom.xml
+++ b/prime-router/pom.xml
@@ -57,13 +57,6 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>kotlinx</id>
-            <url>https://kotlin.bintray.com/kotlinx</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>


### PR DESCRIPTION
This PR removes the project's dependency on BinTray.com which shutting down on May 1. 

This dependency is no longer needed for KotlinX packages. I think our builds will start to fail on May 1 without this change. 

## Changes
- KotlinX repository is removed and the MavenCentral is used for KotlinX packages. 

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test --run end2end` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

