### PR TITLE
changes to support direct submission to ReportStream, etc

### DIFF
--- a/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
@@ -1,0 +1,1813 @@
+
+### Schema:         hhsprotect/hhsprotect-covid-19
+#### Description:   Schema for Submission to HHSProtect
+
+---
+
+**Name**: submitterId
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
+
+---
+
+**Name**: testId
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ReportStream copies value from the specimenId
+
+---
+
+**Name**: testOrdered
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Code
+
+**Documentation**:
+
+eg, 94531-1
+
+---
+
+**Name**: testName
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Long Name
+
+**Documentation**:
+
+Should be the name that matches to Test Ordered LOINC Long Name, in LIVD table
+
+---
+
+**Name**: testResult
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+eg, 260373001
+
+---
+
+**Name**: testCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Eg, "LN"
+
+---
+
+**Name**: testResultCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, SCT.   Custom
+
+---
+
+**Name**: testOrderedDate
+
+**Type**: DATE
+
+**PII**: No
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210108
+
+---
+
+**Name**: testResultDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210111
+
+---
+
+**Name**: testReportDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-22
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210112
+
+---
+
+**Name**: deviceIdentifier
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Testkit Name ID
+
+**Documentation**:
+
+Must match LIVD column M, "Test Kit Name ID"
+
+---
+
+**Name**: deviceName
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Model
+
+**Documentation**:
+
+Required.  Must match LIVD column B, "Model". eg,  "BD Veritor System for Rapid Detection of SARS-CoV-2 & Flu A+B"
+
+---
+
+**Name**: patientUniqueId
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patAge
+
+**Type**: NUMBER
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientRace
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: patientEthnicity
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $alt
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+
+**Alt Value Sets**
+
+Code | Display
+---- | -------
+H|2135-2
+N|2186-5
+U|UNK
+
+**Documentation**:
+
+Internally, ReportStream uses hl70189 (H,N,U), but should use HHS values. (2135-2, 2186-5, UNK, ASKU). A mapping is done here, but better is to switch all of RS to HHS standard.
+
+---
+
+**Name**: patientSex
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: patientCounty
+
+**Type**: TABLE_OR_BLANK
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: patientCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patientState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Extremely important field for routing data to states.
+
+---
+
+**Name**: patientHomeAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: patientHomeAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: patientEmail
+
+**Type**: EMAIL
+
+**PII**: Yes
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: patientNameLast
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Not required, but generally data will not flow to states if last/first name provided.
+
+---
+
+**Name**: patientNameFirst
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: patientNameMiddle
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimenSource
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: specimenId
+
+**Type**: EI
+
+**PII**: No
+
+**HL7 Fields**: SPM-2
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique id, such as a UUID. Note - Need to override the mapper in covid-19.schema file.
+
+---
+
+**Name**: serialNumber
+
+**Type**: ID
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Barcode or QR code.  Unique within one manufacturer.
+
+---
+
+**Name**: specimenDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210113
+
+---
+
+**Name**: firstTest
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: previousTestDate
+
+**Type**: DATE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: previousTestResult
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom field.  Example - 260415000
+
+---
+
+**Name**: previousTestType
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
+
+---
+
+**Name**: healthcareEmployee
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: healthcareEmployeeType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1421009|Specialized surgeon
+3430008|Radiation therapist
+3842006|Chiropractor
+4162009|Dental assistant
+5275007|NA - Nursing auxiliary
+6816002|Specialized nurse
+6868009|Hospital administrator
+8724009|Plastic surgeon
+11661002|Neuropathologist
+11911009|Nephrologist
+11935004|Obstetrician
+13580004|School dental assistant
+14698002|Medical microbiologist
+17561000|Cardiologist
+18803008|Dermatologist
+18850004|Laboratory hematologist
+19244007|Gerodontist
+20145008|Removable prosthodontist
+21365001|Specialized dentist
+21450003|Neuropsychiatrist
+22515006|Medical assistant
+22731001|Orthopedic surgeon
+22983004|Thoracic surgeon
+23278007|Community health physician
+24430003|Physical medicine specialist
+24590004|Urologist
+25961008|Electroencephalography specialist
+26042002|Dental hygienist
+26369006|Public health nurse
+28229004|Optometrist
+28411006|Neonatologist
+28544002|Chemical pathologist
+36682004|PT - Physiotherapist
+37154003|Periodontist
+37504001|Orthodontist
+39677007|Internal medicine specialist
+40127002|Dietitian (general)
+40204001|Hematologist
+40570005|Interpreter
+41672002|Respiratory physician
+41904004|Medical X-ray technician
+43702002|Occupational health nurse
+44652006|Pharmaceutical assistant
+45419001|Masseur
+45440000|Rheumatologist
+45544007|Neurosurgeon
+45956004|Sanitarian
+46255001|Pharmacist
+48740002|Philologist
+49203003|Dispensing optometrist
+49993003|Maxillofacial surgeon
+50149000|Endodontist
+54503009|Faith healer
+56397003|Neurologist
+56466003|Community physician
+56542007|Medical record administrator
+56545009|Cardiovascular surgeon
+57654006|Fixed prosthodontist
+59058001|General physician
+59169001|Orthopedic technician
+59944000|Psychologist
+60008001|Community-based dietitian
+61207006|Medical pathologist
+61246008|Laboratory medicine specialist
+61345009|Otorhinolaryngologist
+61894003|Endocrinologist
+62247001|Family medicine specialist
+63098009|Clinical immunologist
+66476003|Oral pathologist
+66862007|Radiologist
+68867008|Public health dentist
+68950000|Prosthodontist
+69280009|Specialized physician
+71838004|Gastroenterologist
+73265009|Nursing aid
+75271001|MW - Midwife
+76166008|Practical aid (pharmacy)
+76231001|Osteopath
+76899008|Infectious diseases physician
+78703002|General surgeon
+78729002|Diagnostic radiologist
+79898004|Auxiliary midwife
+80409005|Translator
+80546007|OT - Occupational therapist
+80584001|Psychiatrist
+80933006|Nuclear medicine physician
+81464008|Clinical pathologist
+82296001|Pediatrician
+83189004|Other professional nurse
+83273008|Anatomic pathologist
+83685006|Gynecologist
+85733003|General pathologist
+88189002|Anesthesiologist
+88475002|Other dietitians and public health nutritionists
+90201008|Pediatric dentist
+90655003|Care of the elderly physician
+106289002|Dental surgeon
+106291005|Dietician AND/OR public health nutritionist
+106292003|Nurse
+106293008|Nursing personnel
+106294002|Midwifery personnel
+106296000|Physiotherapist AND/OR occupational therapist
+106330007|Philologist, translator AND/OR interpreter
+112247003|Medical doctor
+158965000|Medical practitioner
+158966004|Medical administrator - national
+158967008|Consultant physician
+158968003|Consultant surgeon
+158969006|Consultant gynecology and obstetrics
+158970007|Anesthetist
+158971006|Hospital registrar
+158972004|House officer
+158973009|Occupational physician
+158974003|Clinical medical officer
+158975002|Medical practitioner - teaching
+158977005|Dental administrator
+158978000|Dental consultant
+158979008|Dental general practitioner
+158980006|Dental practitioner - teaching
+158983008|Nurse administrator - national
+158984002|Nursing officer - region
+158985001|Nursing officer - district
+158986000|Nursing administrator - professional body
+158987009|Nursing officer - division
+158988004|Nurse education director
+158989007|Occupational health nursing officer
+158990003|Nursing officer
+158992006|Midwifery sister
+158993001|Nursing sister (theatre)
+158994007|Staff nurse
+158995008|Staff midwife
+158996009|State enrolled nurse
+158997000|District nurse
+158998005|Private nurse
+158999002|Community midwife
+159001001|Clinic nurse
+159002008|Practice nurse
+159003003|School nurse
+159004009|Nurse - teaching
+159005005|Student nurse
+159006006|Dental nurse
+159007002|Community pediatric nurse
+159010009|Hospital pharmacist
+159011008|Retail pharmacist
+159012001|Industrial pharmacist
+159013006|Pharmaceutical officer H.A.
+159014000|Trainee pharmacist
+159016003|Medical radiographer
+159017007|Diagnostic radiographer
+159018002|Therapeutic radiographer
+159019005|Trainee radiographer
+159021000|Ophthalmic optician
+159022007|Trainee optician
+159025009|Remedial gymnast
+159026005|Speech and language therapist
+159027001|Orthoptist
+159028006|Trainee remedial therapist
+159033005|Dietician
+159034004|Podiatrist
+159035003|Dental auxiliary
+159036002|ECG technician
+159037006|EEG technician
+159038001|Artificial limb fitter
+159039009|AT - Audiology technician
+159040006|Pharmacy technician
+159041005|Trainee medical technician
+159141008|Geneticist
+159972006|Surgical corset fitter
+160008000|Dental technician
+224529009|Clinical assistant
+224530004|Senior registrar
+224531000|Registrar
+224532007|Senior house officer
+224533002|MO - Medical officer
+224534008|Health visitor, nurse/midwife
+224535009|Registered nurse
+224536005|Midwifery tutor
+224537001|Accident and Emergency nurse
+224538006|Triage nurse
+224540001|Community nurse
+224541002|Nursing continence advisor
+224542009|Coronary care nurse
+224543004|Diabetic nurse
+224544005|Family planning nurse
+224545006|Care of the elderly nurse
+224546007|ICN - Infection control nurse
+224547003|Intensive therapy nurse
+224548008|Learning disabilities nurse
+224549000|Neonatal nurse
+224550000|Neurology nurse
+224551001|Industrial nurse
+224552008|Oncology nurse
+224553003|Macmillan nurse
+224554009|Marie Curie nurse
+224555005|Pain control nurse
+224556006|Palliative care nurse
+224557002|Chemotherapy nurse
+224558007|Radiotherapy nurse
+224559004|PACU nurse
+224560009|Stomatherapist
+224561008|Theatre nurse
+224562001|Pediatric nurse
+224563006|Psychiatric nurse
+224564000|Community mental health nurse
+224565004|Renal nurse
+224566003|Hemodialysis nurse
+224567007|Wound care nurse
+224569005|Nurse grade
+224570006|Clinical nurse specialist
+224571005|Nurse practitioner
+224572003|Nursing sister
+224573008|CN - Charge nurse
+224574002|Ward manager
+224575001|Nursing team leader
+224576000|Nursing assistant
+224577009|Healthcare assistant
+224578004|Nursery nurse
+224579007|Healthcare service manager
+224580005|Occupational health service manager
+224581009|Community nurse manager
+224583007|Behavior therapist
+224584001|Behavior therapy assistant
+224585000|Drama therapist
+224586004|Domiciliary occupational therapist
+224587008|Occupational therapy helper
+224588003|Psychotherapist
+224589006|Community-based physiotherapist
+224590002|Play therapist
+224591003|Play specialist
+224592005|Play leader
+224593000|Community-based speech/language therapist
+224594006|Speech/language assistant
+224595007|Professional counselor
+224596008|Marriage guidance counselor
+224597004|Trained nurse counselor
+224598009|Trained social worker counselor
+224599001|Trained personnel counselor
+224600003|Psychoanalyst
+224601004|Assistant psychologist
+224602006|Community-based podiatrist
+224603001|Foot care worker
+224604007|Audiometrician
+224605008|Audiometrist
+224606009|Technical healthcare occupation
+224607000|Occupational therapy technical instructor
+224608005|Administrative healthcare staff
+224609002|Complementary health worker
+224610007|Supporting services personnel
+224614003|Research associate
+224615002|Research nurse
+224620002|Human aid to communication
+224621003|Palantypist
+224622005|Note taker
+224623000|Cuer
+224624006|Lipspeaker
+224625007|Interpreter for British sign language
+224626008|Interpreter for Signs supporting English
+224936003|General practitioner locum
+225726006|Lactation consultant
+225727002|Midwife counselor
+265937000|Nursing occupation
+265939002|Medical/dental technicians
+283875005|Parkinson disease nurse
+302211009|Specialist registrar
+303124005|Member of mental health review tribunal
+303129000|Hospital manager
+303133007|Responsible medical officer
+303134001|Independent doctor
+304291006|Bereavement counselor
+304292004|Surgeon
+307988006|Medical technician
+308002005|Remedial therapist
+309294001|Accident and Emergency doctor
+309295000|Clinical oncologist
+309296004|Family planning doctor
+309322005|Associate general practitioner
+309323000|Partner of general practitioner
+309324006|Assistant GP
+309326008|Deputizing general practitioner
+309327004|General practitioner registrar
+309328009|Ambulatory pediatrician
+309329001|Community pediatrician
+309330006|Pediatric cardiologist
+309331005|Pediatric endocrinologist
+309332003|Pediatric gastroenterologist
+309333008|Pediatric nephrologist
+309334002|Pediatric neurologist
+309335001|Pediatric rheumatologist
+309336000|Pediatric oncologist
+309337009|Pain management specialist
+309338004|Intensive care specialist
+309339007|Adult intensive care specialist
+309340009|Pediatric intensive care specialist
+309341008|Blood transfusion doctor
+309342001|Histopathologist
+309343006|Physician
+309345004|Chest physician
+309346003|Thoracic physician
+309347007|Clinical hematologist
+309348002|Clinical neurophysiologist
+309349005|Clinical physiologist
+309350005|Diabetologist
+309351009|Andrologist
+309352002|Neuroendocrinologist
+309353007|Reproductive endocrinologist
+309354001|Thyroidologist
+309355000|Clinical geneticist
+309356004|Clinical cytogeneticist
+309357008|Clinical molecular geneticist
+309358003|Genitourinary medicine physician
+309359006|Palliative care physician
+309360001|Rehabilitation physician
+309361002|Child and adolescent psychiatrist
+309362009|Forensic psychiatrist
+309363004|Liaison psychiatrist
+309364005|Psychogeriatrician
+309365006|Psychiatrist for mental handicap
+309366007|Rehabilitation psychiatrist
+309367003|Obstetrician and gynecologist
+309368008|Breast surgeon
+309369000|Cardiothoracic surgeon
+309371000|Cardiac surgeon
+309372007|Ear, nose and throat surgeon
+309373002|Endocrine surgeon
+309374008|Thyroid surgeon
+309375009|Pituitary surgeon
+309376005|Gastrointestinal surgeon
+309377001|General gastrointestinal surgeon
+309378006|Upper gastrointestinal surgeon
+309379003|Colorectal surgeon
+309380000|Hand surgeon
+309381001|Hepatobiliary surgeon
+309382008|Ophthalmic surgeon
+309383003|Pediatric surgeon
+309384009|Pancreatic surgeon
+309385005|Transplant surgeon
+309386006|Trauma surgeon
+309388007|Vascular surgeon
+309389004|Medical practitioner grade
+309390008|Hospital consultant
+309391007|Visiting specialist registrar
+309392000|Research registrar
+309393005|General practitioner grade
+309394004|General practitioner principal
+309395003|Hospital specialist
+309396002|Associate specialist
+309397006|Research fellow
+309398001|Allied health professional
+309399009|Hospital dietitian
+309400002|Domiciliary physiotherapist
+309401003|General practitioner-based physiotherapist
+309402005|Hospital-based physiotherapist
+309403000|Private physiotherapist
+309404006|Physiotherapy assistant
+309409001|Hospital-based speech and language therapist
+309410006|Arts therapist
+309411005|Dance therapist
+309412003|Music therapist
+309413008|Renal dietitian
+309414002|Liver dietitian
+309415001|Oncology dietitian
+309416000|Pediatric dietitian
+309417009|Diabetes dietitian
+309418004|Audiologist
+309419007|Hearing therapist
+309420001|Audiological scientist
+309421002|Hearing aid dispenser
+309422009|Community-based occupational therapist
+309423004|Hospital occupational therapist
+309427003|Social services occupational therapist
+309428008|Orthotist
+309429000|Surgical fitter
+309434001|Hospital-based podiatrist
+309435000|Podiatry assistant
+309436004|Lymphedema nurse
+309437008|Community learning disabilities nurse
+309439006|Clinical nurse teacher
+309440008|Community practice nurse teacher
+309441007|Nurse tutor
+309442000|Nurse teacher practitioner
+309443005|Nurse lecturer practitioner
+309444004|Outreach nurse
+309445003|Anesthetic nurse
+309446002|Nurse manager
+309450009|Nurse administrator
+309452001|Midwifery grade
+309453006|Midwife
+309454000|Student midwife
+309455004|Parentcraft sister
+309459005|Healthcare professional grade
+309460000|Restorative dentist
+310170009|Pediatric audiologist
+310171008|Immunopathologist
+310172001|Audiological physician
+310173006|Clinical pharmacologist
+310174000|Private doctor
+310175004|Agency nurse
+310176003|Behavioral therapist nurse
+310177007|Cardiac rehabilitation nurse
+310178002|Genitourinary nurse
+310179005|Rheumatology nurse specialist
+310180008|Continence nurse
+310181007|Contact tracing nurse
+310182000|General nurse
+310183005|Nurse for the mentally handicapped
+310184004|Liaison nurse
+310185003|Diabetic liaison nurse
+310186002|Nurse psychotherapist
+310187006|Company nurse
+310188001|Hospital midwife
+310189009|Genetic counselor
+310190000|Mental health counselor
+310191001|Clinical psychologist
+310192008|Educational psychologist
+310193003|Coroner
+310194009|Appliance officer
+310512001|Medical oncologist
+311441001|School medical officer
+312485001|Integrated midwife
+372102007|RN First Assist
+387619007|Optician
+394572006|Medical secretary
+394618009|Hospital nurse
+397824005|Consultant anesthetist
+397897005|Paramedic
+397903001|Staff grade obstetrician
+397908005|Staff grade practitioner
+398130009|Medical student
+398238009|Acting obstetric registrar
+404940000|Physiotherapist technical instructor
+405277009|Resident physician
+405278004|Certified registered nurse anesthetist
+405279007|Attending physician
+405623001|Assigned practitioner
+405684005|Professional initiating surgical case
+405685006|Professional providing staff relief during surgical procedure
+408798009|Consultant pediatrician
+408799001|Consultant neonatologist
+409974004|Health educator
+409975003|Certified health education specialist
+413854007|Circulating nurse
+415075003|Perioperative nurse
+415506007|Scrub nurse
+416160000|Fellow of American Academy of Osteopathy
+420409002|Oculoplastic surgeon
+420678001|Retinal surgeon
+421841007|Admitting physician
+422140007|Medical ophthalmologist
+422234006|Ophthalmologist
+432100008|Health coach
+442867008|Respiratory therapist
+443090005|Podiatric surgeon
+444912007|Hypnotherapist
+445313000|Asthma nurse specialist
+445451001|Nurse case manager
+446050000|PCP - Primary care physician
+446701002|Addiction medicine specialist
+449161006|PA - physician assistant
+471302004|Government midwife
+3981000175106|Nurse complex case manager
+231189271000087109|Naturopath
+236749831000087105|Prosthetist
+258508741000087105|Hip and knee surgeon
+260767431000087107|Hepatologist
+285631911000087106|Shoulder surgeon
+291705421000087106|Interventional radiologist
+341320851000087105|Pediatric radiologist
+368890881000087105|Emergency medicine specialist
+398480381000087106|Family medicine specialist - palliative care
+416186861000087101|Surgical oncologist
+450044741000087104|Acupuncturist
+465511991000087105|Pediatric orthopedic surgeon
+494782281000087101|Pediatric hematologist
+619197631000087102|Neuroradiologist
+623630151000087105|Family medicine specialist - anesthetist
+666997781000087107|Doula
+673825031000087109|Traditional herbal medicine specialist
+682131381000087105|Occupational medicine specialist
+724111801000087104|Pediatric emergency medicine specialist
+747936471000087102|Family medicine specialist - care of the elderly
+766788081000087100|Travel medicine specialist
+767205061000087108|Spine surgeon
+813758161000087106|Maternal or fetal medicine specialist
+822410621000087104|Massage therapist
+847240411000087102|Hospitalist
+853827051000087104|Sports medicine specialist
+926871431000087103|Pediatric respirologist
+954544641000087107|Homeopath
+956387501000087102|Family medicine specialist - emergency medicine
+969118571000087109|Pediatric hematologist or oncologist
+984095901000087105|Foot and ankle surgeon
+990928611000087105|Invasive cardiologist
+999480451000087102|Case manager
+999480461000087104|Kinesthesiologist
+
+**Documentation**:
+
+Custom.  eg, 6816002
+
+---
+
+**Name**: hospitalized
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: hospitalizedCode
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom.  eg, 840539006, same valueset as testResult
+
+---
+
+**Name**: symptomatic
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: symptomsList
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptomCode2^date2; ...
+
+---
+
+**Name**: symptomsIcu
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95420-6
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResident
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResidentType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+22232009|Hospital
+32074000|Long Term Care Hospital
+224929004|Secure Hospital
+42665001|Nursing Home
+30629002|Retirement Home
+74056004|Orphanage
+722173008|Prison-based care site
+20078004|Substance Abuse Treatment Center
+257573002|Boarding House
+224683003|Military Accommodation
+284546000|Hospice
+257628001|Hostel
+310207003|Sheltered Housing
+57656006|Penal Institution
+32911000|Homeless
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: pregnant
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+77386006|Pregnant
+60001007|Not Pregnant
+261665006|Unknown
+
+**Documentation**:
+
+Is the patient pregnant?
+
+---
+
+**Name**: orderingProviderNpi
+
+**Type**: ID_NPI
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "1265050918"
+
+---
+
+**Name**: orderingProviderLname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: orderingProviderFname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: orderingProviderZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: orderingProviderAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: orderingProviderAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: orderingProviderCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: orderingProviderState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: orderingProviderPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: performingFacility
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+Expecting a CLIA number here.  eg, "10D2218834"
+
+---
+
+**Name**: reportingFacility
+
+**Type**: HD
+
+**PII**: No
+
+**HL7 Field**: MSH-4
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Expecting an ISO heirarchic designator here. eg, "1265050918" (same value as in ordering_provider_npi).  Note that reporting_facility_text is also available as a field, if a name is needed.
+
+---
+
+**Name**: facilityZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: testPerformed
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+eg, 94558-4
+
+---
+
+**Name**: orderingFacilityState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Note that many states expect this field to be available, or ReportStream is not able rto route data to them.  Please provide if possible in order for us to route to as many states as possible.
+
+---
+
+**Name**: test_result_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "DETECTED".  Custom.  ReportStream uses testResult code, not this text value.
+
+---
+
+**Name**: patient_dob
+
+**Type**: DATE
+
+**PII**: Yes
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: patient_race_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.    ReportStream uses patientRace code, not this text value.
+
+---
+
+**Name**: patient_ethnicity_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. ReportStream uses the patientEthnicity code, not this text value.
+
+---
+
+**Name**: patient_id
+
+**Type**: TEXT
+
+**PII**: Yes
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patient_phone_number_area_code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. Not currently used. ReportStream assumes area code is in patientPhone
+
+---
+
+**Name**: ordering_provider_phone_number_area_code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Not currently used. ReportStream assumes area code is in orderingProviderPhone
+
+---
+
+**Name**: pregnant_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  ReportStream uses the 'pregnant' code, not this text value.
+
+---

