### PR TITLE
Add fluent assertions to Project

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -61,11 +61,13 @@ tasks.test {
     useJUnitPlatform()
     dependsOn("compileKotlin")
     // Run the test task if specified configuration files are changed
-    inputs.files(fileTree("./") {
-        include("settings/**/*.yml")
-        include("metadata/**/*")
-    })
-    outputs.upToDateWhen { 
+    inputs.files(
+        fileTree("./") {
+            include("settings/**/*.yml")
+            include("metadata/**/*")
+        }
+    )
+    outputs.upToDateWhen {
         // Call gradle with the -Pforcetest option will force the unit tests to run
         if (project.hasProperty("forcetest")) {
             println("Rerunning unit tests...")
@@ -74,6 +76,10 @@ tasks.test {
             true
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
 }
 
 tasks.processResources {
@@ -345,5 +351,6 @@ dependencies {
     testImplementation("com.github.KennethWussmann:mock-fuel:1.3.0")
     testImplementation("io.mockk:mockk:1.11.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.24")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
 }

--- a/prime-router/src/test/kotlin/DocumentationTests.kt
+++ b/prime-router/src/test/kotlin/DocumentationTests.kt
@@ -1,8 +1,9 @@
 package gov.cdc.prime.router
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class DocumentationTests {
     private val documentation = """
@@ -32,7 +33,7 @@ class DocumentationTests {
 """
 
         val docString = DocumentationFactory.getElementDocumentation(elem)
-        assertEquals(expected, docString, "The messages do not match")
+        assertThat(docString).isEqualTo(expected)
     }
 
     @Test
@@ -55,7 +56,7 @@ class DocumentationTests {
 """
 
         val actual = DocumentationFactory.getSchemaDocumentation(schema)
-        assertEquals(expected, actual)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
@@ -76,6 +77,6 @@ $documentation
 ---
 """
         val actual = DocumentationFactory.getElementDocumentation(elemWithDocumentation)
-        assertEquals(expected, actual)
+        assertThat(actual).isEqualTo(expected)
     }
 }

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -1,39 +1,40 @@
 package gov.cdc.prime.router
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFails
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
 
 internal class ElementTests {
 
     @Test
     fun `create element`() {
         val elem1 = Element(name = "first", type = Element.Type.NUMBER)
-        assertNotNull(elem1)
+        assertThat(elem1).isNotNull()
     }
 
     @Test
     fun `compare elements`() {
         val elem1 = Element(name = "first", type = Element.Type.NUMBER)
         val elem2 = Element(name = "first", type = Element.Type.NUMBER)
-        assertEquals(elem1, elem2)
+        assertThat(elem1).isEqualTo(elem2)
 
         val elem3 = Element(name = "first", type = Element.Type.TEXT)
-        assertNotEquals(elem1, elem3)
+        assertThat(elem1).isNotEqualTo(elem3)
     }
 
     @Test
     fun `test schema element`() {
         val elem1 = Element(name = "first", type = Element.Type.NUMBER)
         val elem2 = Element(name = "first", type = Element.Type.NUMBER)
-        assertEquals(elem1, elem2)
-
+        assertThat(elem1).isEqualTo(elem2)
         val elem3 = Element(name = "first", type = Element.Type.TEXT)
-        assertNotEquals(elem1, elem3)
+        assertThat(elem1).isNotEqualTo(elem3)
     }
 
     @Test
@@ -49,10 +50,12 @@ internal class ElementTests {
             ),
             csvFields = Element.csvFields("b", format = "\$alt")
         )
-        val noResult = one.toNormalized("Non", "\$alt")
-        assertEquals("N", noResult)
-        val yesResult = one.toNormalized("Oui", "\$alt")
-        assertEquals("Y", yesResult)
+        one.toNormalized("Non", "\$alt").run {
+            assertThat(this).isEqualTo("N")
+        }
+        one.toNormalized("Oui", "\$alt").run {
+            assertThat(this).isEqualTo("Y")
+        }
     }
 
     @Test
@@ -62,10 +65,12 @@ internal class ElementTests {
             type = Element.Type.DATE,
         )
         // Iso formatted should work
-        val result1 = one.toNormalized("1998-03-30")
-        assertEquals("19980330", result1)
-        val result2 = one.toNormalized("1998-30-03", "yyyy-dd-MM")
-        assertEquals("19980330", result2)
+        one.toNormalized("1998-03-30").run {
+            assertThat(this).isEqualTo("19980330")
+        }
+        one.toNormalized("1998-30-03", "yyyy-dd-MM").run {
+            assertThat(this).isEqualTo("19980330")
+        }
     }
 
     @Test
@@ -75,32 +80,32 @@ internal class ElementTests {
             type = Element.Type.DATETIME,
         )
         // Iso formatted should work
-        val result1 = one.toNormalized("1998-03-30T12:00Z")
-        assertEquals("199803301200+0000", result1)
-        val result2 = one.toNormalized("199803300000+0000")
-        assertEquals("199803300000+0000", result2)
-
+        one.toNormalized("1998-03-30T12:00Z").run {
+            assertThat(this).isEqualTo("199803301200+0000")
+        }
+        one.toNormalized("199803300000+0000").run {
+            assertThat(this).isEqualTo("199803300000+0000")
+        }
         val two = Element(
             "a",
             type = Element.Type.DATETIME,
         )
-
         val o = ZoneId.of(USTimeZone.CENTRAL.zoneId).rules.getOffset(Instant.now()).toString()
         val offset = if (o == "Z") {
             "+0000"
         } else {
             o.replace(":", "")
         }
-        val result3 = two.toNormalized("19980330", "yyyyMMdd")
-        assertEquals("199803300000$offset", result3)
-
+        two.toNormalized("19980330", "yyyyMMdd").run {
+            assertThat(this).isEqualTo("199803300000$offset")
+        }
         val three = Element(
             "a",
             type = Element.Type.DATETIME,
         )
-
-        val result4 = three.toNormalized("2020-12-09", "yyyy-MM-dd")
-        assertEquals("202012090000$offset", result4)
+        three.toNormalized("2020-12-09", "yyyy-MM-dd").run {
+            assertThat(this).isEqualTo("202012090000$offset")
+        }
     }
 
     @Test
@@ -110,18 +115,21 @@ internal class ElementTests {
             type = Element.Type.DATETIME,
         )
         // Iso formatted should work
-        val result1 = one.toFormatted("199803301200")
-        assertEquals("199803301200", result1)
-        val result2 = one.toFormatted("199803300000")
-        assertEquals("199803300000", result2)
+        one.toFormatted("199803301200").run {
+            assertThat(this).isEqualTo("199803301200")
+        }
+        one.toFormatted("199803300000").run {
+            assertThat(this).isEqualTo("199803300000")
+        }
 
         val two = Element(
             "a",
             type = Element.Type.DATETIME,
         )
         // Other formats should work too, including sans the time.
-        val result3 = two.toFormatted("202012090000+0000", "yyyy-MM-dd")
-        assertEquals("2020-12-09", result3)
+        two.toFormatted("202012090000+0000", "yyyy-MM-dd").run {
+            assertThat(this).isEqualTo("2020-12-09")
+        }
     }
 
     @Test
@@ -131,16 +139,22 @@ internal class ElementTests {
             type = Element.Type.POSTAL_CODE,
             csvFields = Element.csvFields("zip")
         )
-        val result1 = one.toNormalized("99999")
-        assertEquals("99999", result1)
-        val result2 = one.toNormalized("99999-9999")
-        assertEquals("99999-9999", result2)
+        one.toNormalized("99999").run {
+            assertThat(this).isEqualTo("99999")
+        }
+        val result2 = one.toNormalized("99999-9999").run {
+            assertThat(this).isEqualTo("99999-9999")
+        }
         // format should not affect normalization
