### PR TITLE
1005 - Added dependency to setting files for test task

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -65,6 +65,11 @@ tasks.test {
     // Use JUnit 5 for running tests
     useJUnitPlatform()
     dependsOn("compileKotlin")
+    // Run the test task if specified configuration files are changed
+    inputs.files(fileTree("./") {
+        include("settings/**/*.yml")
+        include("metadata/**/*")
+    })
     outputs.upToDateWhen { 
         // Call gradle with the -Pforcetest option will force the unit tests to run
         if (project.hasProperty("forcetest")) {


### PR DESCRIPTION
This PR adds a dependency to the Gradle test task to the settings files in the metadata and settings folders.  A change to any of those files will trigger a rerun of the Gradle test task.  I tested this changing files at the different folder levels.

To test:

1. Run `./gradlew test` twice.  The second time it will not run the tests as everything is up to date.
2. Change one or more files in settings (a YML file) and/or metadata (any file) and rerun `./gradlew test` and verify the test run.

## Changes
- add a dependency to the Gradle test task to the settings files in the metadata and settings folders

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
-  https://github.com/CDCgov/prime-data-hub/issues/1005


