### PR TITLE
Increase timeout for front door app

### DIFF
--- a/operations/app/src/modules/front_door/main.tf
+++ b/operations/app/src/modules/front_door/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_frontdoor" "front_door" {
     name = local.name
     resource_group_name = var.resource_group
     enforce_backend_pools_certificate_name_check = true
-    backend_pools_send_receive_timeout_seconds = 30
+    backend_pools_send_receive_timeout_seconds = 90
     friendly_name = local.name
 
     backend_pool_load_balancing {


### PR DESCRIPTION
This PR increases the timeout for the front door from 30 seconds to 90 seconds. Resolves #1003.

## Changes
- Front door timeout increased from 30 seconds to 90 seconds, to allow for slow SFTP checks as described in #1003.
- Function app checked for a similar timeout setting. [The function app's default timeout is 5 minutes](https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json#functiontimeout) and does not require a change.
- Kotlin checked for a similar timeout. Our Kotlin code relies on Azure's HTTP server and the timeout is configurable via the function app, hence no setting to change.

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?


