### PR TITLE
Test support of international characters in content

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -320,6 +320,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core:7.8.2")
     implementation("com.github.kayr:fuzzy-csv:1.6.48")
     implementation("org.commonmark:commonmark:0.17.1")
+    implementation("com.google.guava:guava:30.1.1-jre")
 
     runtimeOnly("com.okta.jwt:okta-jwt-verifier-impl:0.5.1")
     runtimeOnly("com.github.kittinunf.fuel:fuel-jackson:2.3.1")

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -28,6 +28,7 @@ description = "prime-router"
 val azureAppName = "prime-data-hub-router"
 val azureFunctionsDir = "azure-functions"
 val primeMainClass = "gov.cdc.prime.router.cli.MainKt"
+azurefunctions.appName = azureAppName
 
 // Local database information
 val dbUser = (project.properties["DB_USER"] ?: "prime") as String
@@ -140,17 +141,6 @@ tasks.register<JavaExec>("generateDocs") {
     main = primeMainClass
     classpath = sourceSets["main"].runtimeClasspath
     args = listOf("generate-docs")
-}
-
-azurefunctions {
-    appName = azureAppName
-    setAppSettings(
-        closureOf<MutableMap<String, String>> {
-            this["WEBSITE_RUN_FROM_PACKAGE"] = "1"
-            this["FUNCTIONS_EXTENSION_VERSION"] = "3"
-            this["FUNCTIONS_WORKER_RUNTIME"] = "java"
-        }
-    )
 }
 
 tasks.azureFunctionsPackage {

--- a/prime-router/gradle.properties
+++ b/prime-router/gradle.properties
@@ -1,3 +1,3 @@
 # Set the character encoding when running from Gradle.
 # This affects the unit tests and runs of the primeCLI from Gradle.
-org.gradle.jvmargs
+org.gradle.jvmargs="-Dfile.encoding=UTF8"

--- a/prime-router/gradle.properties
+++ b/prime-router/gradle.properties
@@ -1,0 +1,3 @@
+# Set the character encoding when running from Gradle.
+# This affects the unit tests and runs of the primeCLI from Gradle.
+org.gradle.jvmargs

--- a/prime-router/local.settings.json
+++ b/prime-router/local.settings.json
@@ -1,8 +1,10 @@
 {
   "IsEncrypted": false,
   "Values": {
+    "WEBSITE_RUN_FROM_PACKAGE": "1",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "FUNCTIONS_EXTENSION_VERSION": "~3",
+    "JAVA_OPTS": "-Dfile.encoding=UTF-8"
   },
   "ConnectionStrings": {}
 }

--- a/prime-router/prime
+++ b/prime-router/prime
@@ -42,4 +42,4 @@ else
   exit 1
 fi
 
-java -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -jar $jar "$@"
+java -Dfile.encoding=UTF8 -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -jar $jar "$@"

--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -3,7 +3,7 @@ package gov.cdc.prime.router
 import com.github.javafaker.Faker
 import com.github.javafaker.Name
 import java.text.SimpleDateFormat
-import java.util.Random
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 /*
@@ -179,16 +179,17 @@ class FakeDataService {
     }
 }
 
-class FakeReport(val metadata: Metadata) {
+class FakeReport(val metadata: Metadata, val locale : Locale? = null) {
     private val fakeDataService: FakeDataService = FakeDataService()
 
     class RowContext(
         findLookupTable: (String) -> LookupTable? = { null },
         reportState: String? = null,
         val schemaName: String? = null,
-        reportCounty: String? = null
+        reportCounty: String? = null,
+        val locale : Locale? = null
     ) {
-        val faker = Faker()
+        val faker = if (locale == null) Faker() else Faker(locale)
         val patientName: Name = faker.name()
         val schoolName: String = faker.university().name()
         val equipmentModel = randomChoice(
@@ -277,7 +278,7 @@ class FakeReport(val metadata: Metadata) {
     }
 
     private fun buildRow(schema: Schema, targetState: String? = null, targetCounty: String? = null): List<String> {
-        val context = RowContext(metadata::findLookupTable, targetState, schemaName = schema.name, targetCounty)
+        val context = RowContext(metadata::findLookupTable, targetState, schemaName = schema.name, targetCounty, locale)
         return schema.elements.map {
             if (it.mapper.isNullOrEmpty())
                 buildColumn(it, context)

--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -131,7 +131,7 @@ class FakeDataService {
                 "fips-county" -> {
                     when {
                         element.nameContains("state") -> context.state
-                        element.nameContains("county") -> context.county ?: ""
+                        element.nameContains("county") -> context.county
                         else -> TODO("Add this column in a table")
                     }
                 }
@@ -144,7 +144,7 @@ class FakeDataService {
         // each element has a type, and depending on the type defined on the
         // element, we call into some of the functions above
         return when (element.type) {
-            Element.Type.CITY -> context.city ?: faker.address().city()
+            Element.Type.CITY -> context.city
             Element.Type.POSTAL_CODE -> context.zipCode
             Element.Type.TEXT -> createFakeText(element)
             Element.Type.BLANK -> ""
@@ -299,7 +299,7 @@ class FakeReport(val metadata: Metadata, val locale : Locale? = null) {
             metadata.findLookupTable("fips-county")?.getDistinctValuesInColumn("State")
                 ?.toList()
         } else {
-            targetStates?.split(",")
+            targetStates.split(",")
         }
         val rows = (0 until count).map {
             buildRow(schema, roundRobinChoice(states), roundRobinChoice(counties))

--- a/prime-router/src/main/kotlin/cli/FileUtilities.kt
+++ b/prime-router/src/main/kotlin/cli/FileUtilities.kt
@@ -6,6 +6,7 @@ import gov.cdc.prime.router.serializers.CsvSerializer
 import gov.cdc.prime.router.serializers.Hl7Serializer
 import gov.cdc.prime.router.serializers.RedoxSerializer
 import java.io.File
+import java.util.*
 
 class FileUtilities {
     companion object {
@@ -17,6 +18,7 @@ class FileUtilities {
             targetCounties: String? = null,
             directory: String = ".",
             format: Report.Format = Report.Format.CSV,
+            locale : Locale? = null
         ): File {
             val report = createFakeReport(
                 metadata,
@@ -24,6 +26,7 @@ class FileUtilities {
                 count,
                 targetStates,
                 targetCounties,
+                locale
             )
             return writeReportToFile(report, format, metadata, directory, null)
         }
@@ -34,8 +37,9 @@ class FileUtilities {
             count: Int,
             targetStates: String? = null,
             targetCounties: String? = null,
+            locale : Locale? = null
         ): Report {
-            return FakeReport(metadata).build(
+            return FakeReport(metadata, locale).build(
                 metadata.findSchema(sender.schemaName)
                     ?: error("Unable to find schema ${sender.schemaName}"),
                 count,

--- a/prime-router/src/test/kotlin/serializers/CsvSerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/CsvSerializerTests.kt
@@ -473,10 +473,6 @@ class CsvSerializerTests {
 
     @Test
     fun `test using international characters`() {
-        val charset = Charsets.UTF_8
-        assertTrue(Charset.defaultCharset().equals(charset),
-            "Expecting default JVM charset to be $charset, but was ${Charset.defaultCharset()}")
-
         val one = Schema(
             name = "one",
             topic = "test",
@@ -489,9 +485,9 @@ class CsvSerializerTests {
         // Sample UTF-8 taken from https://www.kermitproject.org/utf8.html as a byte array, so we are not
         // restricted by the encoding of this code file
         val koreanString = String(byteArrayOf(-21, -126, -104, -21, -118, -108, 32, -20, -100, -96, -21, -90, -84, -21, -91, -68),
-            charset)
+            Charsets.UTF_8)
         val greekString = String(byteArrayOf(-50, -100, -49, -128, -50, -65, -49, -127, -49, -114),
-            charset)
+            Charsets.UTF_8)
 
         // Java strings are stored as UTF-16
         val csv = """

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -12,6 +12,7 @@ import gov.cdc.prime.router.TestSource
 import org.junit.jupiter.api.TestInstance
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -157,5 +158,48 @@ NTE|1|L|This is a final comment|RE"""
         assertTrue(report.itemCount == 2)
         val hospitalized = (0 until report.itemCount).map { report.getString(it, "hospitalized") }
         assertEquals(setOf(""), hospitalized.toSet())
+    }
+
+    @Test
+    fun `test reading message with international characters from serializer`() {
+        val charset = Charsets.UTF_8
+        assertTrue(
+            Charset.defaultCharset().equals(charset),
+            "Expecting default JVM charset to be $charset, but was ${Charset.defaultCharset()}")
+
+        // Sample UTF-8 taken from https://www.kermitproject.org/utf8.html as a byte array, so we are not
+        // restricted by the encoding of this code file
+        val greekString = String(byteArrayOf(-50, -100, -49, -128, -50, -65, -49, -127, -49, -114),
+            charset)
+
+        // Java strings are stored as UTF-16
+        val intMessage = """MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|||20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
+SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME Data Hub|0.1-SNAPSHOT||20210210
+PID|1||2a14112c-ece1-4f82-915c-7b3a8d152eda^^^Avante at Ormond Beach^PI||$greekString^Kareem^Millie^^^^L||19580810|F||2106-3^White^HL70005^^^^2.5.1|688 Leighann Inlet^^South Rodneychester^TX^67071||^PRN^^roscoe.wilkinson@email.com^1^211^2240784|||||||||U^Unknown^HL70189||||||||N
+ORC|RE|73a6e9bd-aaec-418e-813a-0ad33366ca85|73a6e9bd-aaec-418e-813a-0ad33366ca85|||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI||^WPN^^^1^386^6825220|20210209||||||Avante at Ormond Beach|170 North King Road^^Ormond Beach^FL^32174^^^^12127|^WPN^^jbrush@avantecenters.com^1^407^7397506|^^^^32174
+OBR|1|73a6e9bd-aaec-418e-813a-0ad33366ca85||94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN|||202102090000-0600|202102090000-0600||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI|^WPN^^^1^386^6825220|||||202102090000-0600|||F
+OBX|1|CWE|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN||260415000^Not detected^SCT|||N^Normal (applies to non-numeric results)^HL70078|||F|||202102090000-0600|||CareStart COVID-19 Antigen test_Access Bio, Inc._EUA^^99ELR||202102090000-0600||||Avante at Ormond Beach^^^^^CLIA&2.16.840.1.113883.19.4.6&ISO^^^^10D0876999^CLIA|170 North King Road^^Ormond Beach^FL^32174^^^^12127
+NTE|1|L|This is a comment|RE
+OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+OBX|4|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+OBX|5|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+SPM|1|||258500001^Nasopharyngeal swab^SCT||||71836000^Nasopharyngeal structure (body structure)^SCT^^^^2020-09-01|||||||||202102090000-0600^202102090000-0600
+NTE|1|L|This is a final comment|RE"""
+
+        // arrange
+        val mcf = CanonicalModelClassFactory("2.5.1")
+        context.modelClassFactory = mcf
+        val parser = context.pipeParser
+        // act
+        val reg = "(\r|\n)".toRegex()
+        val cleanedMessage = reg.replace(intMessage, "\r")
+        val hapiMsg = parser.parse(cleanedMessage)
+        val terser = Terser(hapiMsg)
+        // assert
+        assertEquals(
+            greekString,
+            terser.get("/.PID-5-1")
+        )
     }
 }

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -162,15 +162,10 @@ NTE|1|L|This is a final comment|RE"""
 
     @Test
     fun `test reading message with international characters from serializer`() {
-        val charset = Charsets.UTF_8
-        assertTrue(
-            Charset.defaultCharset().equals(charset),
-            "Expecting default JVM charset to be $charset, but was ${Charset.defaultCharset()}")
-
         // Sample UTF-8 taken from https://www.kermitproject.org/utf8.html as a byte array, so we are not
         // restricted by the encoding of this code file
         val greekString = String(byteArrayOf(-50, -100, -49, -128, -50, -65, -49, -127, -49, -114),
-            charset)
+            Charsets.UTF_8)
 
         // Java strings are stored as UTF-16
         val intMessage = """MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|||20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO


### PR DESCRIPTION
This PR adds tests for data with non-ascii characters to check support for international content.

To test:

1. Build and package the baseline: `./gradlew package` and verify the tests are successful.
2. Run the Docker container locally.
3. Run the international character end to end test: `./gradlew primecli --args="test --run intcontent"` and verify the test is successful.

## Changes
- Added serializer unit tests with international characters.  Note that internally Java uses UTF-16, so international characters are supported.
- Added end to end test with international characters.  
- Fixed some compiler warnings on files I touched.
- Added default file encoding to UTF-8.  Different platforms have different default file encodings.

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
- #487

## To Be Done
Need to set the default file.encoding for the Azure deployments.  Need help on this.

