### PR TITLE
Updated mime type for HL7 messages

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -55,8 +55,8 @@ class Report {
     ) {
         INTERNAL("internal", "text/csv"), // A format that serializes all elements of a Report.kt (in CSV)
         CSV("csv", "text/csv"), // A CSV format the follows the csvFields
-        HL7("hl7", "text/hl7", true), // HL7 with one result per file
-        HL7_BATCH("hl7", "text/hl7"), // HL7 with BHS and FHS headers
+        HL7("hl7", "application/hl7-v2", true), // HL7 with one result per file
+        HL7_BATCH("hl7", "application/hl7-v2"), // HL7 with BHS and FHS headers
         REDOX("redox", "text/json", true); // Redox format
         // FHIR
 

--- a/prime-router/src/main/kotlin/Sender.kt
+++ b/prime-router/src/main/kotlin/Sender.kt
@@ -21,7 +21,7 @@ open class Sender(
 
     enum class Format(val mimeType: String) {
         CSV("text/csv"),
-        HL7("text/hl7"),   // todo correct this.  Maybe  x-application/hl7-v2+er7
+        HL7("application/hl7-v2"),
     }
 
     /**


### PR DESCRIPTION
This PR updates the mime type for HL7 messages.

First, there is no HL7 mime type specified in the IANA list. There is an [old 2008 proposal by HL7](https://wiki.hl7.org/Media-types_for_various_message_formats) on what mime types to use, but it mentions registering them with IANA and that has not happened. The best source I can find is the HAPI library, which is already using some similar mime types as [documented here](https://hapifhir.github.io/hapi-hl7v2/hapi-hl7overhttp/specification.html). Based on that information and HAPI's implementation, I will recommend using application/hl7-v2 per their implementation in https://hapifhir.github.io/hapi-hl7v2/hapi-hl7overhttp/xref/ca/uhn/hl7v2/hoh/encoder/EncodingStyle.html#16

## Changes
- Update the mime type

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security

## Fixes
- #1068

## To Be Done

