### PR TITLE
Changes the default file name format back to the classic style until we can communicate the change to states

### DIFF
--- a/prime-router/metadata/file_name_templates/file-name-templates.yml
+++ b/prime-router/metadata/file_name_templates/file-name-templates.yml
@@ -4,9 +4,9 @@
   elements:
     - schemaBaseName()
     - "-"
-    - createdDate()
-    - "-"
     - uuid()
+    - "-"
+    - createdDate()
 
 
 - name: ohio

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -760,10 +760,10 @@ class Report {
             val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
             val nameSuffix = fileFormat?.ext ?: Format.CSV.ext
             val fileName = when (translationConfig) {
-                null -> "${Schema.formBaseName(schemaName)}-${formatter.format(createdDateTime)}-$id"
+                null -> "${Schema.formBaseName(schemaName)}-$id-${formatter.format(createdDateTime)}"
                 else -> metadata.fileNameTemplates[nameFormat.lowercase()].run {
                     this?.getFileName(translationConfig)
-                        ?: "${Schema.formBaseName(schemaName)}-${formatter.format(createdDateTime)}-$id"
+                        ?: "${Schema.formBaseName(schemaName)}-$id-${formatter.format(createdDateTime)}"
                 }
             }
             return "$fileName.$nameSuffix"


### PR DESCRIPTION
This PR changes the default file name format back to the classic style until we can communicate the change to states

## Changes
- updates the name formats yaml to use the old style
- updates the default style in the `Report` class to match the old style

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?
