### PR TITLE
Added publishing of unit test results to builds

### DIFF
--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -67,13 +67,13 @@ jobs:
           java-version: 11
 
       - name: Build Prime Router Package
-        run: bash ./gradlew clean package -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
+        run: bash ./gradlew clean package -x fatjar -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
         
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: build/test-results/**/*.xml
+          files: prime-router/build/test-results/**/*.xml
 
       - name: Generate New Docs
         run: |

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -68,6 +68,12 @@ jobs:
 
       - name: Build Prime Router Package
         run: bash ./gradlew clean package -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
+        
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: build/test-results/**/*.xml
 
       - name: Generate New Docs
         run: |

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -73,6 +73,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
+          # This path is from the root of the repo as needed by the plugin
           files: prime-router/build/test-results/**/*.xml
 
       - name: Generate New Docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
 
       - name: Build Prime Router Package
         run: bash ./gradlew clean package -DDB_USER=$POSTGRES_USER -DDB_PASSWORD=$POSTGRES_PASSWORD
+        
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          # This path is from the root of the repo as needed by the plugin
+          files: prime-router/build/test-results/**/*.xml
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR uses a Github Actions plugin to publish the unit tests results to the Github Actions results, so we can see any errors that may pop up.  I encountered an issue that tests were failing only in Github due to environment differences and I needed to see what the problem was.  I wish you could see the STDOUT of the tests, but you can only see the assertion failure.  The results show in the jobs summary of the build and a comment is added to a PR if there are errors.  More details about the plugin at https://github.com/marketplace/actions/publish-unit-test-results

![image](https://user-images.githubusercontent.com/63804190/119039709-944ea080-b982-11eb-87c3-25a0da75ee59.png)
![image](https://user-images.githubusercontent.com/63804190/119039769-9dd80880-b982-11eb-9a46-e8340f221287.png)

When there are errors ([Click here to see real errors](https://github.com/CDCgov/prime-data-hub/runs/2632215149?check_suite_focus=true)):
![image](https://user-images.githubusercontent.com/63804190/119043312-e8f41a80-b986-11eb-8fd5-61bff9386088.png)

This is what the comment in the PR looks like.  It keeps updating the same comment with the latest results:
![image](https://user-images.githubusercontent.com/63804190/119042703-33c16280-b986-11eb-90ad-e4dccd413b86.png)

## Changes
- Updated the router build to upload the test results
- Updated the release build to upload the router build test results

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
- #1127

## To Be Done


