### PR TITLE
More content edits, adds disclaimer partial to protected pages

### DIFF
--- a/frontend/src/_data/content/index.yaml
+++ b/frontend/src/_data/content/index.yaml
@@ -12,7 +12,7 @@ heroImgAlt: Example screenshot of the ReportStream web application
 
 partners:
   - type: State
-    title: State public health departments
+    title: Public health departments
     summary: Get fast, complete COVID-19 electronic test results from your jurisdiction
     features:
       - title: Support fewer connections
@@ -20,28 +20,36 @@ partners:
           ReportStream's model focuses on aggregating data from multiple sources and senders, which you receive together in a single feed at your preferred frequency and format.
         icon: code.svg
         iconDescription: computer code
-      - title: Get valuable insights
-        summary: ReportStream gives you insights about your data, such as reporting trends, and alerts you if there are any errors.
-        icon: assessment.svg
-        iconDescription: a chart
       - title: Receive data from SimpleReport
         summary: >-
           If your jurisdiction is interested in receiving point-of-care tests results from  <a href="https://simplereport.gov">SimpleReport</a>, you can get this data via ReportStream.
         icon: content_copy.svg
         iconDescription: multiple documents
-  - type: Local
-    title: Local public health departments
-    summary: Get access to COVID-19 electronic test results without building an Electronic Lab Reporting (ELR) connection
-    features:
-      - title:   Receive faster data
-        summary: >-
-          Get direct access to data from senders connected with ReportStream, such as facilities using <a href="https://simplereport.gov">SimpleReport</a>, in your jurisdiction.
-        icon: send.svg
-        iconDescription: a paper airplane
-      - title: No ELR connection necessary
-        summary: Receive data directly via a ReportStream web account.
-        icon: cloud.svg
-        iconDescription: cloud computing
+      - title: Get valuable insights
+        summary: ReportStream gives you insights about your data, such as reporting trends, and alerts you if there are any errors.
+        icon: assessment.svg
+        iconDescription: a chart
+#      - title:   Receive faster data
+#        summary: >-
+#          Get direct access to data from senders connected with ReportStream, such as facilities using <a href="https://simplereport.gov">SimpleReport</a>, in your jurisdiction.
+#        icon: send.svg
+#        iconDescription: a paper airplane
+#      - title: No ELR connection necessary
+#        summary: Receive data directly via a ReportStream web account.
+#        icon: cloud.svg
+#        iconDescription: cloud computing
+  #- type: Local
+  #  title: Local public health departments
+  #  summary: Get access to COVID-19 electronic test results without building an Electronic Lab Reporting (ELR) connection
+  #  features:
+  #    - title:   Receive faster data
+  #      summary: >-
+  #        Get direct access to data from senders connected with ReportStream, such as facilities using <a href="https://simplereport.gov">SimpleReport</a>, in your jurisdiction.
+  #      icon: send.svg
+  #      iconDescription: a paper airplane
+  #    - title: No ELR connection necessary
+  #      icon: cloud.svg
+  #    iconDescription: cloud computing
 
 documentation:
   title: Documentation

--- a/frontend/src/_data/content/index.yaml
+++ b/frontend/src/_data/content/index.yaml
@@ -17,7 +17,7 @@ partners:
     features:
       - title: Support fewer connections
         summary: >-
-          ReportStream’s model focuses on aggregating data from multiple sources and senders, which you receive together in a single feed at your preferred frequency and format.
+          ReportStream's model focuses on aggregating data from multiple sources and senders, which you receive together in a single feed at your preferred frequency and format.
         icon: code.svg
         iconDescription: computer code
       - title: Get valuable insights

--- a/frontend/src/_includes/details_report.liquid
+++ b/frontend/src/_includes/details_report.liquid
@@ -96,7 +96,7 @@
       </li>
     </ol>
   </nav>
-  <h2 class="margin-top-0 margin-bottom-10">
+  <h2 class="margin-top-0 margin-bottom-4">
     <p id="download" class="margin-top-0 margin-bottom-0">Report: <span id="report.id">This is the report ID</span></p>
   </h2>
 </section>
@@ -105,5 +105,5 @@
   <hr />
   <div id="details" class="grid-row grid-gap margin-top-0">
   </div>
-  <hr />
+  <hr class="margin-top-3" />
 </section>

--- a/frontend/src/_includes/details_report.liquid
+++ b/frontend/src/_includes/details_report.liquid
@@ -92,7 +92,7 @@
         </a>
       </li>
       <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-        <span id="org_name"> </span>
+        <span>Report details</span>
       </li>
     </ol>
   </nav>

--- a/frontend/src/_includes/details_report.liquid
+++ b/frontend/src/_includes/details_report.liquid
@@ -45,9 +45,9 @@
                     <p class="text-bold margin-top-0">${moment.utc(report.sent).local().format( 'dddd, MMM DD, YYYY  HH:mm' )}</p>
             </div>
             <div class="tablet:grid-col-6">
