### PR TITLE
Added warning messages on formatting/code failures

### DIFF
--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -452,7 +452,7 @@ data class Element(
                         }
                         else ->
                             if (valueSetRef.toNormalizedCode(formattedValue) != null) null else
-                                "Invalid Code: '$formattedValue' does not match any codes for $fieldMapping"
+                                "Invalid code: '$formattedValue' does not match any codes for $fieldMapping"
                     }
                 }
             }
@@ -574,7 +574,7 @@ data class Element(
                             ?: error("Invalid code: '$formattedValue' is not a display value for element $fieldMapping")
                     else ->
                         valueSetRef?.toNormalizedCode(formattedValue)
-                            ?: error("Invalid Code: '$formattedValue' does not match any codes for $fieldMapping")
+                            ?: error("Invalid code: '$formattedValue' does not match any codes for $fieldMapping")
                 }
             }
             Type.TELEPHONE -> {

--- a/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
@@ -286,6 +286,7 @@ class CsvSerializer(val metadata: Metadata) {
                     when (element.cardinality) {
                         Element.Cardinality.ONE -> errors += error
                         Element.Cardinality.ZERO_OR_ONE -> warnings += error
+                        else -> warnings += "$error - setting value to ''"
                     }
                     return failureValue
                 }


### PR DESCRIPTION
This PR address issue #1061 where warning messages were suppressed in the Json response to the sender on submissions to /api/reports. 

## Changes
- standardized the case on some error messages
- added any messages to the warnings collection if the checkForError failed regardless of the cardinality of the element

## Checklist
- [ ] upload a report with bad data and check the warnings to see if there is a message for all bad data elements

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #1061

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

