### PR TITLE
Bug Fix Settings Authentication Bug

### DIFF
--- a/prime-router/src/main/kotlin/azure/Authentication.kt
+++ b/prime-router/src/main/kotlin/azure/Authentication.kt
@@ -51,7 +51,7 @@ class TestAuthenticationVerifier : AuthenticationVerifier {
 }
 
 class OktaAuthenticationVerifier : AuthenticationVerifier {
-    private val issuerBaseUrl: String = System.getenv(envVariableForOktaBaseUrl)
+    private val issuerBaseUrl: String = System.getenv(envVariableForOktaBaseUrl) ?: ""
 
     override val requiredHosts = emptyList<String>()
 

--- a/prime-router/src/main/kotlin/azure/Authentication.kt
+++ b/prime-router/src/main/kotlin/azure/Authentication.kt
@@ -51,7 +51,7 @@ class TestAuthenticationVerifier : AuthenticationVerifier {
 }
 
 class OktaAuthenticationVerifier : AuthenticationVerifier {
-    val issuerBaseUrl = System.getenv(envVariableForOktaBaseUrl)
+    private val issuerBaseUrl: String = System.getenv(envVariableForOktaBaseUrl)
 
     override val requiredHosts = emptyList<String>()
 
@@ -76,19 +76,19 @@ class OktaAuthenticationVerifier : AuthenticationVerifier {
         minimumLevel: PrincipalLevel,
         organizationName: String?
     ): Boolean {
-        if (organizationName == null && minimumLevel != PrincipalLevel.SYSTEM_ADMIN)
-            error("Internal Error: Expected checks without organizationName to be at the SYSTEM ADMIN level")
+        val groupName = organizationName?.replace('-', '_')
         val lookupMemberships = when (minimumLevel) {
             PrincipalLevel.SYSTEM_ADMIN -> listOf(oktaSystemAdminGroup)
-            PrincipalLevel.ORGANIZATION_ADMIN ->
+            PrincipalLevel.ORGANIZATION_ADMIN -> {
                 listOf(
-                    "$oktaGroupPrefix$organizationName$oktaAdminGroupSuffix",
+                    "$oktaGroupPrefix$groupName$oktaAdminGroupSuffix",
                     oktaSystemAdminGroup
                 )
+            }
             PrincipalLevel.USER ->
                 listOf(
-                    "$oktaGroupPrefix$organizationName",
-                    "$oktaGroupPrefix$organizationName$oktaAdminGroupSuffix",
+                    "$oktaGroupPrefix$groupName",
+                    "$oktaGroupPrefix$groupName$oktaAdminGroupSuffix",
                     oktaSystemAdminGroup
                 )
         }

--- a/prime-router/src/test/kotlin/azure/AuthenticationTests.kt
+++ b/prime-router/src/test/kotlin/azure/AuthenticationTests.kt
@@ -5,26 +5,35 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AuthenticationTests {
-    val verifier = OktaAuthenticationVerifier()
+    private val verifier = OktaAuthenticationVerifier()
 
     @Test
     fun `test user level checkMembership`() {
         val userMemberships = listOf("DHpima_az_phd")
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "pima_az_phd"))
-        assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "foo"))
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = "pima-az-phd"))
+        assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = "az-phd"))
+    }
+
+    @Test
+    fun `test multiple user level checkMembership`() {
+        val userMemberships = listOf("DHpima_az_phd", "DHaz_phd")
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = "pima-az-phd"))
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = "az-phd"))
+        assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = "pa-phd"))
+        assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.USER, organizationName = null))
     }
 
     @Test
     fun `test user level checkMembership with admin account`() {
         val userMemberships = listOf("DHpima_az_phdAdmins", "DHfoo_ax")
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "pima_az_phd"))
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "pima-az-phd"))
         assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "foo"))
     }
 
     @Test
     fun `test user level checkMembership with system account`() {
         val userMemberships = listOf("DHPrimeAdmins")
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "pima_az_phd"))
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "pima-az-phd"))
         // Any org will return true
         assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.USER, "foo"))
         val multiMemberships = listOf("DHPrimeAdmins", "DHfox")
@@ -33,28 +42,44 @@ class AuthenticationTests {
 
     @Test
     fun `test admin level checkMembership with system account`() {
-        val userMemberships = listOf("DHPrimeAdmins")
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "pima_az_phd"))
-        // Any org will return true
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
-        val multiMemberships = listOf("DHPrimeAdmins", "DHfox")
-        assertTrue(verifier.checkMembership(multiMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        // A Prime Admin should always have verified
+        val single = listOf("DHPrimeAdmins")
+        assertTrue(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "pima-az-phd"))
+        assertTrue(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        assertTrue(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, null))
+        val multi = listOf("DHPrimeAdmins", "DHfox")
+        assertTrue(verifier.checkMembership(multi, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+    }
+
+    @Test
+    fun `test admin level checkMembership with user account`() {
+        // A Prime Admin should always have verified
+        val single = listOf("DHaz_phd")
+        assertFalse(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "az-phd"))
+        assertFalse(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        assertFalse(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, null))
+        val multi = listOf("DHaz_phd", "DHfox")
+        assertFalse(verifier.checkMembership(multi, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
     }
 
     @Test
     fun `test admin level checkMembership`() {
-        val userMemberships = listOf("DHpima_az_phdAdmins")
-        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "pima_az_phd"))
-        assertFalse(verifier.checkMembership(userMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
-        val multiMemberships = listOf("DHpima_az_phd", "DHpima_az_phdAdmins")
-        assertTrue(verifier.checkMembership(multiMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "pima_az_phd"))
-        assertFalse(verifier.checkMembership(multiMemberships, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        // a pima_az_phd admin should only be valid for pima-az-orgs
+        val single = listOf("DHpima_az_phdAdmins")
+        assertTrue(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "pima-az-phd"))
+        assertFalse(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        assertFalse(verifier.checkMembership(single, PrincipalLevel.ORGANIZATION_ADMIN, null))
+        val multi = listOf("DHpima_az_phd", "DHpima_az_phdAdmins")
+        assertTrue(verifier.checkMembership(multi, PrincipalLevel.ORGANIZATION_ADMIN, "pima-az-phd"))
+        assertFalse(verifier.checkMembership(multi, PrincipalLevel.ORGANIZATION_ADMIN, "foo"))
+        assertFalse(verifier.checkMembership(multi, PrincipalLevel.ORGANIZATION_ADMIN, null))
     }
 
     @Test
     fun `test system level checkMembership with system account`() {
         val userMemberships = listOf("DHPrimeAdmins")
         assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.SYSTEM_ADMIN, "foo"))
+        assertTrue(verifier.checkMembership(userMemberships, PrincipalLevel.SYSTEM_ADMIN, null))
         val multiMemberships = listOf("DHPrimeAdmins", "DHfox")
         assertTrue(verifier.checkMembership(multiMemberships, PrincipalLevel.SYSTEM_ADMIN, "foo"))
     }


### PR DESCRIPTION
This PR fixes a bug discovered during a bug bash where the web receiver would not see the organization name. The cause turned out to be a general authorization bug in the setting API. 

## Changes
- checkClaim had a bug due the _ vs - difference in organization naming
- Added tests for this condition

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [] Downloaded a file from `http://localhost:7071/api/download`?
- [x] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [x] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #976

## To Be Done
*Create GitHub issues to track the work remaining, if any*


