### PR TITLE
Adds yamlito for NM SFTP repoint

### DIFF
--- a/prime-router/settings/organizations-prod.yml
+++ b/prime-router/settings/organizations-prod.yml
@@ -263,7 +263,7 @@
         useBlankInsteadOfUnknown: patient_race
       transport:
         type: SFTP
-        host: secure.lcfresearch.org
+        host: sftp.syncronys.org
         port: 22
         filePath: ./
       timing:

--- a/prime-router/settings/prod/0022-nm-sftp-repoint.yml
+++ b/prime-router/settings/prod/0022-nm-sftp-repoint.yml
@@ -1,0 +1,41 @@
+---
+name: "elr"
+organizationName: "nm-doh"
+topic: "covid-19"
+translation: !<HL7>
+  useTestProcessingMode: false
+  useBatchHeaders: true
+  receivingApplicationName: "NMDOH"
+  receivingApplicationOID: "2.16.840.1.113883.3.5364"
+  receivingFacilityName: "NMDOH"
+  receivingFacilityOID: "2.16.840.1.113883.3.5364"
+  messageProfileId: null
+  reportingFacilityName: null
+  reportingFacilityId: null
+  suppressQstForAoe: false
+  suppressHl7Fields: "OBX-17-1"
+  suppressAoe: false
+  defaultAoeToUnknown: false
+  useBlankInsteadOfUnknown: "patient_race"
+  truncateHDNamespaceIds: true
+  usePid14ForPatientEmail: false
+  convertTimestampToDateTime: null
+  nameFormat: "APHL_LIGHT"
+  receivingOrganization: "elr"
+  type: "HL7"
+jurisdictionalFilter:
+  - "matches(ordering_facility_state, NM)"
+qualityFilter: []
+deidentify: false
+timing:
+  operation: "MERGE"
+  numberPerDay: 12
+  initialTime: "01:15"
+  timeZone: "EASTERN"
+  maxReportCount: 100
+description: ""
+transport: !<SFTP>
+  host: "sftp.syncronys.org"
+  port: "22"
+  filePath: "./incoming/ELR/"
+  type: "SFTP"


### PR DESCRIPTION
This PR adds a yamlito to repoint NM SFTP server. 

## Changes
- Adds yamlito
- Updates organizations-prod.yml

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1086 


