### PR TITLE
1060 - Improve DEV build times for verify router step

### DIFF
--- a/.github/workflows/build_frontend.yaml
+++ b/.github/workflows/build_frontend.yaml
@@ -19,6 +19,7 @@ jobs:
           filters: |
             frontend:
               - 'frontend/**'
+              - '.github/workflows/build_frontend.yml'
       - id: fork_check
         run: echo "::set-output name=is_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
 

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -77,39 +77,12 @@ jobs:
           name: build_target
           path: prime-router/build
 
-  update_docs:
-    name: Verify Router Docs
-    needs: build_router
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: prime-router
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Explicitly use the head_ref here (which is a branch name, rather
-          # than a commit hash) so we can commit and push back to it.
-          ref: ${{ github.head_ref }}
-
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: 11
-
-      - name: Restore Build Target
-        uses: actions/download-artifact@v2
-        with:
-          name: build_target
-          path: prime-router/build
-
       - name: Generate New Docs
         run: |
           # Clean the docs before regenerating
           rm -rf docs/schema_documentation/*
           # Need to skip DB source generation as we do not have a database but the source is part of the artifacts
-          bash ./gradlew primeCLI --args='generate-docs' --exclude-task generateJooq
+          bash ./gradlew primeCLI --args='generate-docs'
 
       - name: Check for Uncommited Docs
         id: check_changes

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -19,7 +19,7 @@ jobs:
           filters: |
             router:
               - 'prime-router/**'
-              - '.github/build_hub.yml'
+              - '.github/workflows/build_hub.yml'
       - id: fork_check
         run: echo "::set-output name=is_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
 

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -123,6 +123,7 @@ jobs:
 
   update_docs:
     name: Verify Router Docs
+    runs-on: ubuntu-latest
     # Skip this deprecated job - This job needs to be removed once all other branches pull the latest build script
     if: false
     steps:

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -121,4 +121,8 @@ jobs:
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
 
+  update_docs:
+    name: Verify Router Docs
+    # Skip this deprecated job - This job needs to be removed once all other branches pull the latest build script
+    if: false
 

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -125,4 +125,8 @@ jobs:
     name: Verify Router Docs
     # Skip this deprecated job - This job needs to be removed once all other branches pull the latest build script
     if: false
+    steps:
+      - name: Deprecated Job
+        run: |
+            true
 

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           # Clean the docs before regenerating
           rm -rf docs/schema_documentation/*
-          # Need to skip DB source generation as we do not have a database but the source is part of the artifacts
           bash ./gradlew primeCLI --args='generate-docs'
 
       - name: Check for Uncommited Docs

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -69,15 +69,6 @@ jobs:
       - name: Build Prime Router Package
         run: bash ./gradlew clean package -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
 
-      - name: Build Docker Image
-        run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
-
-      - name: Save Build Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: build_target
-          path: prime-router/build
-
       - name: Generate New Docs
         run: |
           # Clean the docs before regenerating
@@ -127,4 +118,8 @@ jobs:
         if: ${{ steps.check_changes.outcome == 'failure' }}
         run: |
           false
+          
+      - name: Build Docker Image
+        run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest
+
 

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -19,6 +19,7 @@ jobs:
           filters: |
             router:
               - 'prime-router/**'
+              - '.github/build_hub.yml'
       - id: fork_check
         run: echo "::set-output name=is_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
 


### PR DESCRIPTION
This PR moves the steps under the Verify Docs build job into the Built Router Job to get rid of the need to save and restore build artifacts, which takes a long time.  The result of the build is the same.    This brought down the build time from about 12mins to 7 mins.

Test:
1. Verify the dev build is successful and that it runs the same steps as before.

## Changes
- Moved the verify docs steps into the build job.
- Removed the save/restore of build artifacts.
- Note there are no changes to the release build
- Added the Github Actions build scripts to the dependency of the DEV builds.
- Rearranged the steps to leave the packaging at the end, so if there is a failure it happens earlier in the build

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
- #1060

## To Be Done
- Need to remove the required Verify Router job from the PR tests once we agree these changes will work.