-                    <h4 class="text-base margin-bottom-0">Total reporting</h4>
+                    <h4 class="text-base margin-bottom-0">Total tests reported</h4>
                     <p class="text-bold margin-top-0">${report.total}</p>
-                    <h4 class="text-base margin-bottom-0">Expires</h4>
+                    <h4 class="text-base margin-bottom-0">Download expires</h4>
                     <p class="text-bold margin-top-0">${moment.utc(report.expires).local().format( 'dddd, MMM DD, YYYY  HH:mm')}</p>
             </div>`
       document.getElementById( "report.id").innerHTML = report.reportId;

--- a/frontend/src/_includes/disclaimer.liquid
+++ b/frontend/src/_includes/disclaimer.liquid
@@ -1,0 +1,5 @@
+<section aria-label="Disclaimer" role="region">
+  <div class="grid-container usa-section usa-prose font-sans-2xs text-base-darker">
+    <p>Data aggregated with ReportStream may be subject to the Privacy Act of 1974, the Health Insurance Portability and Accountability Act of 1996 (HIPAA), and other laws, and requires special safeguarding.</p>
+  </div>
+</section>

--- a/frontend/src/_includes/menu_documentation.liquid
+++ b/frontend/src/_includes/menu_documentation.liquid
@@ -1,7 +1,7 @@
 <section class="grid-container margin-bottom-5">
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-3">
-      <nav aria-label="Secondary navigation">
+      <nav aria-label="Secondary navigation" class="margin-bottom-6">
         <ul class="usa-sidenav">
           <li class="usa-sidenav__item">
             <a href="{{ site.documentationPath }}"

--- a/frontend/src/_layouts/protected.liquid
+++ b/frontend/src/_layouts/protected.liquid
@@ -62,6 +62,10 @@ local_styles:
   {% endif %}
 </main>
 
+{% if disclaimer %}
+  {% include disclaimer %}
+{% endif %}
+
 {% include identifier %}
 
   {% for entry in post_scripts %}

--- a/frontend/src/data-index.html
+++ b/frontend/src/data-index.html
@@ -5,6 +5,7 @@ permalink: "{{ title | slug }}/"
 protected: true
 show_navbar: true
 show_menu: false
+disclaimer: true
 ---
 
 

--- a/frontend/src/data-show.html
+++ b/frontend/src/data-show.html
@@ -4,10 +4,10 @@ title: "Report details"
 protected: true
 show_navbar: true
 show_menu: false
+disclaimer: true
 permalink: "{{ title | slug }}/"
 ---
 
 {% include details_report %}
 {% include table_facilities %}
 <!-- {% include actions %} -->
-  

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -87,7 +87,7 @@ show_menu: false
     <div class="grid-row grid-gap  margin-bottom-2 padding-top-2">
       {% for item in content.index.freeSecure %}
         <div class="tablet:grid-col-6">
-          <img src="{{ site.imgPath }}{{ item.icon }}" aria-hidden="true" focusable="false" alt="Icon of {{ item.iconDescription }}" class="height-7"/>
+          <img src="{{ site.imgPath }}{{ item.icon }}" focusable="false" alt="Icon of {{ item.iconDescription }}" class="height-7"/>
           <h3 class="font-sans-lg">{{ item.title }}</h3>
           <p class="usa-prose">{{ item.summary }}</p>
         </div>

--- a/frontend/src/web-receiver-guide.html
+++ b/frontend/src/web-receiver-guide.html
@@ -35,7 +35,7 @@ current: "web receiver guide"
 <section>
   <h2>Using the Web Receiver</h2>
   <h3>Recommended browser</h3>
-  <p>Please use a modern desktop web browser (ex: <a href="https://www.google.com/chrome/" target="_blank" rel="noopener">Chrome</a>, <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank" rel="noopener">Firefox</a>, <a href="https://www.microsoft.com/en-us/edge" target="_blank" rel="noopener">Edge</a>) to access the Web Receiver site. Please note: the application does not support Internet Explorer 11 or below.</p>
+  <p>Please use a modern desktop web browser (ex: <a href="https://www.google.com/chrome/" target="_blank" rel="noopener">Chrome</a>, <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank" rel="noopener">Firefox</a>, <a href="https://www.apple.com/safari/" target="_blank" rel="noopener">Safari</a>, <a href="https://www.microsoft.com/en-us/edge" target="_blank" rel="noopener">Edge</a>) to access the Web Receiver site. Please note: the application does not support Internet Explorer 11 or below.</p>
 
   <h3>General usage</h3>
 


### PR DESCRIPTION
This PR ... 

Ongoing content fixes from yesterday's bug bash.

## Changes
- Adds a disclaimer partial with text suggestion from Rick
- Adds `if` to main layout to display disclaimer and adds related frontmatter to `data-index` and `data-show` pages
- Edits to homepage content: combines State and Local sections into one after feedback from Rick
- Adds extra spacing for sidebar menu on mobile
- Adds extra text for clarity to data-show labels
- Adds safari as a recommended browser + link

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

