### PR TITLE
Change all logging at the info/warning level to not print the stack trace

### DIFF
--- a/prime-router/src/main/kotlin/azure/DownloadFunction.kt
+++ b/prime-router/src/main/kotlin/azure/DownloadFunction.kt
@@ -197,7 +197,7 @@ class DownloadFunction() : SecretManagement, BaseHistoryFunction() {
                 return response
             }
         } catch (ex: Exception) {
-            context.logger.log(Level.WARNING, "Exception during download of $requestedFile", ex)
+            context.logger.warning("Exception during download of $requestedFile")
             response = request.createResponseBuilder(HttpStatus.NOT_FOUND)
                 .body("File $requestedFile not found")
                 .header("Content-Type", "text/html")

--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -243,7 +243,7 @@ open class BaseHistoryFunction {
                     try{ 
                         facilities = getFieldSummaryForReportId(arrayOf("Testing_lab_name","Testing_lab_CLIA"),it.reportId.toString(), authClaims)
                     }catch( ex: Exception ){
-                        //context.logger.log( Level.INFO, "Exception during getFieldSummaryForReportId - TestingLabName was not found - no facilities data will be published" );
+                        //context.logger.info( "Exception during getFieldSummaryForReportId - TestingLabName was not found - no facilities data will be published" );
                     }
 
                 var actions = getActionsForReportId( it.reportId.toString(), authClaims );
@@ -266,7 +266,7 @@ open class BaseHistoryFunction {
                 .header("Content-Type", "application/json")
                 .build()
         }catch (ex: Exception) {
-            context.logger.log(Level.INFO, "Exception during creating of reports list - file not found")
+            context.logger.info("Exception during creating of reports list - file not found")
             response = request.createResponseBuilder(HttpStatus.NOT_FOUND)
                 .body("File not found")
                 .header("Content-Type", "text/html")
@@ -296,7 +296,7 @@ open class BaseHistoryFunction {
                     .build()
             }
         } catch (ex: Exception) {
-            context.logger.log(Level.WARNING, "Exception during download of $reportIdIn - file not found", ex)
+            context.logger.warning("Exception during download of $reportIdIn - file not found")
             response = request.createResponseBuilder(HttpStatus.NOT_FOUND)
                 .body("File $reportIdIn not found")
                 .header("Content-Type", "text/html")
@@ -365,7 +365,7 @@ open class BaseHistoryFunction {
 
         } 
         catch (ex: Exception) {
-            context.logger.log(Level.INFO, "Exception during download of summary/tests")
+            context.logger.info("Exception during download of summary/tests")
             response = request.createResponseBuilder(HttpStatus.NOT_FOUND)
                 .body("File not found")
                 .header("Content-Type", "text/html")
@@ -395,7 +395,7 @@ open class BaseHistoryFunction {
                 .header("Content-Type", "application/json")
                 .build()
         }catch (ex: Exception) {
-            context.logger.log(Level.INFO, "Exception during download of summary")
+            context.logger.info("Exception during download of summary")
             response = request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body("Exception during GetSummary()")
                 .header("Content-Type", "text/html")

--- a/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
+++ b/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
@@ -25,10 +25,10 @@ class BlobStoreTransport : ITransport {
         return try {
             val receiver = header.receiver ?: error("No receiver defined for report ${header.reportFile.reportId}")
             val bodyUrl = header.reportFile.bodyUrl ?: error("Report ${header.reportFile.reportId} has no blob to copy")
-            context.logger.log(Level.INFO, "About to copy $bodyUrl to $envVar:$storageName")
+            context.logger.info("About to copy $bodyUrl to $envVar:$storageName")
             var newUrl = WorkflowEngine().blob.copyBlob(bodyUrl,envVar, storageName)
             val msg = "Successfully copied $bodyUrl to $newUrl"
-            context.logger.log(Level.INFO, msg)
+            context.logger.info(msg)
             actionHistory.trackActionResult(msg)
             actionHistory.trackSentReport(
                 receiver,
@@ -45,7 +45,7 @@ class BlobStoreTransport : ITransport {
                 "FAILED Blob copy of inputReportId ${header.reportFile.reportId} to " +
                     "$blobTransportType ($envVar:$storageName)" +
                     ", Exception: ${t.localizedMessage}"
-            context.logger.log(Level.WARNING, msg, t)
+            context.logger.warning( msg )
             actionHistory.setActionType(TaskAction.send_error)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -96,7 +96,7 @@ class RedoxTransport() : ITransport, SecretManagement {
             resultMsg =
                 "Exception during REDOX send of reportId ${header.reportFile.reportId}: " +
                 "  ${t.localizedMessage}.  "
-            context.logger.warning(resultMsg)
+                context.logger.log(Level.WARNING, resultMsg, t)
             if (successCount == 0) {
                 nextRetryItems = (retryItems ?: RetryToken.allItems) as MutableList<String>
                 // If even one redox message got through, we'll call that 'send' rather than send_error

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -96,7 +96,7 @@ class RedoxTransport() : ITransport, SecretManagement {
             resultMsg =
                 "Exception during REDOX send of reportId ${header.reportFile.reportId}: " +
                 "  ${t.localizedMessage}.  "
-            context.logger.log(Level.WARNING, resultMsg, t)
+            context.logger.warning(resultMsg)
             if (successCount == 0) {
                 nextRetryItems = (retryItems ?: RetryToken.allItems) as MutableList<String>
                 // If even one redox message got through, we'll call that 'send' rather than send_error

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -47,10 +47,10 @@ class SftpTransport : ITransport, Logging {
             // Dev note:  db table requires body_url to be unique, but not external_name
             val fileName = Report.formExternalFilename(header)
             val sshClient = connect(host, port, credential)
-            context.logger.log(Level.INFO, "Successfully connected to $sftpTransportType, ready to upload $fileName")
+            context.logger.info("Successfully connected to $sftpTransportType, ready to upload $fileName")
             uploadFile(sshClient, sftpTransportType.filePath, fileName, header.content)
             val msg = "Success: sftp upload of $fileName to $sftpTransportType"
-            context.logger.log(Level.INFO, msg)
+            context.logger.info(msg)
             actionHistory.trackActionResult(msg)
             actionHistory.trackSentReport(
                 receiver,
@@ -67,7 +67,7 @@ class SftpTransport : ITransport, Logging {
                 "FAILED Sftp upload of inputReportId ${header.reportFile.reportId} to " +
                     "$sftpTransportType (orgService = ${header.receiver?.fullName ?: "null"})" +
                     ", Exception: ${t.localizedMessage}"
-            context.logger.log(Level.WARNING, msg, t)
+            context.logger.warning(msg)
             actionHistory.setActionType(TaskAction.send_error)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems

--- a/prime-router/src/test/kotlin/transport/RedoxTransportTests.kt
+++ b/prime-router/src/test/kotlin/transport/RedoxTransportTests.kt
@@ -141,6 +141,7 @@ class RedoxTransportTests {
     }
     @Test
     fun `test fetchSecret failure`() {
+    
         val header = makeHeader()
         setupLogger()
         every { redox.secretService }.returns(secretService)
@@ -150,18 +151,21 @@ class RedoxTransportTests {
             .returns(RedoxTransport.SendResult("itemId1", RedoxTransport.ResultStatus.SUCCESS, 1234))
 
         // fetchSecret fails, not on a retry situation.
+
         val retryItemsOut = redox.send(transportType, header, UUID.randomUUID(), null, context, actionHistory)
         assertNotNull(retryItemsOut)
         assertEquals(1, retryItemsOut.size)
         assertTrue(RetryToken.isAllItems(retryItemsOut))
 
         // Now what if fetchSecret fails in a retry situation
+         
         val retryItemsIn = listOf("0", "3")
         val retryItemsOut2 = redox.send(transportType, header, UUID.randomUUID(), retryItemsIn, context, actionHistory)
         assertNotNull(retryItemsOut2)
         assertEquals(2, retryItemsOut2.size)
         assertEquals("0", retryItemsOut2[0])
         assertEquals("3", retryItemsOut2[1])
+        
     }
 
     @Test


### PR DESCRIPTION
This PR changes all logging to:
- use context.logging.{info|warning} in the case of info and warning
- not print the stack trace on instances of info and/or warning 

Reviewer should verify that all logging using context.logging.log is for sever logging only
context.logging.{info|warning} is used in all other cases

## Changes
- use context.logging.{info|warning} in the case of info and warning
- not print the stack trace on instances of info and/or warning 

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [X] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [X] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

