### PR TITLE
Tweak default quality filter to be more lenient

### DIFF
--- a/prime-router/settings/staging/0016-waters.yml
+++ b/prime-router/settings/staging/0016-waters.yml
@@ -1,0 +1,62 @@
+- name: waters
+  description: Waters Testing Only - sends and receives Waters data only
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: waters
+      topic: covid-19
+      schemaName: waters/waters-covid-19
+      format: CSV
+  receivers:
+    - name: CSV
+      organizationName: waters
+      topic: covid-19
+      jurisdictionalFilter: [ "hasAtLeastOneOf(waters_submitter, submitter_uid)" ]
+      qualityFilter: [ "allowAll()" ]
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+      translation:
+        type: CUSTOM
+        schemaName: waters/waters-covid-19
+        format: CSV
+      transport:
+        type: SFTP
+        host: 3.217.175.115
+        port: 22
+        filePath: ./public
+    - name: HL7
+      organizationName: waters
+      topic: covid-19
+      jurisdictionalFilter: [ "hasAtLeastOneOf(waters_submitter, submitter_uid)" ]
+      qualityFilter: [ "allowAll()" ]
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+      translation:
+        type: HL7
+        useBatchHeaders: true
+      transport:
+        type: SFTP
+        host: 3.217.175.115
+        port: 22
+        filePath: ./public
+    - name: TYPICAL_STATE_QUALITY_FILTER
+      organizationName: waters
+      topic: covid-19
+      jurisdictionalFilter: [ "hasAtLeastOneOf(waters_submitter, submitter_uid)" ]
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+      translation:
+        type: CUSTOM
+        schemaName: fl/fl-covid-19
+        format: CSV
+      transport:
+        type: SFTP
+        host: 3.217.175.115
+        port: 22
+        filePath: ./public

--- a/prime-router/src/main/kotlin/JurisdictionalFilters.kt
+++ b/prime-router/src/main/kotlin/JurisdictionalFilters.kt
@@ -248,12 +248,10 @@ object JurisdictionalFilters {
             "patient_first_name," +
             "patient_dob" +
         ")",
-        // has valid location (for contact tracing)
-        "hasAtLeastOneOf(patient_street,patient_zip_code)",
+        // has minimal valid location or other contact info (for contact tracing)
+        "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)",
         // has valid date (for relevance/urgency)
         "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)",
-        // able to conduct contact tracing
-        "hasAtLeastOneOf(patient_phone_number,patient_email)",
     )
 
     /**


### PR DESCRIPTION
This PR tweaks the default quality filter so its now:
```
       // valid human and valid test
        "hasValidDataFor(" +
            "message_id," +
            "equipment_model_name," +
            "specimen_type," +
            "test_result," +
            "patient_last_name," +
            "patient_first_name," +
            "patient_dob" +
        ")",
        // has minimal valid location or other contact info (for contact tracing)
        "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)",
        // has valid date (for relevance/urgency)
        "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)",
```

## Changes
- see above
- 

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [Y] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
no issues known