--- a/prime-router/docs/schema_documentation/waters-cue-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-cue-covid-19.md
@@ -1,0 +1,1815 @@
+
+### Schema:         waters/cue-covid-19
+#### Description:   Cue
+
+---
+
+**Name**: senderId
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
+
+---
+
+**Name**: testOrdered
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Code
+
+**Documentation**:
+
+eg, 94531-1
+
+---
+
+**Name**: testName
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Long Name
+
+**Documentation**:
+
+Should be the name that matches to Test Ordered LOINC Long Name, in LIVD table
+
+---
+
+**Name**: testCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Eg, "LN"
+
+---
+
+**Name**: testResult
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+eg, 260373001
+
+---
+
+**Name**: testResultText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "DETECTED".  Custom.  ReportStream uses testResult code, not this text value.
+
+---
+
+**Name**: testPerformed
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+eg, 94558-4
+
+---
+
+**Name**: testResultCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, SCT.   Custom
+
+---
+
+**Name**: testResultDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210111
+
+---
+
+**Name**: testReportDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-22
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210112
+
+---
+
+**Name**: testOrderedDate
+
+**Type**: DATE
+
+**PII**: No
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210108
+
+---
+
+**Name**: specimenCollectedDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210113
+
+---
+
+**Name**: deviceIdentifier
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Testkit Name ID
+
+**Documentation**:
+
+Must match LIVD column M, "Test Kit Name ID"
+
+---
+
+**Name**: deviceName
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Model
+
+**Documentation**:
+
+Required.  Must match LIVD column B, "Model". eg,  "BD Veritor System for Rapid Detection of SARS-CoV-2 & Flu A+B"
+
+---
+
+**Name**: specimenId
+
+**Type**: EI
+
+**PII**: No
+
+**HL7 Fields**: SPM-2
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique id, such as a UUID. Note - Need to override the mapper in covid-19.schema file.
+
+---
+
+**Name**: serialNumber
+
+**Type**: ID
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Barcode or QR code.  Unique within one manufacturer.
+
+---
+
+**Name**: message_id
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ReportStream copies value from the specimenId
+
+---
+
+**Name**: patientAge
+
+**Type**: NUMBER
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientDob
+
+**Type**: DATE
+
+**PII**: Yes
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: patientRace
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: patientRaceText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.    ReportStream uses patientRace code, not this text value.
+
+---
+
+**Name**: patientEthnicity
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $alt
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+U|Unknown
+
+**Alt Value Sets**
+
+Code | Display
+---- | -------
+H|2135-2
+N|2186-5
+U|UNK
+U|ASKU
+
+**Documentation**:
+
+Internally, ReportStream uses hl70189 (H,N,U), but should use HHS values. (2135-2, 2186-5, UNK, ASKU). A mapping is done here, but better is to switch all of RS to HHS standard.
+
+---
+
+**Name**: patientEthnicityText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. ReportStream uses the patientEthnicity code, not this text value.
+
+---
+
+**Name**: patientSex
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patientZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: patientCounty
+
+**Type**: TABLE_OR_BLANK
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: orderingProviderNpi
+
+**Type**: ID_NPI
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "1265050918"
+
+---
+
+**Name**: orderingProviderLname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: orderingProviderFname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: orderingProviderZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: performingFacility
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+Expecting a CLIA number here.  eg, "10D2218834"
+
+---
+
+**Name**: performingFacilityZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimenSource
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: patientNameLast
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Not required, but generally data will not flow to states if last/first name provided.
+
+---
+
+**Name**: patientNameFirst
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: patientNameMiddle
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientUniqueId
+
+**Type**: TEXT
+
+**PII**: Yes
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientUniqueIdHash
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientHomeAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: patientHomeAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: patientCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patientState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Extremely important field for routing data to states.
+
+---
+
+**Name**: patientPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: patientPhoneArea
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. Not currently used. ReportStream assumes area code is in patientPhone
+
+---
+
+**Name**: orderingProviderAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: orderingProviderAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: orderingProviderCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: orderingProviderState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: orderingProviderPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: orderingProviderPhoneArea
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Not currently used. ReportStream assumes area code is in orderingProviderPhone
+
+---
+
+**Name**: firstTest
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: previousTestType
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
+
+---
+
+**Name**: previousTestDate
+
+**Type**: DATE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: previousTestResult
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom field.  Example - 260415000
+
+---
+
+**Name**: healthcareEmployee
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: healthcareEmployeeType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1421009|Specialized surgeon
+3430008|Radiation therapist
+3842006|Chiropractor
+4162009|Dental assistant
+5275007|NA - Nursing auxiliary
+6816002|Specialized nurse
+6868009|Hospital administrator
+8724009|Plastic surgeon
+11661002|Neuropathologist
+11911009|Nephrologist
+11935004|Obstetrician
+13580004|School dental assistant
+14698002|Medical microbiologist
+17561000|Cardiologist
+18803008|Dermatologist
+18850004|Laboratory hematologist
+19244007|Gerodontist
+20145008|Removable prosthodontist
+21365001|Specialized dentist
+21450003|Neuropsychiatrist
+22515006|Medical assistant
+22731001|Orthopedic surgeon
+22983004|Thoracic surgeon
+23278007|Community health physician
+24430003|Physical medicine specialist
+24590004|Urologist
+25961008|Electroencephalography specialist
+26042002|Dental hygienist
+26369006|Public health nurse
+28229004|Optometrist
+28411006|Neonatologist
+28544002|Chemical pathologist
+36682004|PT - Physiotherapist
+37154003|Periodontist
+37504001|Orthodontist
+39677007|Internal medicine specialist
+40127002|Dietitian (general)
+40204001|Hematologist
+40570005|Interpreter
+41672002|Respiratory physician
+41904004|Medical X-ray technician
+43702002|Occupational health nurse
+44652006|Pharmaceutical assistant
+45419001|Masseur
+45440000|Rheumatologist
+45544007|Neurosurgeon
+45956004|Sanitarian
+46255001|Pharmacist
+48740002|Philologist
+49203003|Dispensing optometrist
+49993003|Maxillofacial surgeon
+50149000|Endodontist
+54503009|Faith healer
+56397003|Neurologist
+56466003|Community physician
+56542007|Medical record administrator
+56545009|Cardiovascular surgeon
+57654006|Fixed prosthodontist
+59058001|General physician
+59169001|Orthopedic technician
+59944000|Psychologist
+60008001|Community-based dietitian
+61207006|Medical pathologist
+61246008|Laboratory medicine specialist
+61345009|Otorhinolaryngologist
+61894003|Endocrinologist
+62247001|Family medicine specialist
+63098009|Clinical immunologist
+66476003|Oral pathologist
+66862007|Radiologist
+68867008|Public health dentist
+68950000|Prosthodontist
+69280009|Specialized physician
+71838004|Gastroenterologist
+73265009|Nursing aid
+75271001|MW - Midwife
+76166008|Practical aid (pharmacy)
+76231001|Osteopath
+76899008|Infectious diseases physician
+78703002|General surgeon
+78729002|Diagnostic radiologist
+79898004|Auxiliary midwife
+80409005|Translator
+80546007|OT - Occupational therapist
+80584001|Psychiatrist
+80933006|Nuclear medicine physician
+81464008|Clinical pathologist
+82296001|Pediatrician
+83189004|Other professional nurse
+83273008|Anatomic pathologist
+83685006|Gynecologist
+85733003|General pathologist
+88189002|Anesthesiologist
+88475002|Other dietitians and public health nutritionists
+90201008|Pediatric dentist
+90655003|Care of the elderly physician
+106289002|Dental surgeon
+106291005|Dietician AND/OR public health nutritionist
+106292003|Nurse
+106293008|Nursing personnel
+106294002|Midwifery personnel
+106296000|Physiotherapist AND/OR occupational therapist
+106330007|Philologist, translator AND/OR interpreter
+112247003|Medical doctor
+158965000|Medical practitioner
+158966004|Medical administrator - national
+158967008|Consultant physician
+158968003|Consultant surgeon
+158969006|Consultant gynecology and obstetrics
+158970007|Anesthetist
+158971006|Hospital registrar
+158972004|House officer
+158973009|Occupational physician
+158974003|Clinical medical officer
+158975002|Medical practitioner - teaching
+158977005|Dental administrator
+158978000|Dental consultant
+158979008|Dental general practitioner
+158980006|Dental practitioner - teaching
+158983008|Nurse administrator - national
+158984002|Nursing officer - region
+158985001|Nursing officer - district
+158986000|Nursing administrator - professional body
+158987009|Nursing officer - division
+158988004|Nurse education director
+158989007|Occupational health nursing officer
+158990003|Nursing officer
+158992006|Midwifery sister
+158993001|Nursing sister (theatre)
+158994007|Staff nurse
+158995008|Staff midwife
+158996009|State enrolled nurse
+158997000|District nurse
+158998005|Private nurse
+158999002|Community midwife
+159001001|Clinic nurse
+159002008|Practice nurse
+159003003|School nurse
+159004009|Nurse - teaching
+159005005|Student nurse
+159006006|Dental nurse
+159007002|Community pediatric nurse
+159010009|Hospital pharmacist
+159011008|Retail pharmacist
+159012001|Industrial pharmacist
+159013006|Pharmaceutical officer H.A.
+159014000|Trainee pharmacist
+159016003|Medical radiographer
+159017007|Diagnostic radiographer
+159018002|Therapeutic radiographer
+159019005|Trainee radiographer
+159021000|Ophthalmic optician
+159022007|Trainee optician
+159025009|Remedial gymnast
+159026005|Speech and language therapist
+159027001|Orthoptist
+159028006|Trainee remedial therapist
+159033005|Dietician
+159034004|Podiatrist
+159035003|Dental auxiliary
+159036002|ECG technician
+159037006|EEG technician
+159038001|Artificial limb fitter
+159039009|AT - Audiology technician
+159040006|Pharmacy technician
+159041005|Trainee medical technician
+159141008|Geneticist
+159972006|Surgical corset fitter
+160008000|Dental technician
+224529009|Clinical assistant
+224530004|Senior registrar
+224531000|Registrar
+224532007|Senior house officer
+224533002|MO - Medical officer
+224534008|Health visitor, nurse/midwife
+224535009|Registered nurse
+224536005|Midwifery tutor
+224537001|Accident and Emergency nurse
+224538006|Triage nurse
+224540001|Community nurse
+224541002|Nursing continence advisor
+224542009|Coronary care nurse
+224543004|Diabetic nurse
+224544005|Family planning nurse
+224545006|Care of the elderly nurse
+224546007|ICN - Infection control nurse
+224547003|Intensive therapy nurse
+224548008|Learning disabilities nurse
+224549000|Neonatal nurse
+224550000|Neurology nurse
+224551001|Industrial nurse
+224552008|Oncology nurse
+224553003|Macmillan nurse
+224554009|Marie Curie nurse
+224555005|Pain control nurse
+224556006|Palliative care nurse
+224557002|Chemotherapy nurse
+224558007|Radiotherapy nurse
+224559004|PACU nurse
+224560009|Stomatherapist
+224561008|Theatre nurse
+224562001|Pediatric nurse
+224563006|Psychiatric nurse
+224564000|Community mental health nurse
+224565004|Renal nurse
+224566003|Hemodialysis nurse
+224567007|Wound care nurse
+224569005|Nurse grade
+224570006|Clinical nurse specialist
+224571005|Nurse practitioner
+224572003|Nursing sister
+224573008|CN - Charge nurse
+224574002|Ward manager
+224575001|Nursing team leader
+224576000|Nursing assistant
+224577009|Healthcare assistant
+224578004|Nursery nurse
+224579007|Healthcare service manager
+224580005|Occupational health service manager
+224581009|Community nurse manager
+224583007|Behavior therapist
+224584001|Behavior therapy assistant
+224585000|Drama therapist
+224586004|Domiciliary occupational therapist
+224587008|Occupational therapy helper
+224588003|Psychotherapist
+224589006|Community-based physiotherapist
+224590002|Play therapist
+224591003|Play specialist
+224592005|Play leader
+224593000|Community-based speech/language therapist
+224594006|Speech/language assistant
+224595007|Professional counselor
+224596008|Marriage guidance counselor
+224597004|Trained nurse counselor
+224598009|Trained social worker counselor
+224599001|Trained personnel counselor
+224600003|Psychoanalyst
+224601004|Assistant psychologist
+224602006|Community-based podiatrist
+224603001|Foot care worker
+224604007|Audiometrician
+224605008|Audiometrist
+224606009|Technical healthcare occupation
+224607000|Occupational therapy technical instructor
+224608005|Administrative healthcare staff
+224609002|Complementary health worker
+224610007|Supporting services personnel
+224614003|Research associate
+224615002|Research nurse
+224620002|Human aid to communication
+224621003|Palantypist
+224622005|Note taker
+224623000|Cuer
+224624006|Lipspeaker
+224625007|Interpreter for British sign language
+224626008|Interpreter for Signs supporting English
+224936003|General practitioner locum
+225726006|Lactation consultant
+225727002|Midwife counselor
+265937000|Nursing occupation
+265939002|Medical/dental technicians
+283875005|Parkinson disease nurse
+302211009|Specialist registrar
+303124005|Member of mental health review tribunal
+303129000|Hospital manager
+303133007|Responsible medical officer
+303134001|Independent doctor
+304291006|Bereavement counselor
+304292004|Surgeon
+307988006|Medical technician
+308002005|Remedial therapist
+309294001|Accident and Emergency doctor
+309295000|Clinical oncologist
+309296004|Family planning doctor
+309322005|Associate general practitioner
+309323000|Partner of general practitioner
+309324006|Assistant GP
+309326008|Deputizing general practitioner
+309327004|General practitioner registrar
+309328009|Ambulatory pediatrician
+309329001|Community pediatrician
+309330006|Pediatric cardiologist
+309331005|Pediatric endocrinologist
+309332003|Pediatric gastroenterologist
+309333008|Pediatric nephrologist
+309334002|Pediatric neurologist
+309335001|Pediatric rheumatologist
+309336000|Pediatric oncologist
+309337009|Pain management specialist
+309338004|Intensive care specialist
+309339007|Adult intensive care specialist
+309340009|Pediatric intensive care specialist
+309341008|Blood transfusion doctor
+309342001|Histopathologist
+309343006|Physician
+309345004|Chest physician
+309346003|Thoracic physician
+309347007|Clinical hematologist
+309348002|Clinical neurophysiologist
+309349005|Clinical physiologist
+309350005|Diabetologist
+309351009|Andrologist
+309352002|Neuroendocrinologist
+309353007|Reproductive endocrinologist
+309354001|Thyroidologist
+309355000|Clinical geneticist
+309356004|Clinical cytogeneticist
+309357008|Clinical molecular geneticist
+309358003|Genitourinary medicine physician
+309359006|Palliative care physician
+309360001|Rehabilitation physician
+309361002|Child and adolescent psychiatrist
+309362009|Forensic psychiatrist
+309363004|Liaison psychiatrist
+309364005|Psychogeriatrician
+309365006|Psychiatrist for mental handicap
+309366007|Rehabilitation psychiatrist
+309367003|Obstetrician and gynecologist
+309368008|Breast surgeon
+309369000|Cardiothoracic surgeon
+309371000|Cardiac surgeon
+309372007|Ear, nose and throat surgeon
+309373002|Endocrine surgeon
+309374008|Thyroid surgeon
+309375009|Pituitary surgeon
+309376005|Gastrointestinal surgeon
+309377001|General gastrointestinal surgeon
+309378006|Upper gastrointestinal surgeon
+309379003|Colorectal surgeon
+309380000|Hand surgeon
+309381001|Hepatobiliary surgeon
+309382008|Ophthalmic surgeon
+309383003|Pediatric surgeon
+309384009|Pancreatic surgeon
+309385005|Transplant surgeon
+309386006|Trauma surgeon
+309388007|Vascular surgeon
+309389004|Medical practitioner grade
+309390008|Hospital consultant
+309391007|Visiting specialist registrar
+309392000|Research registrar
+309393005|General practitioner grade
+309394004|General practitioner principal
+309395003|Hospital specialist
+309396002|Associate specialist
+309397006|Research fellow
+309398001|Allied health professional
+309399009|Hospital dietitian
+309400002|Domiciliary physiotherapist
+309401003|General practitioner-based physiotherapist
+309402005|Hospital-based physiotherapist
+309403000|Private physiotherapist
+309404006|Physiotherapy assistant
+309409001|Hospital-based speech and language therapist
+309410006|Arts therapist
+309411005|Dance therapist
+309412003|Music therapist
+309413008|Renal dietitian
+309414002|Liver dietitian
+309415001|Oncology dietitian
+309416000|Pediatric dietitian
+309417009|Diabetes dietitian
+309418004|Audiologist
+309419007|Hearing therapist
+309420001|Audiological scientist
+309421002|Hearing aid dispenser
+309422009|Community-based occupational therapist
+309423004|Hospital occupational therapist
+309427003|Social services occupational therapist
+309428008|Orthotist
+309429000|Surgical fitter
+309434001|Hospital-based podiatrist
+309435000|Podiatry assistant
+309436004|Lymphedema nurse
+309437008|Community learning disabilities nurse
+309439006|Clinical nurse teacher
+309440008|Community practice nurse teacher
+309441007|Nurse tutor
+309442000|Nurse teacher practitioner
+309443005|Nurse lecturer practitioner
+309444004|Outreach nurse
+309445003|Anesthetic nurse
+309446002|Nurse manager
+309450009|Nurse administrator
+309452001|Midwifery grade
+309453006|Midwife
+309454000|Student midwife
+309455004|Parentcraft sister
+309459005|Healthcare professional grade
+309460000|Restorative dentist
+310170009|Pediatric audiologist
+310171008|Immunopathologist
+310172001|Audiological physician
+310173006|Clinical pharmacologist
+310174000|Private doctor
+310175004|Agency nurse
+310176003|Behavioral therapist nurse
+310177007|Cardiac rehabilitation nurse
+310178002|Genitourinary nurse
+310179005|Rheumatology nurse specialist
+310180008|Continence nurse
+310181007|Contact tracing nurse
+310182000|General nurse
+310183005|Nurse for the mentally handicapped
+310184004|Liaison nurse
+310185003|Diabetic liaison nurse
+310186002|Nurse psychotherapist
+310187006|Company nurse
+310188001|Hospital midwife
+310189009|Genetic counselor
+310190000|Mental health counselor
+310191001|Clinical psychologist
+310192008|Educational psychologist
+310193003|Coroner
+310194009|Appliance officer
+310512001|Medical oncologist
+311441001|School medical officer
+312485001|Integrated midwife
+372102007|RN First Assist
+387619007|Optician
+394572006|Medical secretary
+394618009|Hospital nurse
+397824005|Consultant anesthetist
+397897005|Paramedic
+397903001|Staff grade obstetrician
+397908005|Staff grade practitioner
+398130009|Medical student
+398238009|Acting obstetric registrar
+404940000|Physiotherapist technical instructor
+405277009|Resident physician
+405278004|Certified registered nurse anesthetist
+405279007|Attending physician
+405623001|Assigned practitioner
+405684005|Professional initiating surgical case
+405685006|Professional providing staff relief during surgical procedure
+408798009|Consultant pediatrician
+408799001|Consultant neonatologist
+409974004|Health educator
+409975003|Certified health education specialist
+413854007|Circulating nurse
+415075003|Perioperative nurse
+415506007|Scrub nurse
+416160000|Fellow of American Academy of Osteopathy
+420409002|Oculoplastic surgeon
+420678001|Retinal surgeon
+421841007|Admitting physician
+422140007|Medical ophthalmologist
+422234006|Ophthalmologist
+432100008|Health coach
+442867008|Respiratory therapist
+443090005|Podiatric surgeon
+444912007|Hypnotherapist
+445313000|Asthma nurse specialist
+445451001|Nurse case manager
+446050000|PCP - Primary care physician
+446701002|Addiction medicine specialist
+449161006|PA - physician assistant
+471302004|Government midwife
+3981000175106|Nurse complex case manager
+231189271000087109|Naturopath
+236749831000087105|Prosthetist
+258508741000087105|Hip and knee surgeon
+260767431000087107|Hepatologist
+285631911000087106|Shoulder surgeon
+291705421000087106|Interventional radiologist
+341320851000087105|Pediatric radiologist
+368890881000087105|Emergency medicine specialist
+398480381000087106|Family medicine specialist - palliative care
+416186861000087101|Surgical oncologist
+450044741000087104|Acupuncturist
+465511991000087105|Pediatric orthopedic surgeon
+494782281000087101|Pediatric hematologist
+619197631000087102|Neuroradiologist
+623630151000087105|Family medicine specialist - anesthetist
+666997781000087107|Doula
+673825031000087109|Traditional herbal medicine specialist
+682131381000087105|Occupational medicine specialist
+724111801000087104|Pediatric emergency medicine specialist
+747936471000087102|Family medicine specialist - care of the elderly
+766788081000087100|Travel medicine specialist
+767205061000087108|Spine surgeon
+813758161000087106|Maternal or fetal medicine specialist
+822410621000087104|Massage therapist
+847240411000087102|Hospitalist
+853827051000087104|Sports medicine specialist
+926871431000087103|Pediatric respirologist
+954544641000087107|Homeopath
+956387501000087102|Family medicine specialist - emergency medicine
+969118571000087109|Pediatric hematologist or oncologist
+984095901000087105|Foot and ankle surgeon
+990928611000087105|Invasive cardiologist
+999480451000087102|Case manager
+999480461000087104|Kinesthesiologist
+
+**Documentation**:
+
+Custom.  eg, 6816002
+
+---
+
+**Name**: symptomatic
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: symptomsList
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptomCode2^date2; ...
+
+---
+
+**Name**: hospitalized
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: hospitalizedCode
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom.  eg, 840539006, same valueset as testResult
+
+---
+
+**Name**: symptomsIcu
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95420-6
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResident
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResidentType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+22232009|Hospital
+32074000|Long Term Care Hospital
+224929004|Secure Hospital
+42665001|Nursing Home
+30629002|Retirement Home
+74056004|Orphanage
+722173008|Prison-based care site
+20078004|Substance Abuse Treatment Center
+257573002|Boarding House
+224683003|Military Accommodation
+284546000|Hospice
+257628001|Hostel
+310207003|Sheltered Housing
+57656006|Penal Institution
+32911000|Homeless
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: pregnant
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+77386006|Pregnant
+60001007|Not Pregnant
+261665006|Unknown
+
+**Documentation**:
+
+Is the patient pregnant?
+
+---
+
+**Name**: pregnantText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  ReportStream uses the 'pregnant' code, not this text value.
+
+---
+
+**Name**: patientEmail
+
+**Type**: EMAIL
+
+**PII**: Yes
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: reportingFacility
+
+**Type**: HD
+
+**PII**: No
+
+**HL7 Field**: MSH-4
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Expecting an ISO heirarchic designator here. eg, "1265050918" (same value as in ordering_provider_npi).  Note that reporting_facility_text is also available as a field, if a name is needed.
+
+---
+
+**Name**: ordering_facility_state
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Note that many states expect this field to be available, or ReportStream is not able rto route data to them.  Please provide if possible in order for us to route to as many states as possible.
+
+---