-        val result4 = one.toNormalized("999999999", "\$zipFive")
-        assertEquals("999999999", result4)
-        val result5 = one.toNormalized("KY1-6666") // Cayman zipcode
-        assertEquals("KY1-6666", result5)
-        one.toNormalized("KX33-77777") // Letters and numbers, but a made up zipcode
+        one.toNormalized("999999999", "\$zipFive").run {
+            assertThat(this).isEqualTo("999999999")
+        }
+        one.toNormalized("KY1-6666").run {
+            assertThat(this).isEqualTo("KY1-6666")
+        } // Cayman zipcode
+        one.toNormalized("KX33-77777").run {
+            assertThat(this).isEqualTo("KX33-77777")
+        } // Letters and numbers, but a made up zipcode
         assertFails {
             one.toNormalized("%%%%XXXX") // Unreasonable
         }
@@ -153,21 +167,28 @@ internal class ElementTests {
             type = Element.Type.TELEPHONE,
             csvFields = Element.csvFields("phone")
         )
-        val result1 = one.toNormalized("5559938322")
-        assertEquals("5559938322:1:", result1)
-        val result2 = one.toNormalized("1(555)-968-5052")
-        assertEquals("5559685052:1:", result2)
-        val result3 = one.toNormalized("555-968-5052")
-        assertEquals("5559685052:1:", result3)
-        val result4 = one.toNormalized("+1(555)-968-5052")
-        assertEquals("5559685052:1:", result4)
-        val result5 = one.toNormalized("968-5052")
-        assertEquals("0009685052:1:", result5)
-        val result6 = one.toNormalized("+1(555)-968-5052 x5555")
-        assertEquals("5559685052:1:5555", result6)
+        one.toNormalized("5559938322").run {
+            assertThat(this).isEqualTo("5559938322:1:")
+        }
+        one.toNormalized("1(555)-968-5052").run {
+            assertThat(this).isEqualTo("5559685052:1:")
+        }
+        one.toNormalized("555-968-5052").run {
+            assertThat(this).isEqualTo("5559685052:1:")
+        }
+        one.toNormalized("+1(555)-968-5052").run {
+            assertThat(this).isEqualTo("5559685052:1:")
+        }
+        one.toNormalized("968-5052").run {
+            assertThat(this).isEqualTo("0009685052:1:")
+        }
+        one.toNormalized("+1(555)-968-5052 x5555").run {
+            assertThat(this).isEqualTo("5559685052:1:5555")
+        }
         // MX phone number
-        val result7 = one.toNormalized("+52-65-8888-8888")
-        assertEquals("6588888888:52:", result7)
+        one.toNormalized("+52-65-8888-8888").run {
+            assertThat(this).isEqualTo("6588888888:52:")
+        }
     }
 
     @Test
@@ -177,12 +198,15 @@ internal class ElementTests {
             type = Element.Type.TELEPHONE,
             csvFields = Element.csvFields("phone")
         )
-        val result1 = one.toFormatted("5559938322:1:")
-        assertEquals("5559938322", result1)
-        val result2 = one.toFormatted("5559938322:1:", "\$country-\$area-\$exchange-\$subscriber")
-        assertEquals("1-555-993-8322", result2)
-        val result3 = one.toFormatted("5559938322:1:", "(\$area)\$exchange-\$subscriber")
-        assertEquals("(555)993-8322", result3)
+        one.toFormatted("5559938322:1:").run {
+            assertThat(this).isEqualTo("5559938322")
+        }
+        one.toFormatted("5559938322:1:", "\$country-\$area-\$exchange-\$subscriber").run {
+            assertThat(this).isEqualTo("1-555-993-8322")
+        }
+        one.toFormatted("5559938322:1:", "(\$area)\$exchange-\$subscriber").run {
+            assertThat(this).isEqualTo("(555)993-8322")
+        }
     }
 
     @Test
@@ -192,24 +216,33 @@ internal class ElementTests {
             type = Element.Type.POSTAL_CODE,
             csvFields = Element.csvFields("zip")
         )
-        val result1 = one.toFormatted("99999")
-        assertEquals("99999", result1)
-        val result1a = one.toFormatted("99999-9999")
-        assertEquals("99999-9999", result1a)
-        val result2 = one.toFormatted("99999-9999", "\$zipFivePlusFour")
-        assertEquals("99999-9999", result2)
-        val result3 = one.toFormatted("99999-9999", "\$zipFive")
-        assertEquals("99999", result3)
-        val result4 = one.toFormatted("999999999", "\$zipFive")
-        assertEquals("99999", result4)
-        val result5 = one.toFormatted("999999999", "\$zipFivePlusFour")
-        assertEquals("99999-9999", result5)
-        val result6 = one.toFormatted("99999", "\$zipFivePlusFour")
-        assertEquals("99999", result6)
-        val result7 = one.toFormatted("KY1-5555", "\$zipFivePlusFour")
-        assertEquals("KY1-5555", result7)
-        val result8 = one.toFormatted("XZ5555", "\$zipFivePlusFour")
-        assertEquals("XZ5555", result8)
+        one.toFormatted("99999").run {
+            assertThat(this).isEqualTo("99999")
+        }
+        one.toFormatted("99999-9999").run {
+            assertThat(this).isEqualTo("99999-9999")
+        }
+        one.toFormatted("99999-9999", "\$zipFivePlusFour").run {
+            assertThat(this).isEqualTo("99999-9999")
+        }
+        one.toFormatted("99999-9999", "\$zipFive").run {
+            assertThat(this).isEqualTo("99999")
+        }
+        one.toFormatted("999999999", "\$zipFive").run {
+            assertThat(this).isEqualTo("99999")
+        }
+        one.toFormatted("999999999", "\$zipFivePlusFour").run {
+            assertThat(this).isEqualTo("99999-9999")
+        }
+        one.toFormatted("99999", "\$zipFivePlusFour").run {
+            assertThat(this).isEqualTo("99999")
+        }
+        one.toFormatted("KY1-5555", "\$zipFivePlusFour").run {
+            assertThat(this).isEqualTo("KY1-5555")
+        }
+        one.toFormatted("XZ5555", "\$zipFivePlusFour").run {
+            assertThat(this).isEqualTo("XZ5555")
+        }
     }
 
     @Test
@@ -220,12 +253,16 @@ internal class ElementTests {
             csvFields = Element.csvFields("sampleField"),
             documentation = "I am the parent element"
         )
-
-        var child = Element("child")
-        child = child.inheritFrom(parent)
-
-        assertEquals(parent.documentation, child.documentation, "Documentation value didn't carry over from parent")
-        assertEquals(parent.type, child.type, "Element type didn't carry over from parent")
+        // instead of using var, just call run and transmogrify the child then and there
+        val child = Element("child").run { inheritFrom(parent) }
+        assertThat(
+            parent.documentation,
+            name = "Documentation value didn't carry over from parent"
+        ).isEqualTo(child.documentation)
+        assertThat(
+            parent.type,
+            name = "Element type didn't carry over from parent"
+        ).isEqualTo(child.type)
     }
 
     @Test
@@ -235,20 +272,24 @@ internal class ElementTests {
             type = Element.Type.POSTAL_CODE,
             csvFields = Element.csvFields("zip")
         )
