### PR TITLE
Adds facility name to PID-3-4-1

### DIFF
--- a/prime-router/docs/releases/2021-05-12-release-notes.md
+++ b/prime-router/docs/releases/2021-05-12-release-notes.md
@@ -22,3 +22,8 @@ This release adds the configured topic for the organization sender to the Json r
   "reportItemCount" : 25,
   "destinations" : [ {
 ```
+
+### Adds Reporting Facility Name to PID.3.4.1
+The PID.3.4.1 field should contain the name of the reporting facility that has assigned the patient their ID. This has been added.
+
+The field will also properly truncate if the state requires truncation of HD fields.

--- a/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
@@ -2082,7 +2082,7 @@ aggregator
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
@@ -984,7 +984,7 @@ The name of the facility which the test was ordered from
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
@@ -1073,7 +1073,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/covid-19-redox.md
@@ -1073,7 +1073,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/covid-19.md
+++ b/prime-router/docs/schema_documentation/covid-19.md
@@ -2082,7 +2082,7 @@ aggregator
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/fl-fl-covid-19.md
+++ b/prime-router/docs/schema_documentation/fl-fl-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/gu-gu-covid-19.md
+++ b/prime-router/docs/schema_documentation/gu-gu-covid-19.md
@@ -1757,7 +1757,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2254,7 +2254,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/la-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/la-la-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
@@ -705,7 +705,7 @@ Is the patient symptomatic?
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -1084,7 +1084,7 @@ The phone number of the provider
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nd-nd-covid-19.md
+++ b/prime-router/docs/schema_documentation/nd-nd-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/oh-oh-covid-19.md
+++ b/prime-router/docs/schema_documentation/oh-oh-covid-19.md
@@ -1783,7 +1783,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2280,7 +2280,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
@@ -2082,7 +2082,7 @@ aggregator
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2693,7 +2693,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -1133,7 +1133,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -679,7 +679,7 @@ Is the patient symptomatic?
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -1062,7 +1062,7 @@ The phone number of the provider
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/standard-standard-covid-19.md
+++ b/prime-router/docs/schema_documentation/standard-standard-covid-19.md
@@ -1717,7 +1717,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2174,7 +2174,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -8,7 +8,7 @@
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -801,7 +801,7 @@ Z|No record of this patient
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
+++ b/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
@@ -634,7 +634,7 @@ The last name of provider who ordered the test
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/tx-tx-covid-19.md
+++ b/prime-router/docs/schema_documentation/tx-tx-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/docs/schema_documentation/vt-vt-covid-19.md
+++ b/prime-router/docs/schema_documentation/vt-vt-covid-19.md
@@ -1767,7 +1767,7 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 **Type**: TEXT
 
-**HL7 Field**: MSH-4-1
+**HL7 Fields**: MSH-4-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 
@@ -2264,7 +2264,7 @@ An example of the ID is 03D2159846
 
 **Type**: TEXT
 
-**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1
+**HL7 Fields**: ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -837,6 +837,7 @@ elements:
     natFlatFileField: Reporting_facility_name
     hhsGuidanceField:
     hl7Field: MSH-4-1
+    hl7OutputFields: [ MSH-4-1, PID-3-4-1 ]
     documentation: The reporting facility's name
 
   - name: reporting_facility_clia
@@ -1114,7 +1115,7 @@ elements:
     natFlatFileField: Testing_lab_name
     hhsGuidanceField:
     hl7Field: OBX-23-1
-    hl7OutputFields: [ ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1 ]
+    hl7OutputFields: [ ORC-2-2, OBR-2-2, ORC-3-2, OBR-3-2, OBX-23-1, PID-3-4-1 ]
     documentation: The name of the laboratory which performed the test, can be the same as the sending facility name
 
   - name: testing_lab_specimen_id

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -845,6 +845,6 @@ class Hl7Serializer(val metadata: Metadata): Logging {
         const val MESSAGE_TRIGGER_EVENT = "R01"
         const val SOFTWARE_VENDOR_ORGANIZATION: String = "Centers for Disease Control and Prevention"
         const val SOFTWARE_PRODUCT_NAME: String = "PRIME Data Hub"
-        val HD_FIELDS = listOf("MSH-4-1", "OBR-3-2", "OBR-2-2", "ORC-3-2", "ORC-2-2")
+        val HD_FIELDS = listOf("MSH-4-1", "OBR-3-2", "OBR-2-2", "ORC-3-2", "ORC-2-2", "PID-3-4-1")
     }
 }


### PR DESCRIPTION
This PR adds the facility name to PID-3-4-1. Massachusetts noted that for messages to pass their processing they want to have the testing facility name in PID-3-4-1. This should be a non-breaking change because it is *not* moving the facility name to a different field, it is just outputting it to an additional segment. 

## Changes
- Adds PID-3-4-1 to the `hl7OutputFields` collection for facility name
- Adds PID-3-4-1 to the list of HD fields that can be truncated

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [x] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?