--- a/prime-router/docs/schema_documentation/waters-direct-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-direct-covid-19.md
@@ -4,6 +4,20 @@
 
 ---
 
+**Name**: senderId
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
+
+---
+
 **Name**: testOrdered
 
 **Type**: TABLE
@@ -675,6 +689,16 @@ The patient's first name
 
 ---
 
+**Name**: patientUniqueIdHash
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
 **Name**: patientHomeAddress
 
 **Type**: STREET
@@ -877,6 +901,8 @@ Custom.  Not currently used. ReportStream assumes area code is in orderingProvid
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95417-2
@@ -887,9 +913,9 @@ Custom.  Not currently used. ReportStream assumes area code is in orderingProvid
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
@@ -968,6 +994,8 @@ Custom field.  Example - 260415000
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95418-0
@@ -978,9 +1006,9 @@ Custom field.  Example - 260415000
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
@@ -1507,6 +1535,8 @@ Custom.  eg, 6816002
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95419-8
@@ -1517,9 +1547,9 @@ Custom.  eg, 6816002
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
@@ -1547,6 +1577,8 @@ Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptom
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 77974-4
@@ -1557,9 +1589,9 @@ Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptom
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
@@ -1610,6 +1642,8 @@ Custom.  eg, 840539006, same valueset as testResult
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95420-6
@@ -1620,9 +1654,9 @@ Custom.  eg, 840539006, same valueset as testResult
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
@@ -1636,6 +1670,8 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95421-4
@@ -1646,9 +1682,9 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 Code | Display
 ---- | -------
