### PR TITLE
Redirect to the new download site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ prime-router/routed_files/*
 operations/app/src/**/.terraform*
 operations/app/src/**/terraform.tfstate*
 operations/app/src/**/plan.out
+!operations/app/src/**/.terraform.lock.hcl
 
 # Hashicorp Vault Secrets
 prime-router/.vault/env/**

--- a/operations/app/src/environments/common/.terraform.lock.hcl
+++ b/operations/app/src/environments/common/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.61.0"
+  constraints = "2.61.0"
+  hashes = [
+    "h1:HF/suXV0V9cQyW/bUGj00g/W59JWGpIk9L0FMsCE0u8=",
+    "zh:011075f7a9239e3f4e592f7ace8f40aa1af60e300b97a7d97d3834ecb3a2e27c",
+    "zh:0f6bb1f5b742360b77125c7704d2890f1377db30f62188800a54000e3bc6c764",
+    "zh:353723efc426f48d3f5d49ce0fb52a78c72102f7cb6707c50ee300701a6aa08e",
+    "zh:443d822d7f51327bd5315594c14099f9ea8ccd89968529f7e0337dc201ab789d",
+    "zh:47f508eb252194e6ee71154e7df88d0cc35709a0263a2c66fb93e62b3a213928",
+    "zh:7c522a59851482b65336a710f2ad25d69000ea2c69eebe942e48fa60f6423b88",
+    "zh:a25fa3560ac72836a4e99f43b6814a2eb3f08016c3caf841247d512a7f2e8243",
+    "zh:b5c5a92cb9f063cfea7b664c09b8acb7958f5a007f56f03a3c7b8c9f0902bf04",
+    "zh:c123c5d33b40325396fbf9bd29e789881900eb6f24246a5fec30d314269f8f80",
+    "zh:c935e9681267c052df53537e7c24afac34ec55325a4909b534846374b751b854",
+    "zh:ff6e772af934ffb47c3bdcb36b0c21e20e7b3f3b9e91064477deea8f6c56ce2c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}

--- a/operations/app/src/environments/dev/.terraform.lock.hcl
+++ b/operations/app/src/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+../common/.terraform.lock.hcl

--- a/operations/app/src/environments/dev/main.tf
+++ b/operations/app/src/environments/dev/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "= 2.45.1" # This version must also be changed in other environments
+      version = ">= 2.61.0" # This version must also be changed in other environments
     }
   }
 }

--- a/operations/app/src/environments/prod/.terraform.lock.hcl
+++ b/operations/app/src/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+../common/.terraform.lock.hcl

--- a/operations/app/src/environments/prod/main.tf
+++ b/operations/app/src/environments/prod/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "= 2.45.1" # This version must also be changed in other environments
+      version = ">= 2.61.0" # This version must also be changed in other environments
     }
   }
   backend "azurerm" {

--- a/operations/app/src/environments/staging/.terraform.lock.hcl
+++ b/operations/app/src/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.61.0"
+  constraints = ">= 2.61.0"
+  hashes = [
+    "h1:HF/suXV0V9cQyW/bUGj00g/W59JWGpIk9L0FMsCE0u8=",
+    "zh:011075f7a9239e3f4e592f7ace8f40aa1af60e300b97a7d97d3834ecb3a2e27c",
+    "zh:0f6bb1f5b742360b77125c7704d2890f1377db30f62188800a54000e3bc6c764",
+    "zh:353723efc426f48d3f5d49ce0fb52a78c72102f7cb6707c50ee300701a6aa08e",
+    "zh:443d822d7f51327bd5315594c14099f9ea8ccd89968529f7e0337dc201ab789d",
+    "zh:47f508eb252194e6ee71154e7df88d0cc35709a0263a2c66fb93e62b3a213928",
+    "zh:7c522a59851482b65336a710f2ad25d69000ea2c69eebe942e48fa60f6423b88",
+    "zh:a25fa3560ac72836a4e99f43b6814a2eb3f08016c3caf841247d512a7f2e8243",
+    "zh:b5c5a92cb9f063cfea7b664c09b8acb7958f5a007f56f03a3c7b8c9f0902bf04",
+    "zh:c123c5d33b40325396fbf9bd29e789881900eb6f24246a5fec30d314269f8f80",
+    "zh:c935e9681267c052df53537e7c24afac34ec55325a4909b534846374b751b854",
+    "zh:ff6e772af934ffb47c3bdcb36b0c21e20e7b3f3b9e91064477deea8f6c56ce2c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}

--- a/operations/app/src/environments/staging/main.tf
+++ b/operations/app/src/environments/staging/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "= 2.45.1" # This version must also be changed in other environments
+      version = ">= 2.61.0" # This version must also be changed in other environments
     }
   }
   backend "azurerm" {

--- a/operations/app/src/environments/test/.terraform.lock.hcl
+++ b/operations/app/src/environments/test/.terraform.lock.hcl
@@ -1,0 +1,1 @@
+../common/.terraform.lock.hcl

--- a/operations/app/src/environments/test/main.tf
+++ b/operations/app/src/environments/test/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "= 2.45.1" # This version must also be changed in other environments
+      version = ">= 2.61.0" # This version must also be changed in other environments
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
This PR redirects the old download site (`prime.cdc.gov`) to the new download site (`reportstream.cdc.gov`). Resolves #1179.

This change has been deployed to `staging.prime.cdc.gov` and can be reviewed in that environment.

## Changes
- Redirects the path `/` and `/download` on `*prime.cdc.gov` to `reportstream.cdc.gov`
    - This preserves API functionality on `prime.cdc.gov`
- Adds some logic to handle the dev environment, which does not have an HTTPS cert
- Migrates the Terraform Azure provider to `v.2.61.0` due to a breaking change Microsoft made on April 9th
  - Followed the migration guide provided by Terraform here: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/2.58.0-frontdoor-upgrade-guide
- Remove the terraform lock file from `.gitignore` so we can more easily manage versions across environments
  - Symlinked the lock file in all environments to enforce consistent versions between all environments

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [x] Are additional approvals needed for this change?
    - [ ] Yes, we need to coordinate the launch and deployment of this change
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?
