### PR TITLE
Deploy Metabase to staging

### DIFF
--- a/operations/app/src/environments/prod/main.tf
+++ b/operations/app/src/environments/prod/main.tf
@@ -33,4 +33,5 @@ module "prime_data_hub" {
   https_cert_names = ["prime-cdc-gov", "reportstream-cdc-gov"]
   rsa_key_2048 = "pdhprod-2048-key"
   rsa_key_4096 = "pdhprod-4096-key"
+  is_metabase_env = true
 }

--- a/operations/app/src/environments/staging/main.tf
+++ b/operations/app/src/environments/staging/main.tf
@@ -33,4 +33,5 @@ module "prime_data_hub" {
   https_cert_names = ["staging-prime-cdc-gov", "staging-reportstream-cdc-gov"]
   rsa_key_2048 = "pdhstaging-2048-key"
   rsa_key_4096 = "pdhstaging-4096-key"
+  is_metabase_env = true
 }

--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -173,7 +173,7 @@ resource "azurerm_postgresql_database" "prime_data_hub_db" {
 }
 
 resource "azurerm_postgresql_database" "metabase_db" {
-  count = (var.environment == "test" || var.environment == "prod" ? 1 : 0)
+  count = var.is_metabase_env ? 1 : 0
   name = "metabase"
   resource_group_name = var.resource_group
   server_name = azurerm_postgresql_server.postgres_server.name

--- a/operations/app/src/modules/database/variables.tf
+++ b/operations/app/src/modules/database/variables.tf
@@ -57,3 +57,8 @@ variable "rsa_key_2048" {
     type = string
     description = "Name of the 2048 length RSA key in the Key Vault. Omitting will use Azure-managed key instead of a customer-key."
 }
+
+variable "is_metabase_env" {
+    type = bool
+    description = "Should Metabase be deployed in this environment"
+}

--- a/operations/app/src/modules/front_door/main.tf
+++ b/operations/app/src/modules/front_door/main.tf
@@ -7,7 +7,7 @@ locals {
   name_static = var.environment != "dev" ? "prime-data-hub-${var.environment}-static" : "prime-data-hub-${var.resource_prefix}-static"
 
   functionapp_address = "${var.resource_prefix}-functionapp.azurewebsites.net"
-  metabase_address = (var.environment == "test" || var.environment == "prod" ? "${var.resource_prefix}-metabase.azurewebsites.net" : null)
+  metabase_address = var.is_metabase_env ? "${var.resource_prefix}-metabase.azurewebsites.net" : null
   static_address = trimprefix(trimsuffix(var.storage_web_endpoint, "/"), "https://")
 
   function_certs = [for cert in var.https_cert_names: cert if length(regexall("^[[:alnum:]]*?-?prime.*$", cert)) > 0]
@@ -16,7 +16,7 @@ locals {
   static_certs = [for cert in var.https_cert_names: cert if length(regexall("^[[:alnum:]]*?-?reportstream.*$", cert)) > 0]
   static_endpoints = local.static_certs
 
-  metabase_env = var.environment == "test" || var.environment == "prod" ? [1] : []
+  metabase_env = var.is_metabase_env ? [1] : []
   static_env = length(local.static_endpoints) > 0 ? [1] : []
   dev_env = length(local.static_endpoints) == 0 ? [1] : []
 }

--- a/operations/app/src/modules/front_door/variables.tf
+++ b/operations/app/src/modules/front_door/variables.tf
@@ -37,3 +37,8 @@ variable "storage_web_endpoint" {
   type = string
   description = "Where the static site is located"
 }
+
+variable "is_metabase_env" {
+  type = bool
+  description = "Should Metabase be deployed in this environment"
+}

--- a/operations/app/src/modules/prime_data_hub/main.tf
+++ b/operations/app/src/modules/prime_data_hub/main.tf
@@ -1,162 +1,164 @@
 locals {
-    location = "eastus"
+  location = "eastus"
 }
 
 module "storage" {
-    source = "../storage"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    name = "${var.resource_prefix}storageaccount"
-    location = local.location
-    public_subnet_id = module.network.public_subnet_id
-    container_subnet_id = module.network.container_subnet_id
-    endpoint_subnet_id = module.network.endpoint_subnet_id
-    eventhub_namespace_name = module.event_hub.eventhub_namespace_name
-    eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
-    key_vault_id = module.key_vault.application_key_vault_id
-    rsa_key_4096 = var.rsa_key_4096
+  source = "../storage"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  name = "${var.resource_prefix}storageaccount"
+  location = local.location
+  public_subnet_id = module.network.public_subnet_id
+  container_subnet_id = module.network.container_subnet_id
+  endpoint_subnet_id = module.network.endpoint_subnet_id
+  eventhub_namespace_name = module.event_hub.eventhub_namespace_name
+  eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+  key_vault_id = module.key_vault.application_key_vault_id
+  rsa_key_4096 = var.rsa_key_4096
 }
 
 module "network" {
-    source = "../network"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
+  source = "../network"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
 }
 
 module "container_registry" {
-    source = "../container_registry"
-    environment = var.environment
-    resource_group = var.resource_group
-    name = "${var.resource_prefix}containerregistry"
-    location = local.location
-    public_subnet_id = module.network.public_subnet_id
-    endpoint_subnet_id = module.network.endpoint_subnet_id
+  source = "../container_registry"
+  environment = var.environment
+  resource_group = var.resource_group
+  name = "${var.resource_prefix}containerregistry"
+  location = local.location
+  public_subnet_id = module.network.public_subnet_id
+  endpoint_subnet_id = module.network.endpoint_subnet_id
 }
 
 module "app_service_plan" {
-    source = "../app_service_plan"
-    environment = var.environment
-    resource_group = var.resource_group
-    location = local.location
-    resource_prefix = var.resource_prefix
-    key_vault_id = module.key_vault.application_key_vault_id
+  source = "../app_service_plan"
+  environment = var.environment
+  resource_group = var.resource_group
+  location = local.location
+  resource_prefix = var.resource_prefix
+  key_vault_id = module.key_vault.application_key_vault_id
 }
 
 module "function_app" {
-    source = "../function_app"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
-    app_service_plan_id = module.app_service_plan.app_service_plan_id
-    storage_account_name = module.storage.storage_account_name
-    storage_account_key = module.storage.storage_account_key
-    public_subnet_id = module.network.public_subnet_id
-    endpoint_subnet_id = module.network.endpoint_subnet_id
-    postgres_user = "${module.database.postgres_user}@${module.database.server_name}"
-    postgres_password = module.database.postgres_pass
-    postgres_url = "jdbc:postgresql://${module.database.server_name}.postgres.database.azure.com:5432/prime_data_hub?sslmode=require"
-    okta_redirect_url = var.okta_redirect_url
-    login_server = module.container_registry.login_server
-    admin_user = module.container_registry.admin_username
-    admin_password = module.container_registry.admin_password
-    ai_instrumentation_key = module.application_insights.instrumentation_key
-    eventhub_namespace_name = module.event_hub.eventhub_namespace_name
-    eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
-    app_config_key_vault_id = module.key_vault.app_config_key_vault_id
-    client_config_key_vault_id = module.key_vault.client_config_key_vault_id
-    storage_partner_connection_string = module.storage.storage_partner_connection_string
+  source = "../function_app"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
+  app_service_plan_id = module.app_service_plan.app_service_plan_id
+  storage_account_name = module.storage.storage_account_name
+  storage_account_key = module.storage.storage_account_key
+  public_subnet_id = module.network.public_subnet_id
+  endpoint_subnet_id = module.network.endpoint_subnet_id
+  postgres_user = "${module.database.postgres_user}@${module.database.server_name}"
+  postgres_password = module.database.postgres_pass
+  postgres_url = "jdbc:postgresql://${module.database.server_name}.postgres.database.azure.com:5432/prime_data_hub?sslmode=require"
+  okta_redirect_url = var.okta_redirect_url
+  login_server = module.container_registry.login_server
+  admin_user = module.container_registry.admin_username
+  admin_password = module.container_registry.admin_password
+  ai_instrumentation_key = module.application_insights.instrumentation_key
+  eventhub_namespace_name = module.event_hub.eventhub_namespace_name
+  eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+  app_config_key_vault_id = module.key_vault.app_config_key_vault_id
+  client_config_key_vault_id = module.key_vault.client_config_key_vault_id
+  storage_partner_connection_string = module.storage.storage_partner_connection_string
 }
 
 module "database" {
-    source = "../database"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    name = "${var.resource_prefix}-pgsql"
-    location = local.location
-    endpoint_subnet_id = module.network.endpoint_subnet_id
-    endpoint2_subnet_id = module.network.endpoint2_subnet_id
-    eventhub_namespace_name = module.event_hub.eventhub_namespace_name
-    eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
-    app_config_key_vault_id = module.key_vault.app_config_key_vault_id
-    key_vault_id = module.key_vault.application_key_vault_id
-    rsa_key_2048 = var.rsa_key_2048
+  source = "../database"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  name = "${var.resource_prefix}-pgsql"
+  location = local.location
+  endpoint_subnet_id = module.network.endpoint_subnet_id
+  endpoint2_subnet_id = module.network.endpoint2_subnet_id
+  eventhub_namespace_name = module.event_hub.eventhub_namespace_name
+  eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+  app_config_key_vault_id = module.key_vault.app_config_key_vault_id
+  key_vault_id = module.key_vault.application_key_vault_id
+  rsa_key_2048 = var.rsa_key_2048
+  is_metabase_env = var.is_metabase_env
 }
 
 module "key_vault" {
-    source = "../key_vault"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
-    endpoint_subnet_id = module.network.endpoint_subnet_id
+  source = "../key_vault"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
+  endpoint_subnet_id = module.network.endpoint_subnet_id
 }
 
 module "front_door" {
-    source = "../front_door"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    key_vault_id = module.key_vault.application_key_vault_id
-    eventhub_namespace_name = module.event_hub.eventhub_namespace_name
-    eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
-    https_cert_names = var.https_cert_names
-    storage_web_endpoint = module.storage.storage_web_endpoint
+  source = "../front_door"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  key_vault_id = module.key_vault.application_key_vault_id
+  eventhub_namespace_name = module.event_hub.eventhub_namespace_name
+  eventhub_manage_auth_rule_id = module.event_hub.manage_auth_rule_id
+  https_cert_names = var.https_cert_names
+  storage_web_endpoint = module.storage.storage_web_endpoint
+  is_metabase_env = var.is_metabase_env
 }
 
 module "sftp_container" {
-    count = (var.environment == "prod" ? 0 : 1)
-    source = "../sftp_container"
-    environment = var.environment
-    resource_group = var.resource_group
-    name = "${var.resource_prefix}-sftpserver"
-    location = local.location
-    container_subnet_id = module.network.container_subnet_id
-    storage_account_name = module.storage.storage_account_name
-    storage_account_key = module.storage.storage_account_key
+  count = (var.environment == "prod" ? 0 : 1)
+  source = "../sftp_container"
+  environment = var.environment
+  resource_group = var.resource_group
+  name = "${var.resource_prefix}-sftpserver"
+  location = local.location
+  container_subnet_id = module.network.container_subnet_id
+  storage_account_name = module.storage.storage_account_name
+  storage_account_key = module.storage.storage_account_key
 }
 
 module "metabase" {
-    count = (var.environment == "test" || var.environment == "prod" ? 1 : 0)
-    source = "../metabase"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    name = "${var.resource_prefix}-metabase"
-    location = local.location
-    app_service_plan_id = module.app_service_plan.app_service_plan_id
-    public_subnet_id = module.network.public_subnet_id
-    postgres_url = "postgresql://${module.database.server_name}.postgres.database.azure.com:5432/metabase?user=${module.database.postgres_user}@${module.database.server_name}&password=${module.database.postgres_pass}&sslmode=require&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"
-    ai_instrumentation_key = module.application_insights.instrumentation_key
+  count = var.is_metabase_env ? 1 : 0
+  source = "../metabase"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  name = "${var.resource_prefix}-metabase"
+  location = local.location
+  app_service_plan_id = module.app_service_plan.app_service_plan_id
+  public_subnet_id = module.network.public_subnet_id
+  postgres_url = "postgresql://${module.database.server_name}.postgres.database.azure.com:5432/metabase?user=${module.database.postgres_user}@${module.database.server_name}&password=${module.database.postgres_pass}&sslmode=require&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+  ai_instrumentation_key = module.application_insights.instrumentation_key
 }
 
 module "nat_gateway" {
-    source = "../nat_gateway"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
-    public_subnet_id = module.network.public_subnet_id
+  source = "../nat_gateway"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
+  public_subnet_id = module.network.public_subnet_id
 }
 
 module "application_insights" {
-    source = "../application_insights"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
-    key_vault_id = module.key_vault.application_key_vault_id
+  source = "../application_insights"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
+  key_vault_id = module.key_vault.application_key_vault_id
 }
 
 module "event_hub" {
-    source = "../event_hub"
-    environment = var.environment
-    resource_group = var.resource_group
-    resource_prefix = var.resource_prefix
-    location = local.location
-    endpoint_subnet_id = module.network.endpoint_subnet_id
+  source = "../event_hub"
+  environment = var.environment
+  resource_group = var.resource_group
+  resource_prefix = var.resource_prefix
+  location = local.location
+  endpoint_subnet_id = module.network.endpoint_subnet_id
 }

--- a/operations/app/src/modules/prime_data_hub/variables.tf
+++ b/operations/app/src/modules/prime_data_hub/variables.tf
@@ -32,3 +32,9 @@ variable "okta_redirect_url" {
     type = string
     description = "Okta Redirect URL"
 }
+
+variable "is_metabase_env" {
+    type = bool
+    description = "Should Metabase be deployed in this environment"
+    default = false
+}


### PR DESCRIPTION
This PR deploys Metabase to our staging environment, per request from @jimduff-usds.

## Changes
- Flips the switch to enable a Metabase deploy in staging.
- Refactors the Metabase deployment configuration so there is only one boolean that controls the entire Metabase deployment.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [x] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Security
- The initial deployment will leave Metabase in an un-configured state. We’ll need to quickly configure Metabase after deployment and add authentication.

## To Be Done
- Configure Metabase after deployment. Not sure what goes into this. Perhaps we can restore the production Metabase database into staging to preserve our configuration?
    - Due to the Palo Alto test, I don’t have a working Azure development environment, so I’m unable to experiment prior to deployment to staging.