-YES|Yes
-NO|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/waters-safehealth-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-safehealth-covid-19.md
@@ -1,0 +1,1815 @@
+
+### Schema:         waters/safehealth-covid-19
+#### Description:   SafeHealth
+
+---
+
+**Name**: senderId
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
+
+---
+
+**Name**: testOrdered
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Code
+
+**Documentation**:
+
+eg, 94531-1
+
+---
+
+**Name**: testName
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBR-4-2
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Ordered LOINC Long Name
+
+**Documentation**:
+
+Should be the name that matches to Test Ordered LOINC Long Name, in LIVD table
+
+---
+
+**Name**: testCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Eg, "LN"
+
+---
+
+**Name**: testResult
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-5
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+eg, 260373001
+
+---
+
+**Name**: testResultText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "DETECTED".  Custom.  ReportStream uses testResult code, not this text value.
+
+---
+
+**Name**: testPerformed
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: OBX-3-1
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+eg, 94558-4
+
+---
+
+**Name**: testResultCodingSystem
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, SCT.   Custom
+
+---
+
+**Name**: testResultDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-19
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210111
+
+---
+
+**Name**: testReportDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Field**: OBX-22
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210112
+
+---
+
+**Name**: testOrderedDate
+
+**Type**: DATE
+
+**PII**: No
+
+**HL7 Field**: ORC-15
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210108
+
+---
+
+**Name**: specimenCollectedDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**HL7 Fields**: SPM-17-1, OBR-7, OBR-8, OBX-14
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, 20210113
+
+---
+
+**Name**: deviceIdentifier
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Testkit Name ID
+
+**Documentation**:
+
+Must match LIVD column M, "Test Kit Name ID"
+
+---
+
+**Name**: deviceName
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Model
+
+**Documentation**:
+
+Required.  Must match LIVD column B, "Model". eg,  "BD Veritor System for Rapid Detection of SARS-CoV-2 & Flu A+B"
+
+---
+
+**Name**: specimenId
+
+**Type**: EI
+
+**PII**: No
+
+**HL7 Fields**: SPM-2
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique id, such as a UUID. Note - Need to override the mapper in covid-19.schema file.
+
+---
+
+**Name**: serialNumber
+
+**Type**: ID
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Barcode or QR code.  Unique within one manufacturer.
+
+---
+
+**Name**: message_id
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Field**: MSH-10
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+ReportStream copies value from the specimenId
+
+---
+
+**Name**: patientAge
+
+**Type**: NUMBER
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 30525-0
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientDob
+
+**Type**: DATE
+
+**PII**: Yes
+
+**HL7 Field**: PID-7
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: patientRace
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-10
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: patientRaceText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.    ReportStream uses patientRace code, not this text value.
+
+---
+
+**Name**: patientEthnicity
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $alt
+
+**HL7 Field**: PID-22
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+H|Hispanic or Latino
+N|Non Hispanic or Latino
+U|Unknown
+U|Unknown
+
+**Alt Value Sets**
+
+Code | Display
+---- | -------
+H|2135-2
+N|2186-5
+U|UNK
+U|ASKU
+
+**Documentation**:
+
+Internally, ReportStream uses hl70189 (H,N,U), but should use HHS values. (2135-2, 2186-5, UNK, ASKU). A mapping is done here, but better is to switch all of RS to HHS standard.
+
+---
+
+**Name**: patientEthnicityText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. ReportStream uses the patientEthnicity code, not this text value.
+
+---
+
+**Name**: patientSex
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: PID-8-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+M|Male
+F|Female
+O|Other
+A|Ambiguous
+U|Unknown
+N|Not applicable
+
+**Documentation**:
+
+The patient's gender. There is a valueset defined based on the values in PID-8-1, but downstream consumers are free to define their own accepted values. Please refer to the consumer-specific schema if you have questions.
+
+
+---
+
+**Name**: patientZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: PID-11-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: patientCounty
+
+**Type**: TABLE_OR_BLANK
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: County
+
+---
+
+**Name**: orderingProviderNpi
+
+**Type**: ID_NPI
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-1, OBR-16-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+eg, "1265050918"
+
+---
+
+**Name**: orderingProviderLname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-2, OBR-16-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: orderingProviderFname
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**: ORC-12-3, OBR-16-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: orderingProviderZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-5
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: performingFacility
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**HL7 Fields**: OBX-15-1, OBX-23-10, ORC-3-3, OBR-3-3, OBR-2-3, ORC-2-3
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+Expecting a CLIA number here.  eg, "10D2218834"
+
+---
+
+**Name**: performingFacilityZip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**HL7 Field**: OBX-24-5
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimenSource
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: SPM-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: patientNameLast
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Not required, but generally data will not flow to states if last/first name provided.
+
+---
+
+**Name**: patientNameFirst
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: patientNameMiddle
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**HL7 Field**: PID-5-3
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientUniqueId
+
+**Type**: TEXT
+
+**PII**: Yes
+
+**HL7 Field**: PID-3-1
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientUniqueIdHash
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: patientHomeAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: patientHomeAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's second address line
+
+---
+
+**Name**: patientCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: PID-11-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patientState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: PID-11-4
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Extremely important field for routing data to states.
+
+---
+
+**Name**: patientPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Field**: PID-13
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: patientPhoneArea
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom. Not currently used. ReportStream assumes area code is in patientPhone
+
+---
+
+**Name**: orderingProviderAddress
+
+**Type**: STREET
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-1
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: orderingProviderAddress2
+
+**Type**: STREET_OR_BLANK
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-2
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street second address of the provider
+
+---
+
+**Name**: orderingProviderCity
+
+**Type**: CITY
+
+**PII**: Yes
+
+**HL7 Field**: ORC-24-3
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: orderingProviderState
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-24-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: orderingProviderPhone
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Fields**: ORC-14, OBR-17
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: orderingProviderPhoneArea
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Not currently used. ReportStream assumes area code is in orderingProviderPhone
+
+---
+
+**Name**: firstTest
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: previousTestType
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
+
+---
+
+**Name**: previousTestDate
+
+**Type**: DATE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: previousTestResult
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom field.  Example - 260415000
+
+---
+
+**Name**: healthcareEmployee
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: healthcareEmployeeType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1421009|Specialized surgeon
+3430008|Radiation therapist
+3842006|Chiropractor
+4162009|Dental assistant
+5275007|NA - Nursing auxiliary
+6816002|Specialized nurse
+6868009|Hospital administrator
+8724009|Plastic surgeon
+11661002|Neuropathologist
+11911009|Nephrologist
+11935004|Obstetrician
+13580004|School dental assistant
+14698002|Medical microbiologist
+17561000|Cardiologist
+18803008|Dermatologist
+18850004|Laboratory hematologist
+19244007|Gerodontist
+20145008|Removable prosthodontist
+21365001|Specialized dentist
+21450003|Neuropsychiatrist
+22515006|Medical assistant
+22731001|Orthopedic surgeon
+22983004|Thoracic surgeon
+23278007|Community health physician
+24430003|Physical medicine specialist
+24590004|Urologist
+25961008|Electroencephalography specialist
+26042002|Dental hygienist
+26369006|Public health nurse
+28229004|Optometrist
+28411006|Neonatologist
+28544002|Chemical pathologist
+36682004|PT - Physiotherapist
+37154003|Periodontist
+37504001|Orthodontist
+39677007|Internal medicine specialist
+40127002|Dietitian (general)
+40204001|Hematologist
+40570005|Interpreter
+41672002|Respiratory physician
+41904004|Medical X-ray technician
+43702002|Occupational health nurse
+44652006|Pharmaceutical assistant
+45419001|Masseur
+45440000|Rheumatologist
+45544007|Neurosurgeon
+45956004|Sanitarian
+46255001|Pharmacist
+48740002|Philologist
+49203003|Dispensing optometrist
+49993003|Maxillofacial surgeon
+50149000|Endodontist
+54503009|Faith healer
+56397003|Neurologist
+56466003|Community physician
+56542007|Medical record administrator
+56545009|Cardiovascular surgeon
+57654006|Fixed prosthodontist
+59058001|General physician
+59169001|Orthopedic technician
+59944000|Psychologist
+60008001|Community-based dietitian
+61207006|Medical pathologist
+61246008|Laboratory medicine specialist
+61345009|Otorhinolaryngologist
+61894003|Endocrinologist
+62247001|Family medicine specialist
+63098009|Clinical immunologist
+66476003|Oral pathologist
+66862007|Radiologist
+68867008|Public health dentist
+68950000|Prosthodontist
+69280009|Specialized physician
+71838004|Gastroenterologist
+73265009|Nursing aid
+75271001|MW - Midwife
+76166008|Practical aid (pharmacy)
+76231001|Osteopath
+76899008|Infectious diseases physician
+78703002|General surgeon
+78729002|Diagnostic radiologist
+79898004|Auxiliary midwife
+80409005|Translator
+80546007|OT - Occupational therapist
+80584001|Psychiatrist
+80933006|Nuclear medicine physician
+81464008|Clinical pathologist
+82296001|Pediatrician
+83189004|Other professional nurse
+83273008|Anatomic pathologist
+83685006|Gynecologist
+85733003|General pathologist
+88189002|Anesthesiologist
+88475002|Other dietitians and public health nutritionists
+90201008|Pediatric dentist
+90655003|Care of the elderly physician
+106289002|Dental surgeon
+106291005|Dietician AND/OR public health nutritionist
+106292003|Nurse
+106293008|Nursing personnel
+106294002|Midwifery personnel
+106296000|Physiotherapist AND/OR occupational therapist
+106330007|Philologist, translator AND/OR interpreter
+112247003|Medical doctor
+158965000|Medical practitioner
+158966004|Medical administrator - national
+158967008|Consultant physician
+158968003|Consultant surgeon
+158969006|Consultant gynecology and obstetrics
+158970007|Anesthetist
+158971006|Hospital registrar
+158972004|House officer
+158973009|Occupational physician
+158974003|Clinical medical officer
+158975002|Medical practitioner - teaching
+158977005|Dental administrator
+158978000|Dental consultant
+158979008|Dental general practitioner
+158980006|Dental practitioner - teaching
+158983008|Nurse administrator - national
+158984002|Nursing officer - region
+158985001|Nursing officer - district
+158986000|Nursing administrator - professional body
+158987009|Nursing officer - division
+158988004|Nurse education director
+158989007|Occupational health nursing officer
+158990003|Nursing officer
+158992006|Midwifery sister
+158993001|Nursing sister (theatre)
+158994007|Staff nurse
+158995008|Staff midwife
+158996009|State enrolled nurse
+158997000|District nurse
+158998005|Private nurse
+158999002|Community midwife
+159001001|Clinic nurse
+159002008|Practice nurse
+159003003|School nurse
+159004009|Nurse - teaching
+159005005|Student nurse
+159006006|Dental nurse
+159007002|Community pediatric nurse
+159010009|Hospital pharmacist
+159011008|Retail pharmacist
+159012001|Industrial pharmacist
+159013006|Pharmaceutical officer H.A.
+159014000|Trainee pharmacist
+159016003|Medical radiographer
+159017007|Diagnostic radiographer
+159018002|Therapeutic radiographer
+159019005|Trainee radiographer
+159021000|Ophthalmic optician
+159022007|Trainee optician
+159025009|Remedial gymnast
+159026005|Speech and language therapist
+159027001|Orthoptist
+159028006|Trainee remedial therapist
+159033005|Dietician
+159034004|Podiatrist
+159035003|Dental auxiliary
+159036002|ECG technician
+159037006|EEG technician
+159038001|Artificial limb fitter
+159039009|AT - Audiology technician
+159040006|Pharmacy technician
+159041005|Trainee medical technician
+159141008|Geneticist
+159972006|Surgical corset fitter
+160008000|Dental technician
+224529009|Clinical assistant
+224530004|Senior registrar
+224531000|Registrar
+224532007|Senior house officer
+224533002|MO - Medical officer
+224534008|Health visitor, nurse/midwife
+224535009|Registered nurse
+224536005|Midwifery tutor
+224537001|Accident and Emergency nurse
+224538006|Triage nurse
+224540001|Community nurse
+224541002|Nursing continence advisor
+224542009|Coronary care nurse
+224543004|Diabetic nurse
+224544005|Family planning nurse
+224545006|Care of the elderly nurse
+224546007|ICN - Infection control nurse
+224547003|Intensive therapy nurse
+224548008|Learning disabilities nurse
+224549000|Neonatal nurse
+224550000|Neurology nurse
+224551001|Industrial nurse
+224552008|Oncology nurse
+224553003|Macmillan nurse
+224554009|Marie Curie nurse
+224555005|Pain control nurse
+224556006|Palliative care nurse
+224557002|Chemotherapy nurse
+224558007|Radiotherapy nurse
+224559004|PACU nurse
+224560009|Stomatherapist
+224561008|Theatre nurse
+224562001|Pediatric nurse
+224563006|Psychiatric nurse
+224564000|Community mental health nurse
+224565004|Renal nurse
+224566003|Hemodialysis nurse
+224567007|Wound care nurse
+224569005|Nurse grade
+224570006|Clinical nurse specialist
+224571005|Nurse practitioner
+224572003|Nursing sister
+224573008|CN - Charge nurse
+224574002|Ward manager
+224575001|Nursing team leader
+224576000|Nursing assistant
+224577009|Healthcare assistant
+224578004|Nursery nurse
+224579007|Healthcare service manager
+224580005|Occupational health service manager
+224581009|Community nurse manager
+224583007|Behavior therapist
+224584001|Behavior therapy assistant
+224585000|Drama therapist
+224586004|Domiciliary occupational therapist
+224587008|Occupational therapy helper
+224588003|Psychotherapist
+224589006|Community-based physiotherapist
+224590002|Play therapist
+224591003|Play specialist
+224592005|Play leader
+224593000|Community-based speech/language therapist
+224594006|Speech/language assistant
+224595007|Professional counselor
+224596008|Marriage guidance counselor
+224597004|Trained nurse counselor
+224598009|Trained social worker counselor
+224599001|Trained personnel counselor
+224600003|Psychoanalyst
+224601004|Assistant psychologist
+224602006|Community-based podiatrist
+224603001|Foot care worker
+224604007|Audiometrician
+224605008|Audiometrist
+224606009|Technical healthcare occupation
+224607000|Occupational therapy technical instructor
+224608005|Administrative healthcare staff
+224609002|Complementary health worker
+224610007|Supporting services personnel
+224614003|Research associate
+224615002|Research nurse
+224620002|Human aid to communication
+224621003|Palantypist
+224622005|Note taker
+224623000|Cuer
+224624006|Lipspeaker
+224625007|Interpreter for British sign language
+224626008|Interpreter for Signs supporting English
+224936003|General practitioner locum
+225726006|Lactation consultant
+225727002|Midwife counselor
+265937000|Nursing occupation
+265939002|Medical/dental technicians
+283875005|Parkinson disease nurse
+302211009|Specialist registrar
+303124005|Member of mental health review tribunal
+303129000|Hospital manager
+303133007|Responsible medical officer
+303134001|Independent doctor
+304291006|Bereavement counselor
+304292004|Surgeon
+307988006|Medical technician
+308002005|Remedial therapist
+309294001|Accident and Emergency doctor
+309295000|Clinical oncologist
+309296004|Family planning doctor
+309322005|Associate general practitioner
+309323000|Partner of general practitioner
+309324006|Assistant GP
+309326008|Deputizing general practitioner
+309327004|General practitioner registrar
+309328009|Ambulatory pediatrician
+309329001|Community pediatrician
+309330006|Pediatric cardiologist
+309331005|Pediatric endocrinologist
+309332003|Pediatric gastroenterologist
+309333008|Pediatric nephrologist
+309334002|Pediatric neurologist
+309335001|Pediatric rheumatologist
+309336000|Pediatric oncologist
+309337009|Pain management specialist
+309338004|Intensive care specialist
+309339007|Adult intensive care specialist
+309340009|Pediatric intensive care specialist
+309341008|Blood transfusion doctor
+309342001|Histopathologist
+309343006|Physician
+309345004|Chest physician
+309346003|Thoracic physician
+309347007|Clinical hematologist
+309348002|Clinical neurophysiologist
+309349005|Clinical physiologist
+309350005|Diabetologist
+309351009|Andrologist
+309352002|Neuroendocrinologist
+309353007|Reproductive endocrinologist
+309354001|Thyroidologist
+309355000|Clinical geneticist
+309356004|Clinical cytogeneticist
+309357008|Clinical molecular geneticist
+309358003|Genitourinary medicine physician
+309359006|Palliative care physician
+309360001|Rehabilitation physician
+309361002|Child and adolescent psychiatrist
+309362009|Forensic psychiatrist
+309363004|Liaison psychiatrist
+309364005|Psychogeriatrician
+309365006|Psychiatrist for mental handicap
+309366007|Rehabilitation psychiatrist
+309367003|Obstetrician and gynecologist
+309368008|Breast surgeon
+309369000|Cardiothoracic surgeon
+309371000|Cardiac surgeon
+309372007|Ear, nose and throat surgeon
+309373002|Endocrine surgeon
+309374008|Thyroid surgeon
+309375009|Pituitary surgeon
+309376005|Gastrointestinal surgeon
+309377001|General gastrointestinal surgeon
+309378006|Upper gastrointestinal surgeon
+309379003|Colorectal surgeon
+309380000|Hand surgeon
+309381001|Hepatobiliary surgeon
+309382008|Ophthalmic surgeon
+309383003|Pediatric surgeon
+309384009|Pancreatic surgeon
+309385005|Transplant surgeon
+309386006|Trauma surgeon
+309388007|Vascular surgeon
+309389004|Medical practitioner grade
+309390008|Hospital consultant
+309391007|Visiting specialist registrar
+309392000|Research registrar
+309393005|General practitioner grade
+309394004|General practitioner principal
+309395003|Hospital specialist
+309396002|Associate specialist
+309397006|Research fellow
+309398001|Allied health professional
+309399009|Hospital dietitian
+309400002|Domiciliary physiotherapist
+309401003|General practitioner-based physiotherapist
+309402005|Hospital-based physiotherapist
+309403000|Private physiotherapist
+309404006|Physiotherapy assistant
+309409001|Hospital-based speech and language therapist
+309410006|Arts therapist
+309411005|Dance therapist
+309412003|Music therapist
+309413008|Renal dietitian
+309414002|Liver dietitian
+309415001|Oncology dietitian
+309416000|Pediatric dietitian
+309417009|Diabetes dietitian
+309418004|Audiologist
+309419007|Hearing therapist
+309420001|Audiological scientist
+309421002|Hearing aid dispenser
+309422009|Community-based occupational therapist
+309423004|Hospital occupational therapist
+309427003|Social services occupational therapist
+309428008|Orthotist
+309429000|Surgical fitter
+309434001|Hospital-based podiatrist
+309435000|Podiatry assistant
+309436004|Lymphedema nurse
+309437008|Community learning disabilities nurse
+309439006|Clinical nurse teacher
+309440008|Community practice nurse teacher
+309441007|Nurse tutor
+309442000|Nurse teacher practitioner
+309443005|Nurse lecturer practitioner
+309444004|Outreach nurse
+309445003|Anesthetic nurse
+309446002|Nurse manager
+309450009|Nurse administrator
+309452001|Midwifery grade
+309453006|Midwife
+309454000|Student midwife
+309455004|Parentcraft sister
+309459005|Healthcare professional grade
+309460000|Restorative dentist
+310170009|Pediatric audiologist
+310171008|Immunopathologist
+310172001|Audiological physician
+310173006|Clinical pharmacologist
+310174000|Private doctor
+310175004|Agency nurse
+310176003|Behavioral therapist nurse
+310177007|Cardiac rehabilitation nurse
+310178002|Genitourinary nurse
+310179005|Rheumatology nurse specialist
+310180008|Continence nurse
+310181007|Contact tracing nurse
+310182000|General nurse
+310183005|Nurse for the mentally handicapped
+310184004|Liaison nurse
+310185003|Diabetic liaison nurse
+310186002|Nurse psychotherapist
+310187006|Company nurse
+310188001|Hospital midwife
+310189009|Genetic counselor
+310190000|Mental health counselor
+310191001|Clinical psychologist
+310192008|Educational psychologist
+310193003|Coroner
+310194009|Appliance officer
+310512001|Medical oncologist
+311441001|School medical officer
+312485001|Integrated midwife
+372102007|RN First Assist
+387619007|Optician
+394572006|Medical secretary
+394618009|Hospital nurse
+397824005|Consultant anesthetist
+397897005|Paramedic
+397903001|Staff grade obstetrician
+397908005|Staff grade practitioner
+398130009|Medical student
+398238009|Acting obstetric registrar
+404940000|Physiotherapist technical instructor
+405277009|Resident physician
+405278004|Certified registered nurse anesthetist
+405279007|Attending physician
+405623001|Assigned practitioner
+405684005|Professional initiating surgical case
+405685006|Professional providing staff relief during surgical procedure
+408798009|Consultant pediatrician
+408799001|Consultant neonatologist
+409974004|Health educator
+409975003|Certified health education specialist
+413854007|Circulating nurse
+415075003|Perioperative nurse
+415506007|Scrub nurse
+416160000|Fellow of American Academy of Osteopathy
+420409002|Oculoplastic surgeon
+420678001|Retinal surgeon
+421841007|Admitting physician
+422140007|Medical ophthalmologist
+422234006|Ophthalmologist
+432100008|Health coach
+442867008|Respiratory therapist
+443090005|Podiatric surgeon
+444912007|Hypnotherapist
+445313000|Asthma nurse specialist
+445451001|Nurse case manager
+446050000|PCP - Primary care physician
+446701002|Addiction medicine specialist
+449161006|PA - physician assistant
+471302004|Government midwife
+3981000175106|Nurse complex case manager
+231189271000087109|Naturopath
+236749831000087105|Prosthetist
+258508741000087105|Hip and knee surgeon
+260767431000087107|Hepatologist
+285631911000087106|Shoulder surgeon
+291705421000087106|Interventional radiologist
+341320851000087105|Pediatric radiologist
+368890881000087105|Emergency medicine specialist
+398480381000087106|Family medicine specialist - palliative care
+416186861000087101|Surgical oncologist
+450044741000087104|Acupuncturist
+465511991000087105|Pediatric orthopedic surgeon
+494782281000087101|Pediatric hematologist
+619197631000087102|Neuroradiologist
+623630151000087105|Family medicine specialist - anesthetist
+666997781000087107|Doula
+673825031000087109|Traditional herbal medicine specialist
+682131381000087105|Occupational medicine specialist
+724111801000087104|Pediatric emergency medicine specialist
+747936471000087102|Family medicine specialist - care of the elderly
+766788081000087100|Travel medicine specialist
+767205061000087108|Spine surgeon
+813758161000087106|Maternal or fetal medicine specialist
+822410621000087104|Massage therapist
+847240411000087102|Hospitalist
+853827051000087104|Sports medicine specialist
+926871431000087103|Pediatric respirologist
+954544641000087107|Homeopath
+956387501000087102|Family medicine specialist - emergency medicine
+969118571000087109|Pediatric hematologist or oncologist
+984095901000087105|Foot and ankle surgeon
+990928611000087105|Invasive cardiologist
+999480451000087102|Case manager
+999480461000087104|Kinesthesiologist
+
+**Documentation**:
+
+Custom.  eg, 6816002
+
+---
+
+**Name**: symptomatic
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95419-8
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: symptomsList
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptomCode2^date2; ...
+
+---
+
+**Name**: hospitalized
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 77974-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: hospitalizedCode
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respitory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+
+**Documentation**:
+
+Custom.  eg, 840539006, same valueset as testResult
+
+---
+
+**Name**: symptomsIcu
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95420-6
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResident
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+Y|YES
+N|NO
+UNK|UNK
+
+**Documentation**:
+
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+
+---
+
+**Name**: congregateResidentType
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+22232009|Hospital
+32074000|Long Term Care Hospital
+224929004|Secure Hospital
+42665001|Nursing Home
+30629002|Retirement Home
+74056004|Orphanage
+722173008|Prison-based care site
+20078004|Substance Abuse Treatment Center
+257573002|Boarding House
+224683003|Military Accommodation
+284546000|Hospice
+257628001|Hostel
+310207003|Sheltered Housing
+57656006|Penal Institution
+32911000|Homeless
+
+**Documentation**:
+
+Custom field
+
+---
+
+**Name**: pregnant
+
+**Type**: CODE
+
+**PII**: No
+
+**HL7 Field**: AOE
+
+**LOINC Code**: 82810-3
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+77386006|Pregnant
+60001007|Not Pregnant
+261665006|Unknown
+
+**Documentation**:
+
+Is the patient pregnant?
+
+---
+
+**Name**: pregnantText
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Custom.  ReportStream uses the 'pregnant' code, not this text value.
+
+---
+
+**Name**: patientEmail
+
+**Type**: EMAIL
+
+**PII**: Yes
+
+**HL7 Field**: PID-13-4
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: reportingFacility
+
+**Type**: HD
+
+**PII**: No
+
+**HL7 Field**: MSH-4
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Expecting an ISO heirarchic designator here. eg, "1265050918" (same value as in ordering_provider_npi).  Note that reporting_facility_text is also available as a field, if a name is needed.
+
+---
+
+**Name**: ordering_facility_state
+
+**Type**: TABLE
+
+**PII**: No
+
+**HL7 Field**: ORC-22-4
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+Note that many states expect this field to be available, or ReportStream is not able rto route data to them.  Please provide if possible in order for us to route to as many states as possible.
+
+---

