### PR TITLE
Ignore Database Size in Terraform

### DIFF
--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -43,6 +43,10 @@ resource "azurerm_postgresql_server" "postgres_server" {
 
   lifecycle {
     prevent_destroy = true
+
+    ignore_changes = [
+      storage_mb # Supports auto-grow
+    ]
   }
 
   tags = {
@@ -82,6 +86,10 @@ resource "azurerm_postgresql_server" "postgres_server_replica" {
 
   lifecycle {
     prevent_destroy = true
+
+    ignore_changes = [
+      storage_mb # Supports auto-grow
+    ]
   }
 
   tags = {


### PR DESCRIPTION
This PR resolves an issue where Terraform tries to scale down the database size after the `auto_grow` setting increases our database.

## Changes
- Adds the the `storage_mb` field to the ignored changes list
  - This prevents Terraform from attempting to scale down the database after its grown

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

