### PR TITLE
PagerDuty Alerting Improvements

### DIFF
--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
-  frequency = "PT30M"
+  frequency = "PT1M"
   severity = 0
 
   criteria {
@@ -73,7 +73,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_error" {
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
-  frequency = "PT30M"
+  frequency = "PT1M"
   severity = 1
 
   criteria {
@@ -99,7 +99,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_warn" {
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
-  frequency = "PT30M"
+  frequency = "PT1M"
   severity = 2
 
   criteria {
@@ -125,7 +125,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
-  frequency = "PT30M"
+  frequency = "PT1M"
   severity = 1
 
   criteria {

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -67,9 +67,9 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "exception_alert" {
+resource "azurerm_monitor_metric_alert" "exception_alert_error" {
   count = local.alerting_enabled
-  name = "Exception(s) Raised"
+  name = "Over 10 Exceptions Raised in the Last Hour"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -81,7 +81,59 @@ resource "azurerm_monitor_metric_alert" "exception_alert" {
     metric_name = "exceptions/count"
     aggregation = "Count"
     operator = "GreaterThan"
+    threshold = 9
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group[0].id
+  }
+
+  tags = {
+    "environment" = var.environment
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "exception_alert_warn" {
+  count = local.alerting_enabled
+  name = "One or More Exceptions Raised in the Last Hour"
+  resource_group_name = var.resource_group
+  scopes = [azurerm_application_insights.app_insights.id]
+  window_size = "PT1H"
+  frequency = "PT30M"
+  severity = 2
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name = "exceptions/count"
+    aggregation = "Count"
+    operator = "GreaterThan"
     threshold = 0
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group[0].id
+  }
+
+  tags = {
+    "environment" = var.environment
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
+  count = local.alerting_enabled
+  name = "Over 100 Exceptions Raised in the Last Hour"
+  resource_group_name = var.resource_group
+  scopes = [azurerm_application_insights.app_insights.id]
+  window_size = "PT1H"
+  frequency = "PT30M"
+  severity = 1
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name = "exceptions/count"
+    aggregation = "Count"
+    operator = "GreaterThan"
+    threshold = 99
   }
 
   action {

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
   frequency = "PT1M"
-  severity = 1
+  severity = 0
 
   criteria {
     metric_namespace = "microsoft.insights/components"

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -4,6 +4,7 @@ terraform {
 
 locals{
   ping_url = (var.environment == "prod" ? "https://prime.cdc.gov" : "https://${var.environment}.prime.cdc.gov")
+  alerting_enabled = (var.environment == "prod" || var.environment == "staging" ? 1 : 0)
 }
 
 resource "azurerm_application_insights" "app_insights" {
@@ -18,7 +19,7 @@ resource "azurerm_application_insights" "app_insights" {
 }
 
 resource "azurerm_monitor_action_group" "action_group" {
-  count = (var.environment == "prod" ? 1 : 0)
+  count = local.alerting_enabled
   name = "${var.resource_prefix}-actiongroup"
   resource_group_name = var.resource_group
   short_name = "ReportStream"
@@ -41,7 +42,7 @@ resource "azurerm_monitor_action_group" "action_group" {
 # Severity 4 - Verbose
 
 resource "azurerm_monitor_metric_alert" "availability_alert" {
-  count = (var.environment == "prod" ? 1 : 0)
+  count = local.alerting_enabled
   name = "Degraded Availability"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
@@ -67,7 +68,7 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
 }
 
 resource "azurerm_monitor_metric_alert" "exception_alert" {
-  count = (var.environment == "prod" ? 1 : 0)
+  count = local.alerting_enabled
   name = "Exception(s) Raised"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
@@ -93,7 +94,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert" {
 }
 
 resource "azurerm_application_insights_web_test" "ping_test" {
-  count = (var.environment == "prod" ? 1 : 0)
+  count = local.alerting_enabled
   name = "${var.resource_prefix}-pingfunctions"
   location = var.location
   resource_group_name = var.resource_group

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -44,6 +44,7 @@ resource "azurerm_monitor_action_group" "action_group" {
 resource "azurerm_monitor_metric_alert" "availability_alert" {
   count = local.alerting_enabled
   name = "Degraded Availability"
+  description = "Degraded Availability"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -70,6 +71,7 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
 resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
   count = local.alerting_enabled
   name = "Over 100 Exceptions Raised in the Last Hour"
+  description = "Over 100 Exceptions Raised in the Last Hour"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -96,6 +98,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
 resource "azurerm_monitor_metric_alert" "exception_alert_error" {
   count = local.alerting_enabled
   name = "Over 10 Exceptions Raised in the Last Hour"
+  description = "Over 10 Exceptions Raised in the Last Hour"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"
@@ -122,6 +125,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_error" {
 resource "azurerm_monitor_metric_alert" "exception_alert_warn" {
   count = local.alerting_enabled
   name = "One or More Exceptions Raised in the Last Hour"
+  description = "One or More Exceptions Raised in the Last Hour"
   resource_group_name = var.resource_group
   scopes = [azurerm_application_insights.app_insights.id]
   window_size = "PT1H"

--- a/operations/app/src/modules/application_insights/main.tf
+++ b/operations/app/src/modules/application_insights/main.tf
@@ -67,6 +67,32 @@ resource "azurerm_monitor_metric_alert" "availability_alert" {
   }
 }
 
+resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
+  count = local.alerting_enabled
+  name = "Over 100 Exceptions Raised in the Last Hour"
+  resource_group_name = var.resource_group
+  scopes = [azurerm_application_insights.app_insights.id]
+  window_size = "PT1H"
+  frequency = "PT1M"
+  severity = 1
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name = "exceptions/count"
+    aggregation = "Count"
+    operator = "GreaterThan"
+    threshold = 99
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group[0].id
+  }
+
+  tags = {
+    "environment" = var.environment
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "exception_alert_error" {
   count = local.alerting_enabled
   name = "Over 10 Exceptions Raised in the Last Hour"
@@ -108,32 +134,6 @@ resource "azurerm_monitor_metric_alert" "exception_alert_warn" {
     aggregation = "Count"
     operator = "GreaterThan"
     threshold = 0
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.action_group[0].id
-  }
-
-  tags = {
-    "environment" = var.environment
-  }
-}
-
-resource "azurerm_monitor_metric_alert" "exception_alert_critical" {
-  count = local.alerting_enabled
-  name = "Over 100 Exceptions Raised in the Last Hour"
-  resource_group_name = var.resource_group
-  scopes = [azurerm_application_insights.app_insights.id]
-  window_size = "PT1H"
-  frequency = "PT1M"
-  severity = 1
-
-  criteria {
-    metric_namespace = "microsoft.insights/components"
-    metric_name = "exceptions/count"
-    aggregation = "Count"
-    operator = "GreaterThan"
-    threshold = 99
   }
 
   action {


### PR DESCRIPTION
This PR improves the useful of PagerDuty alerts in both staging and production.

## Changes
- Enables alerting for staging (Resolves CDCGov/prime-devops#1)
  - Alerts in staging never notify on-call support and post to the Slack channel `#prime-reportstream-engineering`
- Tiers the exception alerts so not every exception triggers a full-blown response
  - Exception counts under 10 per hour will be considered a low-priority incident and can be configured with a more lenient response policy
- Increase the frequency alerting conditions are checked from every 30 minutes to every minute
  - Checking every 30 minutes was not useful, as it could be over 30 minutes before we'd be alerted
- Adds a description field to the alerts to the fix the Azure alerting displaying a generic `(Incident triggered via the API)`

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [x] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