--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -12,6 +12,10 @@
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+Include the name of the sender as a substring here.
+
 ---
 
 **Name**: testId
@@ -630,6 +634,8 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95417-2
@@ -640,13 +646,13 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Is this the patient's first test for this condition?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 
@@ -709,6 +715,8 @@ Code | Display
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95418-0
@@ -719,13 +727,13 @@ Code | Display
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Is the patient employed in health care?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 
@@ -745,6 +753,8 @@ Is the patient employed in health care?
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 77974-4
@@ -755,13 +765,13 @@ Is the patient employed in health care?
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Is the patient hospitalized?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 
@@ -770,6 +780,8 @@ Is the patient hospitalized?
 **Type**: CODE
 
 **PII**: No
+
+**Format**: $display
 
 **HL7 Field**: AOE
 
@@ -781,13 +793,13 @@ Is the patient hospitalized?
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Is the patient symptomatic?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 
@@ -807,6 +819,8 @@ Is the patient symptomatic?
 
 **PII**: No
 
+**Format**: $display
+
 **HL7 Field**: AOE
 
 **LOINC Code**: 95420-6
@@ -817,13 +831,13 @@ Is the patient symptomatic?
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Is the patient in the ICU?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 
@@ -832,6 +846,8 @@ Is the patient in the ICU?
 **Type**: CODE
 
 **PII**: No
