### PR TITLE
Adding an SFTP send file option to the CheckFunction

### DIFF
--- a/prime-router/docs/how-to-create-and-manage-receiver-ppks.md
+++ b/prime-router/docs/how-to-create-and-manage-receiver-ppks.md
@@ -141,5 +141,16 @@ curl -s -H 'x-functions-key:<SECRET FUNCTION KEY>' "https://prime.cdc.gov/api/ch
 
 In the above command you will need to have the secret function key to post commands to Azure. This will attempt to connect to the receiver, execute an `ls` and then report back if it was successful. It will *NOT* show any results from the call to `ls`, only whether or not it was able to connect and execute.
 
+You can also test sending a file to a receiver by appending `&sendfile` to the query string. This will create an empty file to send and remove as a test. You can also use this endpoint with a `POST` to send a file as well (subject to size restrictions).
+
+```
+curl -s -H 'x-functions-key:<SECRET FUNCTION KEY>' "https://prime.cdc.gov/api/check?sftpcheck=nj-doh.elr&sendfile"
+```
+```
+curl -s -H 'x-functions-key:<SECRET FUNCTION KEY>' -X POST \
+    --data-binary '@./path/to/testfile.csv' \
+    "https://prime.cdc.gov/api/check?sftpcheck=nj-doh.elr&sendfile"
+```
+
 ## Final Thoughts
 There could be a time in the future when we will need to follow these same steps to generate public/private key pairs for senders as well, especially as we move into the world of OAuth and using FHIR to communicate.

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -14,6 +14,7 @@ import gov.cdc.prime.router.credentials.SftpCredential
 import gov.cdc.prime.router.credentials.UserPassCredential
 import gov.cdc.prime.router.credentials.UserPpkCredential
 import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.sftp.RemoteResourceFilter
 import net.schmizz.sshj.sftp.StatefulSFTPClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
@@ -152,12 +153,16 @@ class SftpTransport : ITransport, Logging {
         }
 
         fun ls(sshClient: SSHClient, path: String): List<String> {
+            return ls(sshClient, path, null)
+        }
+
+        fun ls(sshClient: SSHClient, path: String, resourceFilter: RemoteResourceFilter?): List<String> {
             val lsResults = mutableListOf<String>()
             try {
                 try {
                     sshClient.use { sshClient ->
                         sshClient.newSFTPClient().use {
-                            it.ls(path).map { l -> lsResults.add(l.toString()) }
+                            it.ls(path, resourceFilter).map { l -> lsResults.add(l.toString()) }
                         }
                     }
                 } finally {


### PR DESCRIPTION
Added a `sendfile` flag to the URL and the ability to `POST` a file to test sending a file via SFTP to the receiver.

## Changes
- added `POST` to the end point
- checking for a `sendfile` parameter in the query string and generating a test file based on `GET` or `POST`
- added an `rm` function to the `SftpTransport` class to remove the uploaded file
- changed logging / messaging slightly to account for new logic

## Checklist
- [ ] ensure the old functionality/messaging works as expected (connect, ls and drop)
- [ ] test the `GET` option with the `sendfile` flag
- [ ] test the `POST` option with the `sendfile` flag and sending data in the request body
- [ ] test the `POST` with a file larger than 100K characters to ensure it gets rejected

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
*** Tests FAILED:  garbage *** known issue
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data? 
- [ ] Are additional approvals needed for this change?
- [x] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?
Potential for testers to bog down the end point trying to upload a large file. Also could inundate the end point with lots of small requests.

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #1008

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

