### PR TITLE
Issue 1007: Adding topic to /api/reports Json response

### DIFF
--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -178,7 +178,7 @@ A useful Azure tool to examine Azurite and Azure storage is (Storage Explorer)[h
 
 ## Function Development with Docker Compose
 ### Local SFTP Server
-You will need an SFTP server to receive data from the router.  For local tests, refer to the [SFTP-SETUP document](SFTP_SETUP.md) to setup a local SFTP server as a receiver of data.
+You will need an SFTP server to receive data from the router.  For local tests, refer to the [SFTP-SETUP document](SFTP-SETUP.md) to setup a local SFTP server as a receiver of data.
 
 ### Running the Router Locally
 The project's [README](../readme.md) file contains some steps to use the PRIME router in a CLI. However, for the POC app and most other users of the PRIME router will the router in the Microsoft Azure cloud. When hosted in Azure, the PRIME router uses Docker containers. The `DockerFile` describes how to build this container. 

--- a/prime-router/docs/openapi.yml
+++ b/prime-router/docs/openapi.yml
@@ -456,6 +456,9 @@ components:
         id:
           description: the id for the report assigned by the Hub
           type: string
+        topic:
+          description: the topic configured for the client organization sender
+          type: string
         reportItemCount:
           description: total number of individual reports sent to the Hub (in a csv, the number of data lines sent)
           type: integer

--- a/prime-router/docs/openapi.yml
+++ b/prime-router/docs/openapi.yml
@@ -456,6 +456,10 @@ components:
         id:
           description: the id for the report assigned by the Hub
           type: string
+        timestamp:
+          description: the timestamp for this report submission
+          type: string
+          format: time-date
         topic:
           description: the topic configured for the client organization sender
           type: string

--- a/prime-router/docs/releases/2021-05-12-release-notes.md
+++ b/prime-router/docs/releases/2021-05-12-release-notes.md
@@ -1,0 +1,23 @@
+#  Hub Release Notes
+
+*May 12, 2021*
+
+## General useful links:
+
+- All Schemas are documented here:  [Link to detailed schema dictionaries](../schema_documentation)
+- The Hub API is documented here: [Hub OpenApi Spec](../openapi.yml)
+- [Click here for all release notes](../releases)
+
+## For this release
+
+### Changes to api/reports response
+
+This release adds the configured topic for the organization sender to the Json response. The openapi.yml was updated to reflect the changes as well.
+
+```
+{
+  "id" : "abcd1234-abcd-1234-abcd-abcd1234abcd",
+  "topic" : "covid-19",
+  "reportItemCount" : 25,
+  "destinations" : [ {
+```

--- a/prime-router/docs/releases/2021-05-12-release-notes.md
+++ b/prime-router/docs/releases/2021-05-12-release-notes.md
@@ -12,11 +12,12 @@
 
 ### Changes to api/reports response
 
-This release adds the configured topic for the organization sender to the Json response. The openapi.yml was updated to reflect the changes as well.
+This release adds the configured topic for the organization sender to the Json response along with an ISO-8601 timestamp. The openapi.yml was updated to reflect the changes as well.
 
 ```
 {
   "id" : "abcd1234-abcd-1234-abcd-abcd1234abcd",
+  "timestamp" : "2021-05-11T20:05:02.571867Z",
   "topic" : "covid-19",
   "reportItemCount" : 25,
   "destinations" : [ {

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -19,6 +19,8 @@ import gov.cdc.prime.router.Sender
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.time.format.DateTimeFormatter
+import java.time.Instant
 import java.util.logging.Level
 
 private const val CLIENT_PARAMETER = "client"
@@ -317,6 +319,7 @@ class ReportFunction {
             it.writeStartObject()
             if (result.report != null) {
                 it.writeStringField("id", result.report.id.toString())
+                it.writeStringField("timestamp", DateTimeFormatter.ISO_INSTANT.format(Instant.now()))
                 it.writeStringField("topic", result.report.schema.topic.toString())
                 it.writeNumberField("reportItemCount", result.report.itemCount)
             } else

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -317,6 +317,7 @@ class ReportFunction {
             it.writeStartObject()
             if (result.report != null) {
                 it.writeStringField("id", result.report.id.toString())
+                it.writeStringField("topic", result.report.schema.topic.toString())
                 it.writeNumberField("reportItemCount", result.report.itemCount)
             } else
                 it.writeNullField("id")

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -518,12 +518,10 @@ class End2End : CoolTest() {
                 passed = false
             }
             waitABit(25, environment)
-            passed = examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
+            return passed and examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
         } catch (e: NullPointerException) {
-            bad("***end2end Test FAILED***: Unable to properly parse response json")
-            passed = false
+            return bad("***end2end Test FAILED***: Unable to properly parse response json")
         }
-        return passed
     }
 }
 

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -518,13 +518,10 @@ class End2End : CoolTest() {
                 passed = false
             }
             waitABit(25, environment)
-            return examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
+            passed = examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
         } catch (e: NullPointerException) {
-            return bad("***end2end Test FAILED***: Unable to properly parse response json")
+            bad("***end2end Test FAILED***: Unable to properly parse response json")
             passed = false
-        }
-        if (!passed) {
-            bad("***end2end Test FAILED***")
         }
         return passed
     }

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -507,6 +507,8 @@ class End2End : CoolTest() {
             val tree = jacksonObjectMapper().readTree(json)
             val reportId = ReportId.fromString(tree["id"].textValue())
             echo("Id of submitted report: $reportId")
+            val topic = tree["topic"].textValue()
+            echo("Topic for client org sender: $topic")
             waitABit(25, environment)
             return examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
         } catch (e: NullPointerException) {

--- a/prime-router/src/main/kotlin/cli/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/TestReportStream.kt
@@ -484,6 +484,7 @@ class End2End : CoolTest() {
     override val status = TestStatus.GOODSTUFF
 
     override fun run(environment: ReportStreamEnv, options: CoolTestOptions): Boolean {
+        var passed = true
         ugly("Starting $name Test: send ${simpleRepSender.fullName} data to $allGoodCounties")
         val fakeItemCount = allGoodReceivers.size * options.items
         val file = FileUtilities.createFakeFile(
@@ -498,22 +499,34 @@ class End2End : CoolTest() {
         // Now send it to ReportStream.
         val (responseCode, json) =
             HttpUtilities.postReportFile(environment, file, org.name, simpleRepSender.name, options.key)
-        echo("Response to POST: $responseCode")
-        echo(json)
         if (responseCode != HttpURLConnection.HTTP_CREATED) {
-            return bad("***end2end Test FAILED***:  response code $responseCode")
+            bad("***end2end Test FAILED***:  response code $responseCode")
+            passed = false
+        } else {
+            good("Posting of report succeeded with response code $responseCode")
         }
+        echo(json)
         try {
             val tree = jacksonObjectMapper().readTree(json)
             val reportId = ReportId.fromString(tree["id"].textValue())
             echo("Id of submitted report: $reportId")
-            val topic = tree["topic"].textValue()
-            echo("Topic for client org sender: $topic")
+            val topic = tree["topic"]
+            if (topic != null && !topic.isNull && topic.textValue().equals("covid-19", true)) {
+                good("'topic' is in response and correctly set to 'covid-19'")
+            } else {
+                bad("***end2end Test FAILED***: 'topic' is missing from response json")
+                passed = false
+            }
             waitABit(25, environment)
             return examineLineageResults(reportId, allGoodReceivers, fakeItemCount)
         } catch (e: NullPointerException) {
             return bad("***end2end Test FAILED***: Unable to properly parse response json")
+            passed = false
         }
+        if (!passed) {
+            bad("***end2end Test FAILED***")
+        }
+        return passed
     }
 }
 


### PR DESCRIPTION
## Changes
- added "topic" to the POST Json response for /api/reports
- updated the openapi.yml to reflect the added Json element
- added an echo of the topic (right after Id) in end2end test which will fail if it doesn't exist with an "Unable to properly parse response json" message
- fixed a documentation link in the getting started doc that was going to 404 page

## Checklist
- [ ] Verify that the "topic" is added to the POST /api/reports response Json
- [ ] Review the CLI TestReportStream to determine if the test is adequate
- [ ] Check the openapi.yaml for correctness
- [ ] Ensure the link change for the SFTP readme is correct 

### Testing
- [Y] Tested locally?
- [Y] Ran `quickTest all`?
- [-] Ran `./prime test` against local Docker ReportStream container?
I am seeing end2end, merge, garbage tests failing on this branch, but also fails on the current master branch
- [N] Downloaded a file from `http://localhost:7071/api/download`?
Not sure of the credentials to use here
- [Y] Added tests?
Checking for "topic" in the response Json payload, if it doesn't exist it fails

### Security
- [Y] Did you check for sensitive data, and remove any? 
- [Y] Does logging contain sensitive data?  
- [?] Are additional approvals needed for this change?
- [N] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [Y] Includes a summary of what a code reviewer should verify?
- [N] Updated the release notes?
How do we handle adding notes for an upcoming release? Are the release notes manually curated or generated?
- [-] Database changes are submitted as a separate PR?
- [-] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #1007

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