+
+**Format**: $display
 
 **HL7 Field**: AOE
 
@@ -843,13 +859,13 @@ Is the patient in the ICU?
 
 Code | Display
 ---- | -------
-Y|Yes
-N|No
-UNK|Unknown
+Y|YES
+N|NO
+UNK|UNK
 
 **Documentation**:
 
-Does the patient reside in a congregate care setting?
+Override the base hl70136 valueset with a custom one, to handle slightly different syntax
 
 ---
 

--- a/prime-router/metadata/schemas/WATERS/cue-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/cue-covid-19.schema
@@ -1,0 +1,13 @@
+---
+name: cue-covid-19
+description: Cue
+topic: covid-19
+trackingElement: specimen_id
+basedOn: covid-19
+extends: waters/direct-covid-19
+
+elements:
+  - name: sender_id
+    default: CueHlth
+
+

--- a/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
@@ -160,6 +160,12 @@ elements:
   - name: patient_id
     csvFields: [{ name: patientUniqueId}]
 
+  - name: patient_id_hash
+    # Custom.   Needs to go into covid-19. Mimic waters here.
+    type: TEXT
+    mapper: hash(patient_id)
+    csvFields: [{ name: patientUniqueIdHash}]
+
   - name: patient_street
     csvFields: [{ name: patientHomeAddress}]
 
@@ -205,7 +211,7 @@ elements:
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: firstTest}]
+    csvFields: [{ name: firstTest, format: $display}]
 
   - name: previous_test_type
     documentation:  Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
@@ -227,7 +233,7 @@ elements:
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: healthcareEmployee}]
+    csvFields: [{ name: healthcareEmployee, format: $display}]
 
   - name: healthcare_employee_type
     documentation: Custom.  eg, 6816002
@@ -239,7 +245,7 @@ elements:
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: symptomatic}]
+    csvFields: [{ name: symptomatic, format: $display}]
 
   - name: symptoms_list
     documentation:  Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptomCode2^date2; ...
@@ -250,7 +256,7 @@ elements:
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: hospitalized}]
+    csvFields: [{ name: hospitalized, format: $display}]
 
   - name: hospitalized_code
     documentation:  Custom.  eg, 840539006, same valueset as testResult
@@ -262,13 +268,13 @@ elements:
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: symptomsIcu}]
+    csvFields: [{ name: symptomsIcu, format: $display}]
 
   - name: resident_congregate_setting
     type: CODE
     valueSet: covid-19/yesno
     documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
-    csvFields: [{ name: congregateResident}]
+    csvFields: [{ name: congregateResident, format: $display}]
 
   - name: site_of_care
     documentation: Custom field
@@ -279,7 +285,7 @@ elements:
   - name: pregnant
     csvFields: [{ name: pregnant}]
 
-  - name: pregnantText
+  - name: pregnant_text
     documentation: Custom.  ReportStream uses the 'pregnant' code, not this text value.
     type: TEXT
     csvFields: [{ name: pregnantText}]

--- a/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
@@ -9,6 +9,7 @@ elements:
   # This should be in covid-19.schema - need to ask Carlos how to fix his test.
   - name: sender_id
     type: TEXT
+    cardinality: ONE
     documentation:  ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
     csvFields: [{ name: senderId}]
 

--- a/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/direct-covid-19.schema
@@ -6,6 +6,12 @@ trackingElement: specimen_id
 basedOn: covid-19
 elements:
 
+  # This should be in covid-19.schema - need to ask Carlos how to fix his test.
+  - name: sender_id
+    type: TEXT
+    documentation:  ID name of org that is sending this data to ReportStream.  Suitable for chain of custody tracking.  Not to be confused with sending_application, which in which ReportStream is the 'sender'
+    csvFields: [{ name: senderId}]
+
   - name: ordered_test_code
     documentation: eg, 94531-1
     csvFields: [{ name: testOrdered}]

--- a/prime-router/metadata/schemas/WATERS/safehealth-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/safehealth-covid-19.schema
@@ -1,0 +1,14 @@
+---
+name: safehealth-covid-19
+description: SafeHealth
+topic: covid-19
+trackingElement: specimen_id
+basedOn: covid-19
+extends: waters/direct-covid-19
+
+elements:
+
+  - name: sender_id
+    default: SafeHealth
+
+

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -6,9 +6,9 @@ trackingElement: message_id
 basedOn: covid-19
 elements:
 
-  # Waters sends RS the name of the company sending them data in this field
-  - name: submitter_uid
+  - name: sender_id
     type: TEXT
+    documentation: Include the name of the sender as a substring here.
     csvFields: [{ name: SubmitterUID }]
 
   # This is waters unique id for each row.

--- a/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
+++ b/prime-router/metadata/schemas/WATERS/waters-covid-19.schema
@@ -160,7 +160,10 @@ elements:
     csvFields: [{ name: specimenCollectedDate}]
 
   - name: first_test
-    csvFields: [{ name: firstTest}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: firstTest, format: $display}]
 
   # Custom waters field
   - name: previous_test_date
@@ -180,7 +183,10 @@ elements:
     csvFields: [{ name: previousTestType}]
 
   - name: employed_in_healthcare
-    csvFields: [{ name: healthcareEmployee}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: healthcareEmployee, format: $display}]
 
   # Custom waters field but using same name as simple_report uses.
   - name: patient_role 
@@ -188,10 +194,16 @@ elements:
     type: TEXT
 
   - name: hospitalized
-    csvFields: [{ name: hospitalized}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: hospitalized, format: $display}]
 
   - name: symptomatic_for_disease
-    csvFields: [{ name: symptomatic}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: symptomatic, format: $display}]
 
   # Custom waters field
   # Format for each symptom is symtomCode^date;  
@@ -201,10 +213,16 @@ elements:
     csvFields: [{ name: symptomsList}]
 
   - name: icu
-    csvFields: [{ name: symptomsIcu}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: symptomsIcu, format: $display}]
 
   - name: resident_congregate_setting
-    csvFields: [{ name: congregateResident}]
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: congregateResident, format: $display}]
 
   # Custom waters field
   - name: site_of_care

