### PR TITLE
#1099 Added fat jar to package task

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -263,6 +263,7 @@ tasks.register("package") {
     dependsOn("azureFunctionsPackage")
     dependsOn("copyAzureResources")
     dependsOn("copyAzureScripts")
+    dependsOn("fatJar")
 }
 
 repositories {


### PR DESCRIPTION
This PR adds the creation of the fat jar as part of the package task.

To test:
1. Build the router using `./gradlew clean package`
2. Verify the fat jar was created (build/libs/prime-router-0.1-SNAPSHOT-all.jar)
3. Run the prime tool (e.g. `./prime -h`)

## Changes
- adds the creation of the fat jar as part of the package task

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security

## Fixes
- #1099

## To Be Done