-        assertEquals(
-            "94040",
+        assertThat(
+            "94040"
+        ).isEqualTo(
             postal.toFormatted(postal.toNormalized("94040"))
         )
-        assertEquals(
-            "94040-6000",
+        assertThat(
+            "94040-6000"
+        ).isEqualTo(
             postal.toFormatted(postal.toNormalized("94040-6000"))
         )
-        assertEquals(
-            "94040",
+        assertThat(
+            "94040"
+        ).isEqualTo(
             postal.toFormatted(postal.toNormalized("94040-3600", Element.zipFiveToken), Element.zipFiveToken)
         )
-        assertEquals(
-            "94040-3600",
+        assertThat(
+            "94040-3600"
+        ).isEqualTo(
             postal.toFormatted(
                 postal.toNormalized("94040-3600", Element.zipFivePlusFourToken),
                 Element.zipFivePlusFourToken
@@ -260,12 +301,14 @@ internal class ElementTests {
             type = Element.Type.TELEPHONE,
             csvFields = Element.csvFields("phone")
         )
-        assertEquals(
-            "6509999999",
+        assertThat(
+            "6509999999"
+        ).isEqualTo(
             telephone.toFormatted(telephone.toNormalized("6509999999"))
         )
-        assertEquals(
-            "6509999999",
+        assertThat(
+            "6509999999"
+        ).isEqualTo(
             telephone.toFormatted(telephone.toNormalized("+16509999999"))
         )
 
@@ -274,12 +317,14 @@ internal class ElementTests {
             type = Element.Type.DATE,
             csvFields = Element.csvFields("date")
         )
-        assertEquals(
-            "20201220",
+        assertThat(
+            "20201220"
+        ).isEqualTo(
             date.toFormatted(date.toNormalized("20201220"))
         )
-        assertEquals(
-            "20201220",
+        assertThat(
+            "20201220"
+        ).isEqualTo(
             date.toFormatted(date.toNormalized("2020-12-20"))
         )
 
@@ -288,12 +333,14 @@ internal class ElementTests {
             type = Element.Type.DATETIME,
             csvFields = Element.csvFields("datetime")
         )
-        assertEquals(
-            "202012200000+0000",
+        assertThat(
+            "202012200000+0000"
+        ).isEqualTo(
             datetime.toFormatted(datetime.toNormalized("202012200000+0000"))
         )
-        assertEquals(
-            "202012200000+0000",
+        assertThat(
+            "202012200000+0000"
+        ).isEqualTo(
             datetime.toFormatted(datetime.toNormalized("2020-12-20T00:00Z"))
         )
 
@@ -302,12 +349,12 @@ internal class ElementTests {
             type = Element.Type.HD,
             csvFields = Element.csvFields("hd")
         )
-        assertEquals(
-            "HDName",
+        assertThat(
+            "HDName"
+        ).isEqualTo(
             hd.toFormatted(hd.toNormalized("HDName"))
         )
-        assertEquals(
-            "HDName^0.0.0.0.0.1^ISO",
+        assertThat("HDName^0.0.0.0.0.1^ISO").isEqualTo(
             postal.toFormatted(hd.toNormalized("HDName^0.0.0.0.0.1^ISO"))
         )
 
@@ -316,14 +363,16 @@ internal class ElementTests {
             type = Element.Type.EI,
             csvFields = Element.csvFields("ei")
         )
-        assertEquals(
-            "EIName",
-            ei.toFormatted(ei.toNormalized("EIName"))
-        )
-        assertEquals(
-            "EIName^EINamespace^0.0.0.0.0.1^ISO",
-            postal.toFormatted(ei.toNormalized("EIName^EINamespace^0.0.0.0.0.1^ISO"))
-        )
+        assertThat("EIName")
+            .isEqualTo(
+                ei.toFormatted(ei.toNormalized("EIName"))
+            )
+        assertThat("EIName^EINamespace^0.0.0.0.0.1^ISO")
+            .isEqualTo(
+                postal.toFormatted(
+                    ei.toNormalized("EIName^EINamespace^0.0.0.0.0.1^ISO")
+                )
+            )
     }
 
     @Test
@@ -342,12 +391,12 @@ internal class ElementTests {
                 Element.SubValue("sending_oid", "0.0.0.011", "\$universalId")
             )
         )
-        assertEquals("happy^0.0.0.011^ISO", normalized)
+        assertThat("happy^0.0.0.011^ISO").isEqualTo(normalized)
 
         val sendingAppName = sendingApp.toFormatted(normalized, Element.hdNameToken)
-        assertEquals("happy", sendingAppName)
+        assertThat("happy").isEqualTo(sendingAppName)
         val sendingOid = sendingApp.toFormatted(normalized, Element.hdUniversalIdToken)
-        assertEquals("0.0.0.011", sendingOid)
+        assertThat("0.0.0.011").isEqualTo(sendingOid)
     }
 
     @Test
@@ -373,41 +422,46 @@ internal class ElementTests {
             )
         )
         // because something is a
-        assertEquals(one.toFormatted("Y", "\$code"), "Y")
-        assertEquals(one.toNormalized("Y", "\$code"), "Y")
-        assertEquals(one.checkForError("Y", "\$code"), null)
+        assertThat(one.toFormatted("Y", "\$code")).isEqualTo("Y")
+        assertThat(one.toNormalized("Y", "\$code")).isEqualTo("Y")
+        assertThat(one.checkForError("Y", "\$code")).isNull()
     }
 
     @Test
     fun `test truncate`() {
-        val uno = Element(
+        Element(
             name = "uno",
             type = Element.Type.TEXT,
             maxLength = 2,
-        )
-        assertEquals("ab", uno.truncateIfNeeded("abcde"))
-        val dos = Element(
+        ).run {
+            assertThat("ab").isEqualTo(this.truncateIfNeeded("abcde"))
+        }
+        Element(
             name = "dos",
             type = Element.Type.ID_CLIA, // this type is never truncated.
             maxLength = 2,
-        )
-        assertEquals("abcde", dos.truncateIfNeeded("abcde"))
-        val tres = Element(
+        ).run {
+            assertThat("abcde").isEqualTo(this.truncateIfNeeded("abcde"))
+        }
+        Element(
             name = "tres",
             type = Element.Type.TEXT,
             maxLength = 20, // max > actual strlen, nothing to truncate
-        )
-        assertEquals("abcde", tres.truncateIfNeeded("abcde"))
-        val cuatro = Element( // zilch is an ok valuer = Element(  // maxLength is null, don't truncate.
+        ).run {
+            assertThat("abcde").isEqualTo(this.truncateIfNeeded("abcde"))
+        }
+        Element( // zilch is an ok valuer = Element(  // maxLength is null, don't truncate.
             name = "cuatro",
             type = Element.Type.TEXT,
-        )
-        assertEquals("abcde", cuatro.truncateIfNeeded("abcde"))
-        val cinco = Element(
+        ).run {
+            assertThat("abcde").isEqualTo(this.truncateIfNeeded("abcde"))
+        }
+        Element(
             name = "cinco",
             type = Element.Type.TEXT,
             maxLength = 0, // zilch is an ok value
-        )
-        assertEquals("", cinco.truncateIfNeeded("abcde"))
+        ).run {
+            assertThat("").isEqualTo(this.truncateIfNeeded("abcde"))
+        }
     }
 }

--- a/prime-router/src/test/kotlin/FakeReportTests.kt
+++ b/prime-router/src/test/kotlin/FakeReportTests.kt
@@ -1,13 +1,16 @@
 package gov.cdc.prime.router
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import java.io.ByteArrayInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.assertNotNull
 import kotlin.test.fail
 
-internal class FakeReportTests {
+class FakeReportTests {
     private val schemaName = "test"
     private val rowContext = FakeReport.RowContext(schemaName = schemaName)
     private val metadata = Metadata(
@@ -180,10 +183,9 @@ internal class FakeReportTests {
         val fieldName = "testing_lab_and_facility"
         val concatField = metadata.findSchema(schemaName)
             ?.findElement(fieldName) ?: fail("Lookup failure: $fieldName")
-
         val actual = FakeReport(metadata).buildMappedColumn(concatField, rowContext)
         val expected = "Any lab USA^Any facility USA"
-        assertEquals(expected, actual)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
@@ -191,22 +193,21 @@ internal class FakeReportTests {
         val fieldName = "testing_lab_and_facility2"
         val concatField = metadata.findSchema(schemaName)
             ?.findElement(fieldName) ?: fail("Lookup failure: $fieldName")
-
         val actual = FakeReport(metadata).buildMappedColumn(concatField, rowContext)
         val expected = "Any lab USA, Any facility USA"
-        assertEquals(expected, actual)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `test row context getting expected zip code results`() {
         // arrange
         val metadata = Metadata("./metadata")
-        assertNotNull(metadata)
+        assertThat(metadata).isNotNull()
         val zipCodeTable = metadata.findLookupTable("zip-code-data")
-        assertNotNull(zipCodeTable)
+        assertThat(zipCodeTable).isNotNull()
         val state = "VT"
         val county = "Rutland"
-        val matchingCityRows = zipCodeTable.filter(
+        val matchingCityRows = zipCodeTable!!.filter(
             "city",
             mapOf(
                 "state_abbr" to state,
@@ -231,7 +232,7 @@ internal class FakeReportTests {
         println(matchingZipRows.joinToString())
         println("${context.city} - ${context.zipCode}")
         // assert
-        assert(matchingCityRows.contains(context.city))
-        assert(matchingZipRows.contains(context.zipCode))
+        assertThat(matchingCityRows).contains(context.city)
+        assertThat(matchingZipRows).contains(context.zipCode)
     }
 }

--- a/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
+++ b/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
@@ -10,7 +10,6 @@ import assertk.assertions.support.show
 import tech.tablesaw.api.StringColumn
 import tech.tablesaw.api.Table
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class JurisdictionalFilterTests {
 
@@ -85,9 +84,9 @@ class JurisdictionalFilterTests {
         val args3 = listOf("AZ", "Pima")
         val selection3 = filter.getSelection(args3, table, rcvr)
         val filteredTable3 = table.where(selection3)
-        assertEquals(2, filteredTable3.rowCount())
-        assertEquals("Baltimore City", filteredTable3.getString(0, "patient_county"))
-        assertEquals("Pima", filteredTable3.getString(1, "patient_county"))
+        assertThat(filteredTable3).hasRowCount(2)
+        assertThat(filteredTable3.getString(0, "patient_county")).isEqualTo("Baltimore City")
+        assertThat(filteredTable3.getString(1, "patient_county")).isEqualTo("Pima")
 
         val args4 = listOf("MD") // wrong num args
         assertThat { filter.getSelection(args4, table, rcvr) }.isFailure()
@@ -103,7 +102,7 @@ class JurisdictionalFilterTests {
         val args1 = listOf("a", "a") // correct # args.
         val selection = filter.getSelection(args1, table, rcvr)
         val filteredTable = table.where(selection)
-        assertThat(filteredTable.rowCount()).isEqualTo(0)
+        assertThat(filteredTable).hasRowCount(0)
     }
 
     @Test
@@ -123,17 +122,17 @@ class JurisdictionalFilterTests {
         val args1 = listOf("colA", "A1", "colB", "B3")
         val selection1 = filter.getSelection(args1, table, rcvr)
         val filteredTable1 = table.where(selection1)
-        assertEquals(2, filteredTable1.rowCount())
-        assertEquals("B1", filteredTable1.getString(0, "colB"))
-        assertEquals("B3", filteredTable1.getString(1, "colB"))
+        assertThat(filteredTable1).hasRowCount(2)
+        assertThat(filteredTable1.getString(0, "colB")).isEqualTo("B1")
+        assertThat(filteredTable1.getString(1, "colB")).isEqualTo("B3")
 
         val args2 = listOf("colA", "(?i)A.*", "colB", ".*4") // test a regex
         val selection2 = filter.getSelection(args2, table, rcvr)
         val filteredTable2 = table.where(selection2)
-        assertEquals(3, filteredTable2.rowCount())
-        assertEquals("B1", filteredTable2.getString(0, "colB"))
-        assertEquals("B2", filteredTable2.getString(1, "colB"))
-        assertEquals("B4", filteredTable2.getString(2, "colB"))
+        assertThat(filteredTable2).hasRowCount(3)
+        assertThat(filteredTable2.getString(0, "colB")).isEqualTo("B1")
+        assertThat(filteredTable2.getString(1, "colB")).isEqualTo("B2")
+        assertThat(filteredTable2.getString(2, "colB")).isEqualTo("B4")
 
         val args4 = listOf("colA", "([?:|") // malformed regex
         assertThat { filter.getSelection(args4, table, rcvr) }.isFailure()
@@ -151,45 +150,45 @@ class JurisdictionalFilterTests {
         val emptyArgs = listOf<String>()
         var selection = filter.getSelection(emptyArgs, table, rcvr)
         var filteredTable = table.where(selection)
-        assertEquals(4, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(4)
 
         val junkColName = listOf("quux")
         selection = filter.getSelection(junkColName, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(0, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(0)
 
         val oneGoodoneBadColName = listOf("quux", "colB")
         selection = filter.getSelection(oneGoodoneBadColName, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(0, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(0)
 
         val oneGoodColName = listOf("colB")
         selection = filter.getSelection(oneGoodColName, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(4, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(4)
 
         val colWithEmpty = listOf("colA")
         selection = filter.getSelection(colWithEmpty, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(3, filteredTable.rowCount())
-        assertEquals("A1", filteredTable.getString(0, "colA"))
-        assertEquals("A2", filteredTable.getString(1, "colA"))
-        assertEquals("A4", filteredTable.getString(2, "colA"))
+        assertThat(filteredTable).hasRowCount(3)
+        assertThat(filteredTable.getString(0, "colA")).isEqualTo("A1")
+        assertThat(filteredTable.getString(1, "colA")).isEqualTo("A2")
+        assertThat(filteredTable.getString(2, "colA")).isEqualTo("A4")
 
         val colWithNull = listOf("colC")
         selection = filter.getSelection(colWithNull, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(3, filteredTable.rowCount())
-        assertEquals("C1", filteredTable.getString(0, "colC"))
-        assertEquals("C2", filteredTable.getString(1, "colC"))
-        assertEquals("C3", filteredTable.getString(2, "colC"))
+        assertThat(filteredTable).hasRowCount(3)
+        assertThat(filteredTable.getString(0, "colC")).isEqualTo("C1")
+        assertThat(filteredTable.getString(1, "colC")).isEqualTo("C2")
+        assertThat(filteredTable.getString(2, "colC")).isEqualTo("C3")
 
         val allCols = listOf("colA", "colB", "colC")
         selection = filter.getSelection(allCols, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(2, filteredTable.rowCount())
-        assertEquals("C1", filteredTable.getString(0, "colC"))
-        assertEquals("C2", filteredTable.getString(1, "colC"))
+        assertThat(filteredTable).hasRowCount(2)
+        assertThat(filteredTable.getString(0, "colC")).isEqualTo("C1")
+        assertThat(filteredTable.getString(1, "colC")).isEqualTo("C2")
     }
 
     @Test
@@ -207,33 +206,33 @@ class JurisdictionalFilterTests {
         val junkColNames = listOf("foo", "bar", "baz")
         var selection = filter.getSelection(junkColNames, table, rcvr)
         var filteredTable = table.where(selection)
-        assertEquals(0, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(0)
 
         val oneGoodColName = listOf("foo", "bar", "colB")
         selection = filter.getSelection(oneGoodColName, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(4, filteredTable.rowCount())
+        assertThat(filteredTable).hasRowCount(4)
 
         val colWithEmptyString = listOf("foo", "colA")
         selection = filter.getSelection(colWithEmptyString, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(3, filteredTable.rowCount())
-        assertEquals("A1", filteredTable.getString(0, "colA"))
-        assertEquals("A2", filteredTable.getString(1, "colA"))
-        assertEquals("A4", filteredTable.getString(2, "colA"))
+        assertThat(filteredTable).hasRowCount(3)
+        assertThat(filteredTable.getString(0, "colA")).isEqualTo("A1")
+        assertThat(filteredTable.getString(1, "colA")).isEqualTo("A2")
+        assertThat(filteredTable.getString(2, "colA")).isEqualTo("A4")
 
         val colWithNull = listOf("colC")
         selection = filter.getSelection(colWithNull, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(3, filteredTable.rowCount())
-        assertEquals("C1", filteredTable.getString(0, "colC"))
-        assertEquals("C2", filteredTable.getString(1, "colC"))
-        assertEquals("C3", filteredTable.getString(2, "colC"))
+        assertThat(filteredTable).hasRowCount(3)
+        assertThat(filteredTable.getString(0, "colC")).isEqualTo("C1")
+        assertThat(filteredTable.getString(1, "colC")).isEqualTo("C2")
+        assertThat(filteredTable.getString(2, "colC")).isEqualTo("C3")
 
         val allCols = listOf("colA", "colB", "colC")
         selection = filter.getSelection(allCols, table, rcvr)
         filteredTable = table.where(selection)
-        assertThat(filteredTable.rowCount()).isEqualTo(4)
+        assertThat(filteredTable).hasRowCount(4)
 
         // First row does not exist for colA nor colB. No colC at all.
         val table2 = Table.create(
@@ -242,7 +241,7 @@ class JurisdictionalFilterTests {
         )
         selection = filter.getSelection(allCols, table2, rcvr)
         filteredTable = table.where(selection)
-        assertThat(filteredTable.rowCount()).isEqualTo(1)
+        assertThat(filteredTable).hasRowCount(1)
         assertThat(filteredTable.getString(0, "colA")).isEqualTo("A2")
     }
 
@@ -261,7 +260,7 @@ class JurisdictionalFilterTests {
         val emptyArgs = listOf<String>()
         val selection = filter.getSelection(emptyArgs, table, rcvr)
         val filteredTable = table.where(selection)
-        assertThat(filteredTable.rowCount()).isEqualTo(4)
+        assertThat(filteredTable).hasRowCount(4)
     }
 
     companion object {

--- a/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
+++ b/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
@@ -1,15 +1,20 @@
 package gov.cdc.prime.router
 
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
 import tech.tablesaw.api.StringColumn
 import tech.tablesaw.api.Table
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
-import kotlin.test.assertTrue
 
 class JurisdictionalFilterTests {
 
-    val rcvr = Receiver("name", "org","topic","schema",Report.Format.CSV)
+    private val rcvr = Receiver("name", "org", "topic", "schema", Report.Format.CSV)
 
     @Test
     fun `test Matches`() {
@@ -18,19 +23,18 @@ class JurisdictionalFilterTests {
             StringColumn.create("colA", listOf("A1", "a2", "X3")),
             StringColumn.create("colB", listOf("B1", "B2", "B3"))
         )
-
         val args1 = listOf("colA", "A1")
         val selection1 = filter.getSelection(args1, table, rcvr)
         val filteredTable1 = table.where(selection1)
-        assertEquals(1, filteredTable1.rowCount())
-        assertEquals("B1", filteredTable1.getString(0, "colB"))
+        assertThat(filteredTable1).hasRowCount(1)
+        assertThat(filteredTable1.getString(0, "colB")).isEqualTo("B1")
 
         val args2 = listOf("colA", "(?i)A.*") // test a regex
         val selection2 = filter.getSelection(args2, table, rcvr)
         val filteredTable2 = table.where(selection2)
-        assertEquals(2, filteredTable2.rowCount())
-        assertEquals("B1", filteredTable2.getString(0, "colB"))
-        assertEquals("B2", filteredTable2.getString(1, "colB"))
+        assertThat(filteredTable2).hasRowCount(2)
+        assertThat(filteredTable2.getString(0, "colB")).isEqualTo("B1")
+        assertThat(filteredTable2.getString(1, "colB")).isEqualTo("B2")
     }
 
     @Test
@@ -42,7 +46,7 @@ class JurisdictionalFilterTests {
 
         val args1 = listOf("a", "b") // correct # args.
         // However, table doesn't have the expected columns, so an empty selection
-        assertTrue(filter.getSelection(args1, table, rcvr).isEmpty)
+        assertThat(filter.getSelection(args1, table, rcvr)).isEmpty()
     }
 
     @Test
@@ -66,16 +70,16 @@ class JurisdictionalFilterTests {
         val args1 = listOf("MD", "Prince George's")
         val selection1 = filter.getSelection(args1, table, rcvr)
         val filteredTable1 = table.where(selection1)
-        assertEquals(1, filteredTable1.rowCount())
-        assertEquals("Prince George's", filteredTable1.getString(0, "patient_county"))
+        assertThat(filteredTable1).hasRowCount(1)
+        assertThat(filteredTable1.getString(0, "patient_county")).isEqualTo("Prince George's")
 
         // Both Baltimore and Baltimore City should match
         val args2 = listOf("MD", "Baltimore")
         val selection2 = filter.getSelection(args2, table, rcvr)
         val filteredTable2 = table.where(selection2)
-        assertEquals(2, filteredTable2.rowCount())
-        assertEquals("Baltimore", filteredTable2.getString(0, "patient_county"))
-        assertEquals("Baltimore City", filteredTable2.getString(1, "patient_county"))
+        assertThat(filteredTable2).hasRowCount(2)
+        assertThat(filteredTable2.getString(0, "patient_county")).isEqualTo("Baltimore")
+        assertThat(filteredTable2.getString(1, "patient_county")).isEqualTo("Baltimore City")
 
         // Test the 'OR':   result is selected if the patient OR the facility are in the location:
         val args3 = listOf("AZ", "Pima")
@@ -86,7 +90,7 @@ class JurisdictionalFilterTests {
         assertEquals("Pima", filteredTable3.getString(1, "patient_county"))
 
         val args4 = listOf("MD") // wrong num args
-        assertFails { filter.getSelection(args4, table, rcvr) }
+        assertThat { filter.getSelection(args4, table, rcvr) }.isFailure()
     }
 
     @Test
@@ -96,11 +100,10 @@ class JurisdictionalFilterTests {
             StringColumn.create("BOGUS", listOf("a", "b", "c", "d")),
             StringColumn.create("BOGUS2", listOf("a", "b", "c", "d")),
         )
-
         val args1 = listOf("a", "a") // correct # args.
         val selection = filter.getSelection(args1, table, rcvr)
         val filteredTable = table.where(selection)
-        assertEquals(0, filteredTable.rowCount())
+        assertThat(filteredTable.rowCount()).isEqualTo(0)
     }
 
     @Test
@@ -112,10 +115,10 @@ class JurisdictionalFilterTests {
         )
 
         val emptyArgs = listOf<String>()
-        assertFails { filter.getSelection(emptyArgs, table, rcvr) }
+        assertThat { filter.getSelection(emptyArgs, table, rcvr) }.isFailure()
 
         val missingArgs = listOf("colA", "A1", "colB") // must have even number of args
-        assertFails { filter.getSelection(missingArgs, table, rcvr) }
+        assertThat { filter.getSelection(missingArgs, table, rcvr) }.isFailure()
 
         val args1 = listOf("colA", "A1", "colB", "B3")
         val selection1 = filter.getSelection(args1, table, rcvr)
@@ -133,7 +136,7 @@ class JurisdictionalFilterTests {
         assertEquals("B4", filteredTable2.getString(2, "colB"))
 
         val args4 = listOf("colA", "([?:|") // malformed regex
-        assertFails { val selection4 = filter.getSelection(args4, table, rcvr) }
+        assertThat { filter.getSelection(args4, table, rcvr) }.isFailure()
     }
 
     @Test
@@ -182,7 +185,7 @@ class JurisdictionalFilterTests {
         assertEquals("C3", filteredTable.getString(2, "colC"))
 
         val allCols = listOf("colA", "colB", "colC")
-        selection =  filter.getSelection(allCols, table, rcvr)
+        selection = filter.getSelection(allCols, table, rcvr)
         filteredTable = table.where(selection)
         assertEquals(2, filteredTable.rowCount())
         assertEquals("C1", filteredTable.getString(0, "colC"))
@@ -199,20 +202,20 @@ class JurisdictionalFilterTests {
         )
 
         val emptyArgs = listOf<String>()
-        assertFails{ filter.getSelection(emptyArgs, table, rcvr) }
+        assertThat { filter.getSelection(emptyArgs, table, rcvr) }.isFailure()
 
         val junkColNames = listOf("foo", "bar", "baz")
-        var selection =  filter.getSelection(junkColNames, table, rcvr)
+        var selection = filter.getSelection(junkColNames, table, rcvr)
         var filteredTable = table.where(selection)
         assertEquals(0, filteredTable.rowCount())
 
         val oneGoodColName = listOf("foo", "bar", "colB")
-        selection =  filter.getSelection(oneGoodColName, table, rcvr)
+        selection = filter.getSelection(oneGoodColName, table, rcvr)
         filteredTable = table.where(selection)
         assertEquals(4, filteredTable.rowCount())
 
         val colWithEmptyString = listOf("foo", "colA")
-        selection =  filter.getSelection(colWithEmptyString, table, rcvr)
+        selection = filter.getSelection(colWithEmptyString, table, rcvr)
         filteredTable = table.where(selection)
         assertEquals(3, filteredTable.rowCount())
         assertEquals("A1", filteredTable.getString(0, "colA"))
@@ -220,7 +223,7 @@ class JurisdictionalFilterTests {
         assertEquals("A4", filteredTable.getString(2, "colA"))
 
         val colWithNull = listOf("colC")
-        selection =  filter.getSelection(colWithNull, table, rcvr)
+        selection = filter.getSelection(colWithNull, table, rcvr)
         filteredTable = table.where(selection)
         assertEquals(3, filteredTable.rowCount())
         assertEquals("C1", filteredTable.getString(0, "colC"))
@@ -228,21 +231,20 @@ class JurisdictionalFilterTests {
         assertEquals("C3", filteredTable.getString(2, "colC"))
 
         val allCols = listOf("colA", "colB", "colC")
-        selection =  filter.getSelection(allCols, table, rcvr)
+        selection = filter.getSelection(allCols, table, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(4, filteredTable.rowCount())
+        assertThat(filteredTable.rowCount()).isEqualTo(4)
 
         // First row does not exist for colA nor colB. No colC at all.
         val table2 = Table.create(
             StringColumn.create("colA", listOf("", "A2")),
             StringColumn.create("colB", listOf(null, "B2")),
         )
-        selection =  filter.getSelection(allCols, table2, rcvr)
+        selection = filter.getSelection(allCols, table2, rcvr)
         filteredTable = table.where(selection)
-        assertEquals(1, filteredTable.rowCount())
-        assertEquals("A2", filteredTable.getString(0, "colA"))
+        assertThat(filteredTable.rowCount()).isEqualTo(1)
+        assertThat(filteredTable.getString(0, "colA")).isEqualTo("A2")
     }
-
 
     @Test
     fun `test allowAll`() {
@@ -254,12 +256,18 @@ class JurisdictionalFilterTests {
         )
 
         val colName = listOf("colA", "colB")
-        assertFails{ filter.getSelection(colName, table, rcvr) }
+        assertThat { filter.getSelection(colName, table, rcvr) }.isFailure()
 
         val emptyArgs = listOf<String>()
-        var selection =  filter.getSelection(emptyArgs, table, rcvr)
-        var filteredTable = table.where(selection)
-        assertEquals(4, filteredTable.rowCount())
+        val selection = filter.getSelection(emptyArgs, table, rcvr)
+        val filteredTable = table.where(selection)
+        assertThat(filteredTable.rowCount()).isEqualTo(4)
     }
 
+    companion object {
+        private fun Assert<Table>.hasRowCount(expected: Int) = given { actual ->
+            if (actual.rowCount() == expected) return
+            expected("rowCount:${show(expected)} but was rowCount:${show(actual.rowCount())}")
+        }
+    }
 }

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -170,16 +170,17 @@ class MetadataTests {
         assertEquals("\$code", childElement!!.csvFields?.first()?.format)
         // sibling uses extends
         val sibling = metadata.findSchema("sibling_schema")
-        assertNotNull(sibling)
-        val siblingElement = sibling.findElement(elementName)
-        assertThat(siblingElement)
+        assertThat(sibling)
+            .isNotNull()
+            .hasElement(elementName)
             .isNotNull()
             .csvFieldsHasSize(1)
+        val siblingElement = sibling!!.findElement(elementName)
         assertNull(siblingElement!!.csvFields?.first()?.format)
         // twin uses basedOn instead of extends
         val twin = metadata.findSchema("twin_schema")
-        assertNotNull(twin)
-        assertThat(twin.findElement(elementName)).all {
+        assertThat(twin).isNotNull()
+        assertThat(twin!!.findElement(elementName)).all {
             isNotNull()
             prop("csvFields") { Element::csvFields.call(it) }.hasSize(1)
             prop("csvFields") { Element::csvFields.call(it) }.given {
@@ -227,6 +228,11 @@ class MetadataTests {
     }
 
     companion object {
+        // below are a set of extension functions that assertK can use to run assertions on our code.
+        // these come in two flavors:
+        // - given, which just checks a value and returns Unit, meaning you cannot chain assertions
+        // - transform, which not only checks your assertion, but returns a value wrapped in Assertion<> so you
+        //   you can chain assertions.
         private fun Assert<List<*>?>.hasSize(expected: Int) = given { actual ->
             if (actual?.size == expected) return
             expected("size:${show(expected)} but was ${show(actual?.size?.toString() ?: "null")}")

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -16,7 +16,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class MetadataTests {
     @Test

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -1,18 +1,27 @@
 package gov.cdc.prime.router
 
-import org.junit.jupiter.api.Test
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameAs
+import assertk.assertions.isNull
+import assertk.assertions.isSameAs
+import assertk.assertions.prop
+import assertk.assertions.support.appendName
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class MetadataTests {
     @Test
     fun `test loading metadata catalog`() {
         val metadata = Metadata("./metadata")
-        assertNotNull(metadata)
+        assertThat(metadata).isNotNull()
     }
 
     @Test
@@ -21,7 +30,7 @@ class MetadataTests {
             Schema(Element("a"), name = "one", topic = "test"),
             Schema(Element("a"), Element("b"), name = "two", topic = "test")
         )
-        assertNotNull(metadata.findSchema("one"))
+        assertThat(metadata.findSchema("one")).isNotNull()
     }
 
     @Test
@@ -31,7 +40,10 @@ class MetadataTests {
             Schema(Element("a"), Element("b"), name = "two", topic = "test", basedOn = "one")
         )
         val two = metadata.findSchema("two")
-        assertEquals("foo", two?.findElement("a")?.default)
+        assertThat(two)
+            .isNotNull()
+            .hasElement("a")
+            .hasDefaultEqualTo("foo")
     }
 
     @Test
@@ -41,8 +53,13 @@ class MetadataTests {
             Schema(Element("a"), name = "two", topic = "test", extends = "one")
         )
         val two = metadata.findSchema("two")
-        assertEquals("foo", two?.findElement("a")?.default)
-        assertNotNull(two?.findElement("b"))
+        assertThat(two)
+            .isNotNull()
+            .hasElement("b")
+        assertThat(two)
+            .isNotNull()
+            .hasElement("a")
+            .hasDefaultEqualTo("foo")
     }
 
     @Test
@@ -53,10 +70,13 @@ class MetadataTests {
             Schema(Element("a"), Element("d"), name = "three", topic = "test", extends = "two")
         )
         val three = metadata.findSchema("three")
-        assertEquals("foo", three?.findElement("a")?.default)
-        assertNull(three?.findElement("b"))
-        assertNotNull(three?.findElement("c"))
-        assertNotNull(three?.findElement("d"))
+        assertThat(three?.findElement("b")).isNull()
+        assertThat(three).isNotNull().hasElement("c")
+        assertThat(three).isNotNull().hasElement("d")
+        assertThat(three)
+            .isNotNull()
+            .hasElement("a")
+            .hasDefaultEqualTo("foo")
     }
 
     @Test
@@ -65,13 +85,13 @@ class MetadataTests {
             ValueSet("one", ValueSet.SetSystem.HL7),
             ValueSet("two", ValueSet.SetSystem.LOCAL)
         )
-        assertNotNull(metadata.findValueSet("one"))
+        assertThat(metadata.findValueSet("one")).isNotNull()
     }
 
     @Test
     fun `load value set directory`() {
         val metadata = Metadata().loadValueSetCatalog("./metadata/valuesets")
-        assertNotNull(metadata.findValueSet("hl70136"))
+        assertThat(metadata.findValueSet("hl70136")).isNotNull()
     }
 
     @Test
@@ -80,7 +100,7 @@ class MetadataTests {
             Schema(name = "One", topic = "test", elements = listOf(Element("a"))),
             Schema(name = "Two", topic = "test", elements = listOf(Element("a"), Element("b")))
         )
-        assertNotNull(metadata.findSchema("one"))
+        assertThat(metadata.findSchema("one")).isNotNull()
     }
 
     @Test
@@ -138,28 +158,33 @@ class MetadataTests {
         // assert
         val elementName = "a"
         val parent = metadata.findSchema("base_schema")
-        assertNotNull(parent)
-        assertTrue(parent.findElement(elementName)?.csvFields.isNullOrEmpty())
+        assertThat(parent).isNotNull()
+        assertTrue(parent!!.findElement(elementName)?.csvFields.isNullOrEmpty())
         // the first child element
         val child = metadata.findSchema("child_schema")
-        assertNotNull(child)
-        val childElement = child.findElement(elementName)
-        assertNotNull(childElement)
-        assertEquals("\$code", childElement.csvFields?.first()?.format)
+        assertThat(child).isNotNull()
+        val childElement = child!!.findElement(elementName)
+        assertThat(childElement).isNotNull()
+        assertEquals("\$code", childElement!!.csvFields?.first()?.format)
         // sibling uses extends
         val sibling = metadata.findSchema("sibling_schema")
         assertNotNull(sibling)
         val siblingElement = sibling.findElement(elementName)
-        assertNotNull(siblingElement)
-        assertTrue(siblingElement.csvFields?.count() == 1)
-        assertNull(siblingElement.csvFields?.first()?.format)
+        assertThat(siblingElement)
+            .isNotNull()
+            .csvFieldsHasSize(1)
+        assertNull(siblingElement!!.csvFields?.first()?.format)
         // twin uses basedOn instead of extends
         val twin = metadata.findSchema("twin_schema")
         assertNotNull(twin)
-        val twinElement = twin.findElement(elementName)
-        assertNotNull(twinElement)
-        assertTrue(twinElement.csvFields?.count() == 1)
-        assertNull(twinElement.csvFields?.first()?.format)
+        assertThat(twin.findElement(elementName)).all {
+            isNotNull()
+            prop("csvFields") { Element::csvFields.call(it) }.hasSize(1)
+            prop("csvFields") { Element::csvFields.call(it) }.given {
+                if (it?.first()?.format.isNullOrEmpty()) return@given
+                expected("format expected to be null but was ${show(it?.first()?.format)}")
+            }
+        }
     }
 
     @Test
@@ -187,8 +212,8 @@ class MetadataTests {
         val shouldBeExtended = valueSet.mergeAltValues(additionalValues)
 
         // assert
-        assertSame(valueSet, shouldBeSame)
-        assertNotSame(valueSet, shouldBeDifferent)
+        assertThat(valueSet).isSameAs(shouldBeSame)
+        assertThat(valueSet).isNotSameAs(shouldBeDifferent)
 
         assertNotNull(shouldBeSame.values.find { it.code.equals("UNK", ignoreCase = true) })
         assertNotNull(shouldBeDifferent.values.find { it.code.equals("U", ignoreCase = true) })
@@ -197,5 +222,32 @@ class MetadataTests {
 
         assertNotNull(shouldBeExtended.values.find { it.code.equals("M", ignoreCase = true) })
         assertNotNull(shouldBeExtended.values.find { it.code.equals("UNK", ignoreCase = true) })
+    }
+
+    companion object {
+        private fun Assert<List<*>?>.hasSize(expected: Int) = given { actual ->
+            if (actual?.size == expected) return
+            expected("size:${show(expected)} but was ${show(actual?.size?.toString() ?: "null")}")
+        }
+
+        private fun Assert<Schema>.hasElement(expected: String): Assert<Element?> = transform(
+            appendName("elementName")
+        ) { actual ->
+            if (actual.findElement(expected) != null) {
+                actual.findElement(expected)
+            } else {
+                expected("element named ${show(expected)} to exist")
+            }
+        }
+
+        private fun Assert<Element?>.hasDefaultEqualTo(expected: String) = given { actual ->
+            if (actual?.default == expected) return@given
+            expected("default:${show(expected)} but was ${show(actual?.default ?: "null")}")
+        }
+
+        private fun Assert<Element?>.csvFieldsHasSize(expected: Int) = given { actual ->
+            if (actual?.csvFields?.size == expected) return@given
+            expected("csvFields size:${show(expected)} but was ${show(actual?.csvFields?.size ?: "null")}")
+        }
     }
 }

--- a/prime-router/src/test/kotlin/MetadataTests.kt
+++ b/prime-router/src/test/kotlin/MetadataTests.kt
@@ -6,6 +6,7 @@ import assertk.assertThat
 import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameAs
 import assertk.assertions.isNull
+import assertk.assertions.isNullOrEmpty
 import assertk.assertions.isSameAs
 import assertk.assertions.prop
 import assertk.assertions.support.appendName
@@ -159,7 +160,9 @@ class MetadataTests {
         val elementName = "a"
         val parent = metadata.findSchema("base_schema")
         assertThat(parent).isNotNull()
-        assertTrue(parent!!.findElement(elementName)?.csvFields.isNullOrEmpty())
+            .hasElement(elementName)
+            .prop("csvFields") { Element::csvFields.call(it) }
+            .isNullOrEmpty()
         // the first child element
         val child = metadata.findSchema("child_schema")
         assertThat(child).isNotNull()

--- a/prime-router/src/test/kotlin/SimpleReportTests.kt
+++ b/prime-router/src/test/kotlin/SimpleReportTests.kt
@@ -276,7 +276,6 @@ class SimpleReportTests {
             recordId: String = "Patient_ID"
         ) {
             assertThat(testFile).exists()
-            assertThat(testFile).exists()
             assertThat(expectedResultsFile).exists()
             // A bit of a hack:  diff the two files.
             val testFileLines = testFile.readLines()

--- a/prime-router/src/test/kotlin/TranslatorTests.kt
+++ b/prime-router/src/test/kotlin/TranslatorTests.kt
@@ -1,8 +1,10 @@
 package gov.cdc.prime.router
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import java.io.ByteArrayInputStream
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class TranslatorTests {
     private val receiversYaml = """
@@ -22,44 +24,42 @@ class TranslatorTests {
                 schemaName: one
                 format: CSV
     """.trimIndent()
+    private val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
 
     @Test
     fun `test buildMapping`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
         val two = Schema(name = "two", topic = "test", elements = listOf(Element("a"), Element("b")))
         val metadata = Metadata().loadSchemas(one, two)
         val translator = Translator(metadata, FileSettings())
-
-        val oneToTwo = translator.buildMapping(fromSchema = one, toSchema = two, defaultValues = emptyMap())
-        assertEquals(one, oneToTwo.fromSchema)
-        assertEquals(two, oneToTwo.toSchema)
-        assertEquals(1, oneToTwo.useDirectly.size)
-        assertEquals("a", oneToTwo.useDirectly["a"])
-        assertEquals(false, oneToTwo.useDefault.contains("b"))
-        assertEquals(0, oneToTwo.missing.size)
-
-        val twoToOne = translator.buildMapping(fromSchema = two, toSchema = one, defaultValues = emptyMap())
-        assertEquals(1, twoToOne.useDirectly.size)
-        assertEquals("a", twoToOne.useDirectly["a"])
-        assertEquals(0, twoToOne.useDefault.size)
-        assertEquals(0, twoToOne.missing.size)
+        translator.buildMapping(fromSchema = one, toSchema = two, defaultValues = emptyMap()).run {
+            assertThat(one).isEqualTo(fromSchema)
+            assertThat(two).isEqualTo(toSchema)
+            assertThat(1).isEqualTo(useDirectly.size)
+            assertThat("a").isEqualTo(useDirectly["a"])
+            assertThat(false).isEqualTo(useDefault.contains("b"))
+            assertThat(0).isEqualTo(missing.size)
+        }
+        translator.buildMapping(fromSchema = two, toSchema = one, defaultValues = emptyMap()).run {
+            assertThat(1).isEqualTo(useDirectly.size)
+            assertThat("a").isEqualTo(useDirectly["a"])
+            assertThat(0).isEqualTo(useDefault.size)
+            assertThat(0).isEqualTo(missing.size)
+        }
     }
 
     @Test
     fun `test buildMapping with default`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
         val two = Schema(name = "two", topic = "test", elements = listOf(Element("a"), Element("b", default = "x")))
         val metadata = Metadata().loadSchemas(one, two)
         val translator = Translator(metadata, FileSettings())
-
-        val oneToTwo = translator.buildMapping(fromSchema = one, toSchema = two, defaultValues = mapOf("b" to "foo"))
-        assertEquals(true, oneToTwo.useDefault.contains("b"))
-        assertEquals("foo", oneToTwo.useDefault["b"])
+        translator.buildMapping(fromSchema = one, toSchema = two, defaultValues = mapOf("b" to "foo")).run {
+            assertThat(useDefault.contains("b")).isTrue()
+            assertThat("foo").isEqualTo(useDefault["b"])
+        }
     }
 
     @Test
     fun `test buildMapping with missing`() {
-        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a")))
         val three = Schema(
             name = "three",
             topic = "test",
@@ -67,30 +67,29 @@ class TranslatorTests {
         )
         val metadata = Metadata().loadSchemas(one, three)
         val translator = Translator(metadata, FileSettings())
-
-        val oneToThree = translator.buildMapping(fromSchema = one, toSchema = three, defaultValues = emptyMap())
-        assertEquals(1, oneToThree.useDirectly.size)
-        assertEquals("a", oneToThree.useDirectly["a"])
-        assertEquals(0, oneToThree.useDefault.size)
-        assertEquals(1, oneToThree.missing.size)
+        translator.buildMapping(fromSchema = one, toSchema = three, defaultValues = emptyMap()).run {
+            assertThat(1).isEqualTo(this.useDirectly.size)
+            assertThat("a").isEqualTo(this.useDirectly["a"])
+            assertThat(0).isEqualTo(this.useDefault.size)
+            assertThat(1).isEqualTo(this.missing.size)
+        }
     }
 
     @Test
     fun `test filterAndMapByReceiver`() {
         val metadata = Metadata()
-        val settings = FileSettings()
-        settings.loadOrganizations(ByteArrayInputStream(receiversYaml.toByteArray()))
+        val settings = FileSettings().also {
+            it.loadOrganizations(ByteArrayInputStream(receiversYaml.toByteArray()))
+        }
         val translator = Translator(metadata, settings)
-
         val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
         val table1 = Report(one, listOf(listOf("1", "2"), listOf("3", "4")), TestSource)
-
-        val result = translator.filterAndTranslateByReceiver(table1, warnings = mutableListOf<ResultDetail>())
-
-        assertEquals(1, result.size)
-        val (mappedTable, forReceiver) = result[0]
-        assertEquals(table1.schema, mappedTable.schema)
-        assertEquals(1, mappedTable.itemCount)
-        assertEquals(settings.receivers.toTypedArray()[0], forReceiver)
+        translator.filterAndTranslateByReceiver(table1, warnings = mutableListOf()).run {
+            assertThat(1).isEqualTo(this.size)
+            val (mappedTable, forReceiver) = this[0]
+            assertThat(table1.schema).isEqualTo(mappedTable.schema)
+            assertThat(1).isEqualTo(mappedTable.itemCount)
+            assertThat(settings.receivers.toTypedArray()[0]).isEqualTo(forReceiver)
+        }
     }
 }


### PR DESCRIPTION
This PR adds a reference to the assertk fluent assertions library, and converts some tests to use the assertk library as examples.

Fluent assertions are easier to read and are chainable, so you're able to more clearly express the intent of your checks in your tests. An example from our own code is:

```kotlin
// this checks to see if the schema is not null, and if it has an element named "c"
assertThat(three).isNotNull().hasElement("c")
```

```kotlin
// this checks to see if the schema is not null, it has an element named "a" and the element has two csvFields attached
assertThat(schema).isNotNull().hasElement("a").csvFieldsHasSize(2)
```
In both of the cases above, I've not only made use of the built-in assertions provided by assertk, but I also added extension methods that let us build our own custom assertions.  Extension methods in assertk come in two flavors:
- `given` where the value is checked and either returns unit or throws the expected condition to fail the test
- `transform` where a value is checked in the assertion, and then a value is returned so assertions can be chained, or the test fails and expected is thrown.

This is more easily explained by examples:
```kotlin
// this checks a nullable list to see if it has a size. by default assertk doesn't do tests on nullable type
// this is a given assertion, which means it's expected it will either return unit or will throw
private fun Assert<List<*>?>.hasSize(expected: Int) = given { actual ->
    // check the size for what was expected, and if it matches, then return
    if (actual?.size == expected) return
    // otherwise fail
    expected("size:${show(expected)} but was ${show(actual?.size?.toString() ?: "null")}")
}

// this checks a schema for an element, and if the element doesn't exist, fails
// this is a transform assertion, which means it takes in a schema object, but actually returns
// a nullable Element wrapped in an assertion, which then lets us chain our assertions
private fun Assert<Schema>.hasElement(expected: String): Assert<Element?> = transform(
    appendName("elementName")
) { actual ->
    // if the schema contains an element with name expected, return the actual element
    if (actual.findElement(expected) != null) {
        actual.findElement(expected)
    } else {
        expected("element named ${show(expected)} to exist")
    }
}
```

The biggest shortcoming I see with assertK is it doesn't work on nullable types cleanly, so we will have some custom code to write for some of our logic, but given how easy that is to accomplish, I don't see it as major hurdle.

## Changes
- Adds reference to the assertk library
- Converts some tests to use assertk style fluent assertions
- Adds some extension methods to demonstrate how they're done
- Added in setting in gradle to parallelize our tests

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?