--- a/prime-router/metadata/schemas/hhsprotect/hhsprotect-covid-19.schema
+++ b/prime-router/metadata/schemas/hhsprotect/hhsprotect-covid-19.schema
@@ -1,0 +1,258 @@
+---
+name: hhsprotect-covid-19
+description: Schema for Submission to HHSProtect
+topic: covid-19
+trackingElement: message_id
+basedOn: covid-19
+extends: waters/direct-covid-19
+elements:
+
+  # Not doing these metadata fields:
+  #  CHAINCODEID
+  #  KEY
+  #  BLOCKNO
+  #  TXNISVALID
+  #  TXNINITIATOR
+  #  DOCTYPE
+  #  SCHEMAVERSION
+  #  SUBMISSIONSTATUS
+  #  ATTRIBUTEERRORS
+  #  TNNNO
+  #  TXNID
+  #  TXNTIMESTAMP
+  #  TNSISDELETE
+
+  # Not doing these data fields
+  #  PATIENTDOB
+  #  PATIENTRACETEXT
+  #  PATIENTETHNICITYTEXT
+  #  TESTRESULTTEXT
+  #  PATIENTPHONEAREA
+  #  PREGNANTTEXT
+  #  ORDERINGPROVIDERPHONEAREA
+
+  # Two additional fields added:  testPerformed, orderingFacilityState
+
+  - name: sender_id
+    # Same as SUBMITTERUSERID from Waters
+    csvFields: [{ name: submitterId}]
+
+  - name: message_id
+    csvFields: [{ name: testId}]
+
+  - name: ordered_test_code
+    csvFields: [{ name: testOrdered}]
+
+  - name: ordered_test_name
+    csvFields: [{ name: testName}]
+
+  - name: test_result
+    csvFields: [{ name: testResult }]
+
+  - name: test_coding_system
+    csvFields: [{ name: testCodingSystem}]
+
+  - name: test_result_coding_system
+    csvFields: [{ name: testResultCodingSystem }]
+
+  - name: order_test_date
+    csvFields: [{ name: testOrderedDate}]
+
+  - name: test_result_date
+    csvFields: [{ name: testResultDate}]
+
+  - name: test_result_report_date
+    csvFields: [{ name: testReportDate}]
+
+  - name: test_kit_name_id
+    csvFields: [{ name: deviceIdentifier}]
+
+  - name: equipment_model_name
+    csvFields: [{ name: deviceName}]
+
+  - name: patient_id_hash
+    csvFields: [{ name: patientUniqueId}]
+
+  - name: patient_age
+    # Not sure why this name doesn't follow pattern,eg, patientAge
+    csvFields: [{ name: patAge}]
+
+  - name: patient_race
+    csvFields: [{ name: patientRace}]
+
+  - name: patient_ethnicity
+    # Want to display 2135-2, 2186-5, UNK (note loss of info with ASKU).  Fix by changing covid-19.schema to use (2135-2, etc)
+    altValues:
+      - code: H
+        display: 2135-2
+      - code: N
+        display: 2186-5
+      - code: U
+        display: UNK
+    csvFields: [{ name: patientEthnicity, format: $alt}]
+
+  - name: patient_gender
+    csvFields: [{ name: patientSex}]
+
+  - name: patient_zip_code 
+    # Again, doesn't follow naming pattern
+    csvFields: [{ name: patZip}]
+
+  - name: patient_county
+    csvFields: [{ name: patientCounty}]
+
+  - name: patient_city
+    csvFields: [{ name: patientCity}]
+
+  - name: patient_state
+    csvFields: [{ name: patientState}]
+
+  - name: patient_street
+    csvFields: [{ name: patientHomeAddress}]
+
+  - name: patient_street2
+    csvFields: [{ name: patientHomeAddress2}]
+
+  - name: patient_email
+    csvFields: [{ name: patientEmail}]
+
+  - name: patient_phone_number
+    csvFields: [{ name: patientPhone}]
+
+  - name: patient_last_name
+    csvFields: [{ name: patientNameLast}]
+
+  - name: patient_first_name
+    csvFields: [{ name: patientNameFirst}]
+
+  - name: patient_middle_name
+    csvFields: [{ name: patientNameMiddle}]
+
+  - name: specimen_type
+    csvFields: [{ name: specimenSource}]
+
+  - name: specimen_id
+    csvFields: [{ name: specimenId}]
+
+  - name: equipment_instance_id
+    csvFields: [{ name: serialNumber}]
+
+  - name: specimen_collection_date_time
+    csvFields: [{ name: specimenDate}]
+
+  - name: first_test
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: firstTest, format: $display}]
+
+  - name: previous_test_date
+    csvFields: [{ name: previousTestDate}]
+
+  - name: previous_test_result
+    csvFields: [{ name: previousTestResult}]
+
+  - name: previous_test_type
+    csvFields: [{ name: previousTestType}]
+
+  - name: employed_in_healthcare
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: healthcareEmployee, format: $display}]
+
+  - name: healthcare_employee_type
+    csvFields: [{ name: healthcareEmployeeType}]
+
+  - name: hospitalized
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: hospitalized, format: $display}]
+
+  - name: hospitalized_code
+    csvFields: [{ name: hospitalizedCode}]
+
+  - name: symptomatic_for_disease
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: symptomatic, format: $display}]
+
+  - name: symptoms_list
+    csvFields: [{ name: symptomsList}]
+
+  - name: icu
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: symptomsIcu, format: $display}]
+
+  - name: resident_congregate_setting
+    type: CODE
+    valueSet: covid-19/yesno
+    csvFields: [{ name: congregateResident, format: $display}]
+
+  - name: site_of_care
+    csvFields: [{ name: congregateResidentType}]
+
+  - name: pregnant
+    csvFields: [{ name: pregnant}]
+
+  - name: ordering_provider_id
+    csvFields: [{ name: orderingProviderNpi}]
+
+  - name: ordering_provider_last_name
+    csvFields: [{ name: orderingProviderLname}]
+
+  - name: ordering_provider_first_name
+    csvFields: [{ name: orderingProviderFname}]
+
+  - name: ordering_provider_zip_code
+    csvFields: [{ name: orderingProviderZip}]
+
+  - name: ordering_provider_street
+    csvFields: [{ name: orderingProviderAddress}]
+
+  - name: ordering_provider_street2
+    csvFields: [{ name: orderingProviderAddress2}]
+
+  - name: ordering_provider_city
+    csvFields: [{ name: orderingProviderCity}]
+
+  - name: ordering_provider_state
+    csvFields: [{ name: orderingProviderState}]
+
+  - name: ordering_provider_phone_number
+    csvFields: [{ name: orderingProviderPhone}]
+
+  - name: testing_lab_clia
+    csvFields: [{ name: performingFacility}]
+
+  - name: reporting_facility
+    csvFields: [{ name: reportingFacility}]
+
+  - name: testing_lab_zip_code
+    # Is 'performingFacilityZip' in waters.
+    csvFields: [{ name: facilityZip}]
+
+  # Not in what waters sends to hhs
+  - name: test_performed_code
+    csvFields: [{ name: testPerformed }]
+    
+  # Not in what waters sends to hhs
+  - name: ordering_facility_state
+    csvFields: [{ name: orderingFacilityState }]
+
+  # Force these fields, inherited from the parent, to not display, by not giving them csvFields values
+  - name: test_result_text
+    csvFields: []
+  - name: patient_dob
+    csvFields: []
+  - name: patient_race_text
+    csvFields: []
+  - name: patient_ethnicity_text
+    csvFields: []
+  - name: patient_id
+    csvFields: []
+  - name: patient_phone_number_area_code
+    csvFields: []
+  - name: ordering_provider_phone_number_area_code
+    csvFields: []
+  - name: pregnant_text
+    csvFields: []

--- a/prime-router/metadata/valuesets/covid-19.valuesets
+++ b/prime-router/metadata/valuesets/covid-19.valuesets
@@ -191,16 +191,16 @@
 
 - name: covid-19/yesno
   # See YES, NO, UNK in the reference URL.
-  reference: Painfully, slightly different from the display values in hl7-136, which are Yes, No, Unknown, and code values, which are Y,N,UNK.
+  reference: This maps (YES,NO,UNK) to the ReportStream internal hl70136 (Y,N,UNK)
   system: LOCAL
   referenceUrl: https://www.hhs.gov/sites/default/files/non-lab-based-covid19-test-reporting.pdf
   values:
-    - code: YES
-      display: Yes
-    - code: NO
-      display: No
+    - code: Y
+      display: YES
+    - code: N
+      display: NO
     - code: UNK
-      display: Unknown
+      display: UNK
 
 
 

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -1093,6 +1093,7 @@
       organizationName: "hhsprotect"
       topic: "covid-19"
       jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)" ]
+#      jurisdictionalFilter: [ "matches(sender_id,SafeHealth)" ]
       qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -44,7 +44,7 @@
       - name: default
         organizationName: cue
         topic: covid-19
-        schemaName: waters/direct-covid-19
+        schemaName: waters/cue-covid-19
         format: CSV
 
   - name: strac

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -1236,7 +1236,7 @@
           initialTime: 00:00
         translation:
           type: CUSTOM
-          schemaName: waters/waters-covid-19
+          schemaName: hhsprotect/hhsprotect-covid-19
           format: CSV
         transport:
           type: BLOBSTORE

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -1097,7 +1097,7 @@
       qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"
-        schemaName: "waters/direct-covid-19"
+        schemaName: "hhsprotect/hhsprotect-covid-19"
         format: "CSV"
       deidentify: true
       timing:

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -1086,15 +1086,16 @@
 
 
   - name: "hhsprotect"
-    description: "HHS Protect"
+    description: "HHSProtect"
     jurisdiction: "FEDERAL"
     receivers:
     - name: "elr"
       organizationName: "hhsprotect"
       topic: "covid-19"
+      jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
       translation:
         type: "CUSTOM"
-        schemaName: "waters/waters-covid-19"
+        schemaName: "waters/direct-covid-19"
         format: "CSV"
       deidentify: true
       timing:

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -1092,7 +1092,8 @@
     - name: "elr"
       organizationName: "hhsprotect"
       topic: "covid-19"
-      jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
+      jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)" ]
+      qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"
         schemaName: "waters/direct-covid-19"

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -34,7 +34,7 @@
       - name: default
         organizationName: safehealth
         topic: covid-19
-        schemaName: waters/direct-covid-19
+        schemaName: waters/safehealth-covid-19
         format: CSV
 
   - name: cue

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -24,7 +24,7 @@
       - name: default
         organizationName: safehealth
         topic: covid-19
-        schemaName: waters/direct-covid-19
+        schemaName: waters/safehealth-covid-19
         format: CSV
 
   - name: cue

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -812,15 +812,16 @@
           timeZone: EASTERN
 
   - name: "hhsprotect"
-    description: "HHS Protect"
+    description: "HHSProtect"
     jurisdiction: "FEDERAL"
     receivers:
     - name: "elr"
       organizationName: "hhsprotect"
       topic: "covid-19"
+      jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
       translation:
         type: "CUSTOM"
-        schemaName: "waters/waters-covid-19"
+        schemaName: "waters/direct-covid-19"
         format: "CSV"
       deidentify: true
       timing:

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -822,7 +822,7 @@
       qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"
-        schemaName: "waters/direct-covid-19"
+        schemaName: "hhsprotect/hhsprotect-covid-19"
         format: "CSV"
       deidentify: true
       timing:

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -34,7 +34,7 @@
       - name: default
         organizationName: cue
         topic: covid-19
-        schemaName: waters/direct-covid-19
+        schemaName: waters/cue-covid-19
         format: CSV
 
   - name: waters

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -961,7 +961,7 @@
           initialTime: 00:00
         translation:
           type: CUSTOM
-          schemaName: waters/waters-covid-19
+          schemaName: hhsprotect/hhsprotect-covid-19
           format: CSV
         transport:
           type: BLOBSTORE

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -818,7 +818,8 @@
     - name: "elr"
       organizationName: "hhsprotect"
       topic: "covid-19"
-      jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
+      jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)" ]
+      qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"
         schemaName: "waters/direct-covid-19"

--- a/prime-router/settings/prod/0026-hhsprotect.yml
+++ b/prime-router/settings/prod/0026-hhsprotect.yml
@@ -14,7 +14,7 @@
       nameFormat: "STANDARD"
       receivingOrganization: null
       type: "CUSTOM"
-    jurisdictionFilter: [ "matches(sender_id,SafeHealth)" ]
+    jurisdictionalFilter: [ "matches(sender_id,SafeHealth)" ]
     qualityFilter:
     - "allowAll()"
     deidentify: true

--- a/prime-router/settings/prod/0026-hhsprotect.yml
+++ b/prime-router/settings/prod/0026-hhsprotect.yml
@@ -1,0 +1,31 @@
+# Run this:   ./prime multiple-settings set --input ./settings/prod/0026-hhsprotect.yml --env prod
+---
+- name: "hhsprotect"
+  description: "HHSProtect"
+  jurisdiction: "FEDERAL"
+  receivers:
+  - name: "elr"
+    organizationName: "hhsprotect"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "waters/direct-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionFilter: [ "matches(sender_id,SafeHealth)" ]
+    qualityFilter:
+    - "allowAll()"
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 12
+      initialTime: "01:25"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: "HHSProtect in production filters by the 'sender_id' field, with no quality filter"
+    transport: !<BLOBSTORE>
+      storageName: "PartnerStorage"
+      containerName: "hhsprotect"
+      type: "BLOBSTORE"

--- a/prime-router/settings/prod/0026-hhsprotect.yml
+++ b/prime-router/settings/prod/0026-hhsprotect.yml
@@ -8,7 +8,7 @@
     organizationName: "hhsprotect"
     topic: "covid-19"
     translation: !<CUSTOM>
-      schemaName: "waters/direct-covid-19"
+      schemaName: "hhsprotect/hhsprotect-covid-19"
       format: "CSV"
       defaults: {}
       nameFormat: "STANDARD"

--- a/prime-router/settings/prod/0026-hhsprotect.yml
+++ b/prime-router/settings/prod/0026-hhsprotect.yml
@@ -29,3 +29,23 @@
       storageName: "PartnerStorage"
       containerName: "hhsprotect"
       type: "BLOBSTORE"
+
+- name: safehealth
+  description: SAFE - Safe Health Systems
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: safehealth
+      topic: covid-19
+      schemaName: waters/safehealth-covid-19
+      format: CSV
+
+- name: cue
+  description: Cue
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: cue
+      topic: covid-19
+      schemaName: waters/cue-covid-19
+      format: CSV

--- a/prime-router/settings/staging/0020-hhsprotect.yml
+++ b/prime-router/settings/staging/0020-hhsprotect.yml
@@ -29,3 +29,24 @@
       storageName: "PartnerStorage"
       containerName: "hhsprotect"
       type: "BLOBSTORE"
+
+- name: safehealth
+  description: SAFE - Safe Health Systems
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: safehealth
+      topic: covid-19
+      schemaName: waters/safehealth-covid-19
+      format: CSV
+
+- name: cue
+  description: Cue
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: cue
+      topic: covid-19
+      schemaName: waters/cue-covid-19
+      format: CSV
+

--- a/prime-router/settings/staging/0020-hhsprotect.yml
+++ b/prime-router/settings/staging/0020-hhsprotect.yml
@@ -14,7 +14,7 @@
       nameFormat: "STANDARD"
       receivingOrganization: null
       type: "CUSTOM"
-    jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
+    jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)" ]
     qualityFilter:
     - "allowAll()"
     deidentify: true

--- a/prime-router/settings/staging/0020-hhsprotect.yml
+++ b/prime-router/settings/staging/0020-hhsprotect.yml
@@ -1,4 +1,5 @@
 # Run this:   ./prime multiple-settings set --input ./settings/staging/0020-hhsprotect.yml --env staging
+# And direct is not needed as a sender any more:  ./prime organization remove --help --env staging --name direct
 ---
 - name: "hhsprotect"
   description: "HHSProtect"
