### PR TITLE
Adds manifest property to suppress fat jar warning

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -82,6 +82,7 @@ tasks.jar {
         /* We put the CLI main class in the manifest at this step as a convenience to allow this jar to be
         run by the ./prime script. It will be overwritten by the Azure host or the CLI fat jar package. */
         attributes("Main-Class" to primeMainClass)
+        attributes("Multi-Release" to true)
     }
 }
 


### PR DESCRIPTION
This PR adds a property to the manifest for the jar to prevent warnings after building the fat jar. 

## Changes
- Adds property to the manifest for the jar

