### PR TITLE
Removed SQL exclusion from build script

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -51,11 +51,6 @@ val compileTestKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions.jvmTarget = "11"
 compileTestKotlin.kotlinOptions.jvmTarget = "11"
 
-sourceSets.main {
-    // Exclude SQL files from being copied to resulting package
-    resources.exclude("**/*.sql")
-}
-
 tasks.clean {
     // Delete the old Maven build folder
     delete("target")


### PR DESCRIPTION
This PR adds the SQL scripts to the build artifact.

To test:

1. Build and package the baseline by running `./gradlew clean package`
2. Inspect the contents of the file `build/azure-functions/prime-data-hub-router/prime-router-0.1-SNAPSHOT.jar` e.g. open as a ZIP file) and verify the SQL files exist in the `db/migration` folder

## Changes
- Add SQL scripts to build artifact

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
- #1024 

## To Be Done