@@ -50,3 +51,164 @@
       schemaName: waters/cue-covid-19
       format: CSV
 
+- name: "waters"
+  description: "Waters Testing Only - sends and receives Waters data only"
+  jurisdiction: "FEDERAL"
+  stateCode: null
+  countyName: null
+  senders:
+  - name: "default"
+    organizationName: "waters"
+    format: "CSV"
+    topic: "covid-19"
+    schemaName: "waters/waters-covid-19"
+  receivers:
+  - name: "CSV"
+    organizationName: "waters"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "waters/waters-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)
+    qualityFilter:
+    - "allowAll()"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    transport: !<SFTP>
+      host: "3.217.175.115"
+      port: "22"
+      filePath: "./public"
+      type: "SFTP"
+  - name: "HL7"
+    organizationName: "waters"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: null
+      receivingApplicationOID: null
+      receivingFacilityName: null
+      receivingFacilityOID: null
+      messageProfileId: null
+      reportingFacilityName: null
+      reportingFacilityId: null
+      suppressQstForAoe: false
+      suppressHl7Fields: null
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: null
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "HL7"
+    jurisdictionalFilter:
+    - matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)
+    qualityFilter:
+    - "allowAll()"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<SFTP>
+      host: "3.217.175.115"
+      port: "22"
+      filePath: "./public"
+      type: "SFTP"
+  - name: "TYPICAL_STATE_QUALITY_FILTER"
+    organizationName: "waters"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "fl/fl-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*)
+    qualityFilter: []
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<SFTP>
+      host: "3.217.175.115"
+      port: "22"
+      filePath: "./public"
+      type: "SFTP"
+  - name: "joe"
+    organizationName: "waters"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "waters/waters-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "hasAtLeastOneOf(waters_submitter, sender_id)"
+    - "orEquals(patient_state, JM, ordering_facility_state, JM)"
+    qualityFilter:
+    - "allowAll()"
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<SFTP>
+      host: "3.217.175.115"
+      port: "22"
+      filePath: "./public/joe"
+      type: "SFTP"
+  - name: "giang"
+    organizationName: "waters"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "waters/waters-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "hasAtLeastOneOf(waters_submitter, sender_id)"
+    - "orEquals(patient_state, GH, ordering_facility_state, GH)"
+    qualityFilter:
+    - "allowAll()"
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<SFTP>
+      host: "3.217.175.115"
+      port: "22"
+      filePath: "./public/giang"
+      type: "SFTP"

--- a/prime-router/settings/staging/0020-hhsprotect.yml
+++ b/prime-router/settings/staging/0020-hhsprotect.yml
@@ -1,14 +1,14 @@
 # Run this:   ./prime multiple-settings set --input ./settings/staging/0020-hhsprotect.yml --env staging
 ---
 - name: "hhsprotect"
-  description: "HHS Protect"
+  description: "HHSProtect"
   jurisdiction: "FEDERAL"
   receivers:
   - name: "elr"
     organizationName: "hhsprotect"
     topic: "covid-19"
     translation: !<CUSTOM>
-      schemaName: "waters/direct-covid-19"
+      schemaName: "hhsprotect/hhsprotect-covid-19"
       format: "CSV"
       defaults: {}
       nameFormat: "STANDARD"

--- a/prime-router/settings/staging/0020-hhsprotect.yml
+++ b/prime-router/settings/staging/0020-hhsprotect.yml
@@ -1,0 +1,31 @@
+# Run this:   ./prime multiple-settings set --input ./settings/staging/0020-hhsprotect.yml --env staging
+---
+- name: "hhsprotect"
+  description: "HHS Protect"
+  jurisdiction: "FEDERAL"
+  receivers:
+  - name: "elr"
+    organizationName: "hhsprotect"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "waters/direct-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionFilter: [ "matches(sender_id,.*SafeHealth,*,.*CueHlth.*,.*ImageMover.*)" ]
+    qualityFilter:
+    - "allowAll()"
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: "HHSProtect in staging filters by the 'sender_id' field, with no quality filter"
+    transport: !<BLOBSTORE>
+      storageName: "PartnerStorage"
+      containerName: "hhsprotect"
+      type: "BLOBSTORE"

--- a/prime-router/src/main/kotlin/DocumentationFactory.kt
+++ b/prime-router/src/main/kotlin/DocumentationFactory.kt
@@ -14,7 +14,7 @@ object DocumentationFactory {
     // to end users or be converted into HTML if we want to be fancy
 
     fun getElementDocumentation(element: Element): String {
-        val csvField = element.csvFields?.get(0)
+        val csvField = if (element.csvFields?.isNotEmpty() == true) element.csvFields?.get(0) else null
         val sb = StringBuilder()
         val displayName = csvField?.name ?: element.name
 

--- a/prime-router/src/main/kotlin/JurisdictionalFilters.kt
+++ b/prime-router/src/main/kotlin/JurisdictionalFilters.kt
@@ -194,7 +194,7 @@ class HasValidDataFor : JurisdictionalFilter {
         val columnNames = table.columnNames()
         args.forEach { colName ->
             if (columnNames.contains(colName)) {
-                val before = selection.or(Selection.withRange(0,0))  // hack copy constructor!  For logging only.
+                val before = Selection.with(*selection.toArray())  // hack way to copy to a new Selection obj
                 selection = selection.andNot(table.stringColumn(colName).isEmptyString)
                 JurisdictionalFilters.logFiltering(before, selection,"$name($colName)", receiver)
             } else {
@@ -333,10 +333,12 @@ object JurisdictionalFilters: Logging {
             if (after.size() == 0) {
                 logAllEliminated(before.size(), filterDescription, receiver)
             } else {
+                // Note:  the expression 'before.andNot(after)' actually changes the 'before' obj!
+                val beforeSize = before.size()
                 val eliminatedRows = before.andNot(after)
                 logger.warn("For ${receiver.fullName}, qualityFilter $filterDescription" +
-                    " reduced the Item count from ${before.size()} to ${after.size()}.  " +
-                    "These rows eliminated: ${eliminatedRows.joinToString(",")}")
+                    " reduced the Item count from $beforeSize to ${after.size()}.  " +
+                    "Row numbers eliminated: ${eliminatedRows.joinToString(",")}")
 
             }
         }

--- a/prime-router/src/main/kotlin/Mappers.kt
+++ b/prime-router/src/main/kotlin/Mappers.kt
@@ -1,10 +1,12 @@
 package gov.cdc.prime.router
 
+import java.security.MessageDigest
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
+import javax.xml.bind.DatatypeConverter
 
 /**
  * A *Mapper* is defined as a property of a schema element. It is used to create
@@ -603,6 +605,32 @@ class ZipCodeToCountyMapper : Mapper {
         }
         return table.lookupValue(indexColumn = "zipcode", indexValue = cleanedZip, "county")
     }
+}
+
+/**
+ * Create a SHA-256 digest hash of the concatenation of values
+ * Example:   hash(patient_last_name,patient_first_name)
+ */
+class HashMapper : Mapper {
+    override val name = "hash"
+
+    override fun valueNames(element: Element, args: List<String>) = args
+
+    override fun apply(element: Element, args: List<String>, values: List<ElementAndValue>): String? {
+        if (args.isEmpty()) error("Must pass at least one element name to $name")
+        if (values.isEmpty()) return null
+        val concatenation = values.joinToString("") { it.value }
+        if (concatenation.isEmpty()) return null
+        return digest(concatenation.toByteArray()).lowercase()
+    }
+
+    companion object {
+        fun digest(input: ByteArray): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(input)
+            return DatatypeConverter.printHexBinary(digest)
+        }
+    }
+
 }
 
 object Mappers {

--- a/prime-router/src/main/kotlin/Metadata.kt
+++ b/prime-router/src/main/kotlin/Metadata.kt
@@ -32,6 +32,7 @@ class Metadata {
         ZipCodeToCountyMapper(),
         SplitByCommaMapper(),
         TimestampMapper(),
+        HashMapper(),
     )
 
     private var jurisdictionalFilters = listOf(

--- a/prime-router/src/main/kotlin/Translator.kt
+++ b/prime-router/src/main/kotlin/Translator.kt
@@ -86,7 +86,7 @@ class Translator(private val metadata: Metadata, private val settings: SettingsP
             JurisdictionalFilters.defaultQualityFilters[receiver.topic] != null ->
                 JurisdictionalFilters.defaultQualityFilters[receiver.topic]!!
             else -> {
-                logger.info("No default quality filter found for topic ${receiver.topic}. Not doing qual filtering")
+                logger.info("No default qualityFilter found for topic ${receiver.topic}. Not doing qual filtering")
                 emptyList<String>()
             }
         }
@@ -99,8 +99,8 @@ class Translator(private val metadata: Metadata, private val settings: SettingsP
         val qualityFilteredReport = jurisFilteredReport.filter(qualityFilterAndArgs, receiver)
         if (qualityFilteredReport.itemCount != jurisFilteredReport.itemCount) {
             logger.warn("Data quality problem in report ${input.id}, receiver ${receiver.fullName}: " +
-                "There were ${jurisFilteredReport.itemCount} rows prior to quality filtering, and " +
-                "${qualityFilteredReport.itemCount} rows after quality filtering.")
+                "There were ${jurisFilteredReport.itemCount} rows prior to qualityFilter, and " +
+                "${qualityFilteredReport.itemCount} rows after qualityFilter.")
         }
 
         // Always succeed in translating an empty report after filtering (even if the mapping process would fail)

--- a/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
+++ b/prime-router/src/test/kotlin/JurisdictionalFilterTests.kt
@@ -37,6 +37,25 @@ class JurisdictionalFilterTests {
     }
 
     @Test
+    fun `test Matches with multiple regexi`() {
+        val filter = Matches()
+        val table = Table.create(
+            StringColumn.create("colA", listOf("A long list of items here", "items", "A short list here")),
+            StringColumn.create("colB", listOf("B1", "B2", "B3"))
+        )
+        val args1 = listOf("colA", "items")
+        val selection1 = filter.getSelection(args1, table, rcvr)
+        val filteredTable1 = table.where(selection1)
+        assertThat(filteredTable1).hasRowCount(1)
+        assertThat(filteredTable1.getString(0, "colB")).isEqualTo("B2")
+
+        val args2 = listOf("colA", ".*items.*", ".*short.*") // test multiple regexi
+        val selection2 = filter.getSelection(args2, table, rcvr)
+        val filteredTable2 = table.where(selection2)
+        assertThat(filteredTable2).hasRowCount(3)
+    }
+
+    @Test
     fun `test empty Matches`() {
         val filter = Matches()
         val table = Table.create(

--- a/prime-router/src/test/kotlin/MapperTests.kt
+++ b/prime-router/src/test/kotlin/MapperTests.kt
@@ -3,6 +3,7 @@ package gov.cdc.prime.router
 import java.io.ByteArrayInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertNull
 import kotlin.test.fail
 
@@ -409,4 +410,32 @@ class MapperTests {
         val actual = mapper.apply(lookupElement, listOf("patient_zip_code"), values)
         assertEquals(expected, actual, "Expected: $expected, Actual: $actual")
     }
+
+    @Test
+    fun `test HashMapper`() {
+        val mapper = HashMapper()
+        val elementA = Element("a")
+        val elementB = Element("b")
+        val elementC = Element("c")
+
+        // Single value conversion
+        val arg = listOf("a")
+        val value = listOf(ElementAndValue(elementA, "6086edf8e412650032408e96"))
+        assertEquals("47496cafa04e9c489444b60575399f51e9abc061f4fdda40c31d814325bfc223",
+            mapper.apply(elementA, arg, value))
+        // Multiple values concatenated
+        val args = listOf("a", "b", "c")
+        val values = listOf(
+            ElementAndValue(elementA, "string1"),
+            ElementAndValue(elementB, "string2"),
+            ElementAndValue(elementC, "string3")
+        )
+        assertEquals("c8fa773cd54e7a7eb7ca08577d0bd23e6ce3a73e61df176213d9ec90f06cb45f",
+            mapper.apply(elementA, args, values))
+        // Unhappy path cases
+        assertFails { mapper.apply(elementA, listOf(), listOf()) }  // must pass a field name
+        assertNull(mapper.apply(elementA, arg, listOf()))  // column not found in the data.
+        assertNull(mapper.apply(elementA, arg, listOf(ElementAndValue(elementA,"")))) // column has empty data
+    }
+
 }


### PR DESCRIPTION
## Changes in this PR:

- Wrote a new `hhsprotect/hhsprotect-covid-19` schema, that generally mimics what Waters sends.  Does not send redundant text versions of code columns.  Added a couple columns.  See that schema for details.
- Wrote new `hash(column-name1, column-name2) `mapper, which generates a sha-256 digest of the concatenation table values.
- This is now used generate hashes identical to Waters, so that HHSProtect can detect duplicates.   Only doing this for patient_id right now - the patient_id we send to HHSProtect is the hashed version, not the real one.
- For incoming waters, direct data, and outgoing HHSProtect, use YES,NO,UNK instead of Y,N,UNK
- Delivery codes for ethnicity are done per HHS standard (TODO: fix this in covid-19.schema globally)
- Added detailed logging to the qualityFilters.   It now lists the row number of every row removed, in the logs.  Next step is to get this into ActionHistory, and into the json payload returned on ingest 201.
- HHSProtect now does a jurisdiction filter on sender_id value. This should be a safe way to prevent, for example, SimpleReport data from going to HHSProtect.   Its set fairly lenient to send major Waters senders in Local and Test, but is pretty locked down in Prod.
- Added schemas for new senders.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [X] Added tests?

### Security
- [X] Did you check for sensitive data, and remove any? 
- [N] Does logging contain sensitive data?  
- [N] Are additional approvals needed for this change?
- [N] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [Y] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
no issues known.

## To Be Done
- refactor a couple Elements up into covid-19.schema, per my comments.

