### PR TITLE
Improving error/warning messages in Json response to report submission

### DIFF
--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -177,6 +177,10 @@ data class Element(
             type == Type.TABLE_OR_BLANK ||
             type == Type.BLANK
 
+    // Creates a field mapping string showing the external CSV header name(s)
+    // and the corresponding internal field name
+    val fieldMapping get() = "'${this.csvFields?.joinToString { it -> it.name }}' ('${this.name}')"
+
     fun inheritFrom(baseElement: Element): Element {
         return Element(
             name = this.name,
@@ -256,12 +260,12 @@ data class Element(
                     // TODO Revisit: there may be times that normalizedValue is not an altValue
                     altDisplayToken ->
                         toAltDisplay(normalizedValue)
-                            ?: error("Schema Error: '$normalizedValue' is not in altValues set for '$name")
+                            ?: error("Schema Error: '$normalizedValue' is not in altValues set for $fieldMapping")
                     codeToken ->
                         toCode(normalizedValue)
                             ?: error(
                                 "Schema Error: " +
-                                    "'$normalizedValue' is not in valueSet '$valueSet' for '$name'/'$format'. " +
+                                    "'$normalizedValue' is not in valueSet '$valueSet' for $fieldMapping/'$format'. " +
                                     "\nAvailable values are " +
                                     "${valueSetRef?.values?.joinToString { "${it.code} -> ${it.display}" }}" +
                                     "\nAlt values (${altValues?.count()}) are " +
@@ -269,12 +273,12 @@ data class Element(
                             )
                     caretToken -> {
                         val display = valueSetRef?.toDisplayFromCode(normalizedValue)
-                            ?: error("Internal Error: '$normalizedValue' cannot be formatted for '$name'")
+                            ?: error("Internal Error: '$normalizedValue' cannot be formatted for $fieldMapping")
                         "$normalizedValue^$display^${valueSetRef.systemCode}"
                     }
                     displayToken -> {
                         valueSetRef?.toDisplayFromCode(normalizedValue)
-                            ?: error("Internal Error: '$normalizedValue' cannot be formatted for '$name'")
+                            ?: error("Internal Error: '$normalizedValue' cannot be formatted for $fieldMapping")
                     }
                     systemToken -> {
                         // Very confusing, but this special case is in the HHS Guidance Confluence page
@@ -326,7 +330,7 @@ data class Element(
                     hdNameToken -> hdFields.name
                     hdUniversalIdToken -> hdFields.universalId ?: ""
                     hdSystemToken -> hdFields.universalIdSystem ?: ""
-                    else -> error("Schema Error: unsupported HD format for output: '$format' in '$name'")
+                    else -> error("Schema Error: unsupported HD format for output: '$format' in $fieldMapping")
                 }
             }
             Type.EI -> {
@@ -337,7 +341,7 @@ data class Element(
                     eiNamespaceIdToken -> eiFields.namespace ?: ""
                     eiUniversalIdToken -> eiFields.universalId ?: ""
                     eiSystemToken -> eiFields.universalIdSystem ?: ""
-                    else -> error("Schema Error: unsupported EI format for output: '$format' in '$name'")
+                    else -> error("Schema Error: unsupported EI format for output: '$format' in $fieldMapping")
                 }
             }
             else -> normalizedValue
@@ -370,7 +374,7 @@ data class Element(
      * Take a formatted value and check to see if can be stored in a report.
      */
     fun checkForError(formattedValue: String, format: String? = null): String? {
-        if (formattedValue.isBlank() && !isOptional && !canBeBlank) return "Blank value for element '$name'"
+        if (formattedValue.isBlank() && !isOptional && !canBeBlank) return "Blank value for element $fieldMapping"
         return when (type) {
             Type.DATE -> {
                 try {
@@ -383,7 +387,7 @@ data class Element(
                     LocalDate.parse(formattedValue, formatter)
                     null
                 } catch (e: DateTimeParseException) {
-                    "Invalid date: '$formattedValue' for element '$name'"
+                    "Invalid date: '$formattedValue' for element $fieldMapping"
                 }
             }
             Type.DATETIME -> {
@@ -415,28 +419,28 @@ data class Element(
                     LocalDate.parse(formattedValue, formatter)
                     null
                 } catch (e: DateTimeParseException) {
-                    "Invalid date: '$formattedValue' for element '$name'"
+                    "Invalid date: '$formattedValue' for element $fieldMapping"
                 }
             }
             Type.CODE -> {
                 // First, prioritize use of a local $alt format, even if no value set exists.
                 return if (format == altDisplayToken) {
                     if (toAltCode(formattedValue) != null) null else
-                        "Invalid code: '$formattedValue' is not a display value in altValues set for '$name'"
+                        "Invalid code: '$formattedValue' is not a display value in altValues set for $fieldMapping"
                 } else {
-                    if (valueSetRef == null) error("Schema Error: missing value set for $name")
+                    if (valueSetRef == null) error("Schema Error: missing value set for $fieldMapping")
                     when (format) {
                         displayToken ->
                             if (valueSetRef.toCodeFromDisplay(formattedValue) != null) null else
-                                "Invalid code: '$formattedValue' not a display value for element '$name'"
+                                "Invalid code: '$formattedValue' not a display value for element $fieldMapping"
                         codeToken -> {
                             val values = altValues ?: valueSetRef.values
                             if (values.find { it.code == formattedValue } != null) null else
-                                "Invalid code: '$formattedValue' is not a code value for element '$name'"
+                                "Invalid code: '$formattedValue' is not a code value for element $fieldMapping"
                         }
                         else ->
                             if (valueSetRef.toNormalizedCode(formattedValue) != null) null else
-                                "Invalid Code: '$formattedValue' does not match any codes for '$name'"
+                                "Invalid Code: '$formattedValue' does not match any codes for $fieldMapping"
                     }
                 }
             }
@@ -446,17 +450,17 @@ data class Element(
                     // this then causes a report level failure, not an element level failure
                     val number = phoneNumberUtil.parse(formattedValue, "US")
                     if (!number.hasNationalNumber() || number.nationalNumber > 9999999999L)
-                        "Invalid phone number '$formattedValue' for '$name'"
+                        "Invalid phone number '$formattedValue' for $fieldMapping"
                     else
                         null
                 } catch (ex: Exception) {
-                    "Invalid phone number '$formattedValue' for '$name'"
+                    "Invalid phone number '$formattedValue' for $fieldMapping"
                 }
             }
             Type.POSTAL_CODE -> {
                 // Let in all formats defined by http://www.dhl.com.tw/content/dam/downloads/tw/express/forms/postcode_formats.pdf
                 return if (!Regex("^[A-Za-z\\d\\- ]{3,12}\$").matches(formattedValue))
-                    "Invalid postal code '$formattedValue'"
+                    "Invalid postal code '$formattedValue' for $fieldMapping"
                 else
                     null
             }
@@ -470,7 +474,7 @@ data class Element(
                         val parts = formattedValue.split(hdDelimiter)
                         if (parts.size == 1 || parts.size == 3) null else "Invalid HD format"
                     }
-                    else -> "Unsupported HD format for input: '$format' in '$name'"
+                    else -> "Unsupported HD format for input: '$format' in $fieldMapping"
                 }
             }
             Type.EI -> {
@@ -483,7 +487,7 @@ data class Element(
                         val parts = formattedValue.split(eiDelimiter)
                         if (parts.size == 1 || parts.size == 4) null else "Invalid EI format"
                     }
-                    else -> "Unsupported EI format for input: '$format' in '$name'"
+                    else -> "Unsupported EI format for input: '$format' in $fieldMapping"
                 }
             }
 
@@ -507,7 +511,7 @@ data class Element(
                     val formatter = DateTimeFormatter.ofPattern(format ?: datePattern, Locale.ENGLISH)
                     LocalDate.parse(formattedValue, formatter)
                 } catch (e: DateTimeParseException) {
-                    error("Invalid date: '$formattedValue' for element '$name'")
+                    error("Invalid date: '$formattedValue' for element $fieldMapping")
                 }
                 normalDate.format(dateFormatter)
             }
@@ -538,7 +542,7 @@ data class Element(
                     val zoneOffset = ZoneId.of(USTimeZone.CENTRAL.zoneId).rules.getOffset(Instant.now())
                     OffsetDateTime.of(date, LocalTime.of(0, 0), zoneOffset)
                 } catch (e: DateTimeParseException) {
-                    error("Invalid date: '$formattedValue' for element '$name'")
+                    error("Invalid date: '$formattedValue' for element $fieldMapping")
                 }
                 normalDateTime.format(datetimeFormatter)
             }
@@ -548,30 +552,30 @@ data class Element(
                     altDisplayToken ->
                         toAltCode(formattedValue)
                             ?: error(
-                                "Invalid code: '$formattedValue' is not a display value in altValues set for '$name'"
+                                "Invalid code: '$formattedValue' is not a display value in altValues set for $fieldMapping"
                             )
                     codeToken ->
                         toCode(formattedValue)
-                            ?: error("Invalid code '$formattedValue' is not a display value in valueSet for '$name")
+                            ?: error("Invalid code '$formattedValue' is not a display value in valueSet for $fieldMapping")
                     displayToken ->
                         valueSetRef?.toCodeFromDisplay(formattedValue)
-                            ?: error("Invalid code: '$formattedValue' not a display value for element '$name'")
+                            ?: error("Invalid code: '$formattedValue' is not a display value for element $fieldMapping")
                     else ->
                         valueSetRef?.toNormalizedCode(formattedValue)
-                            ?: error("Invalid Code: '$formattedValue' does not match any codes for '$name'")
+                            ?: error("Invalid Code: '$formattedValue' does not match any codes for $fieldMapping")
                 }
             }
             Type.TELEPHONE -> {
                 val number = phoneNumberUtil.parse(formattedValue, "US")
                 if (!number.hasNationalNumber() || number.nationalNumber > 9999999999L)
-                    error("Invalid phone number '$formattedValue' for '$name'")
+                    error("Invalid phone number '$formattedValue' for $fieldMapping")
                 val nationalNumber = DecimalFormat("0000000000").format(number.nationalNumber)
                 "${nationalNumber}$phoneDelimiter${number.countryCode}$phoneDelimiter${number.extension}"
             }
             Type.POSTAL_CODE -> {
                 // Let in all formats defined by http://www.dhl.com.tw/content/dam/downloads/tw/express/forms/postcode_formats.pdf
                 if (!Regex("^[A-Za-z\\d\\- ]{3,12}\$").matches(formattedValue))
-                    error("Input Error: invalid postal code '$formattedValue'")
+                    error("Input Error: invalid postal code '$formattedValue' for $fieldMapping")
                 formattedValue.replace(" ", "")
             }
             Type.HD -> {
@@ -672,7 +676,7 @@ data class Element(
 
     fun toAltDisplay(code: String): String? {
         if (!isCodeType) error("Internal Error: asking for an altDisplay for a non-code type")
-        if (altValues == null) error("Schema Error: missing alt values for '$name'")
+        if (altValues == null) error("Schema Error: missing alt values for $fieldMapping")
         val altValue = altValues.find { code.equals(it.code, ignoreCase = true) }
             ?: altValues.find { "*" == it.code }
         return altValue?.display
@@ -680,7 +684,7 @@ data class Element(
 
     fun toAltCode(altDisplay: String): String? {
         if (!isCodeType) error("Internal Error: asking for an altDisplay for a non-code type")
-        if (altValues == null) error("Schema Error: missing alt values for '$name'")
+        if (altValues == null) error("Schema Error: missing alt values for $fieldMapping")
         val altValue = altValues.find { altDisplay.equals(it.display, ignoreCase = true) }
             ?: altValues.find { "*" == it.display }
         return altValue?.code
@@ -689,7 +693,7 @@ data class Element(
     fun toCode(code: String): String? {
         if (!isCodeType) error("Internal Error: asking for codeValue for a non-code type")
         // if there are alt values, use those, otherwise, use the valueSet
-        val values = valueSetRef?.values ?: error("Unable to find a value set for $name.")
+        val values = valueSetRef?.values ?: error("Unable to find a value set for $fieldMapping.")
         val codeValue = values.find {
             code.equals(it.code, ignoreCase = true) || code.equals(it.replaces, ignoreCase = true)
         } ?: values.find { "*" == it.code }

--- a/prime-router/src/main/kotlin/Schema.kt
+++ b/prime-router/src/main/kotlin/Schema.kt
@@ -79,6 +79,11 @@ data class Schema(
         return elementIndex[name]
     }
 
+    fun findElementByCsvName(name: String): Element? {
+        elements?.forEach{ e -> e.csvFields?.forEach { if (name.equals(it.name, true)) return e } }
+        return null
+    }
+
     fun containsElement(name: String): Boolean {
         return elementIndex[name] != null
     }

--- a/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
@@ -171,7 +171,7 @@ class CsvSerializer(val metadata: Metadata) {
                         if (element.csvFields != null) {
                             element.csvFields.map { field ->
                                 val value = report.getString(row, element.name)
-                                    ?: error("Internal Error: table is missing '${element.name} column")
+                                    ?: error("Internal Error: table is missing ${element.fieldMapping} column")
                                 element.toFormatted(value, field.format)
                             }
                         } else {
@@ -246,8 +246,8 @@ class CsvSerializer(val metadata: Metadata) {
         val missingRequiredHeaders = requiredHeaders - actualHeaders
         val missingOptionalHeaders = optionalHeaders - actualHeaders
         val ignoredHeaders = actualHeaders - requiredHeaders - optionalHeaders - headersWithDefault
-        val errors = missingRequiredHeaders.map { "Missing '$it' header" }
-        val warnings = missingOptionalHeaders.map { "Missing '$it' header" } +
+        val errors = missingRequiredHeaders.map { "Missing ${schema.findElementByCsvName(it)?.fieldMapping} header" }
+        val warnings = missingOptionalHeaders.map { "Missing ${schema.findElementByCsvName(it)?.fieldMapping} header" } +
             ignoredHeaders.map { "Unexpected '$it' header is ignored" }
 
         return CsvMapping(useCsv, useMapper, useDefault, errors, warnings)
@@ -335,7 +335,7 @@ class CsvSerializer(val metadata: Metadata) {
             }
             if (value.isBlank() && !element.canBeBlank) {
                 when (element.cardinality) {
-                    Element.Cardinality.ONE -> errors += "Empty value for '${element.name}'"
+                    Element.Cardinality.ONE -> errors += "Empty value for ${element.fieldMapping}"
                     Element.Cardinality.ZERO_OR_ONE -> {
                     }
                 }


### PR DESCRIPTION
When posting a report that has unexpected column headers or invalid/unexpected data, the messages provided in the Json response use internal field names that are confusing to the client posting the report. On missing fields, the message shows the CSV header but not the external/internal combination. After discussion on issue #1066 this format was decided:
`'<external field(s)>' ('<internal field>')`

## Changes
- added a custom getter to create the desired field mapping
- replaced the internal field name in all the messaging to the field mapping from the custom getter
- added a findElementByCsvName to the Schema class to find the Element and access the custom getter for missing fields

## Checklist
- [ ] review the errors and warnings by submitting bad data and confirm that they contain the desired information

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
*** Tests FAILED:  garbage *** (known issue)
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #1066

## To Be Done
*Create GitHub issues to track the work remaining, if any*


