### PR TITLE
239 - Fix Release build script to use Gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,21 +33,14 @@ jobs:
           distribution: 'adopt'
           java-version: 11
 
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-maven-${{ hashFiles('prime-router/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
-
-      - name: Build Maven Package
-        run: mvn -B clean package --file pom.xml -Dpg.user=$POSTGRES_USER -Dpg.password=$POSTGRES_PASSWORD
+      - name: Build Prime Router Package
+        run: bash ./gradlew clean package -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
-          path: prime-router/target
+          path: prime-router/build
           retention-days: 7
 
   build_frontend_release:
@@ -90,7 +83,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
-          path: prime-router/target
+          path: prime-router/build
 
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v2
@@ -156,7 +149,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
-          path: prime-router/target
+          path: prime-router/build
 
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v2
@@ -223,7 +216,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: prime-router-build-${{ github.run_id }}
-          path: prime-router/target
+          path: prime-router/build
 
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This PR updates the release build script to use Gradle.  Unfortunately it cannot be tested without a merge.

## Changes
- Update the release build script to use Gradle

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
Issue #239



